### PR TITLE
fix: read flat dot-notation keys in NpmRegistry.getPackageInfo

### DIFF
--- a/.changeset/eager-eagle-697.md
+++ b/.changeset/eager-eagle-697.md
@@ -1,0 +1,7 @@
+---
+"@savvy-web/github-action-effects": patch
+---
+
+## Bug Fixes
+
+Fix `NpmRegistry.getPackageInfo` returning undefined for `integrity` and `tarball` fields due to `npm view` using flat dot-notation keys (`"dist.integrity"`) instead of nested objects. Fixes #21.

--- a/src/layers/NpmRegistryLive.test.ts
+++ b/src/layers/NpmRegistryLive.test.ts
@@ -83,15 +83,13 @@ describe("NpmRegistryLive", () => {
 		expect(result).toEqual(["1.0.0"]);
 	});
 
-	it("getPackageInfo maps fields correctly", async () => {
+	it("getPackageInfo reads flat dot-notation keys from npm view", async () => {
 		const npmOutput = JSON.stringify({
 			name: "effect",
 			version: "3.2.0",
 			"dist-tags": { latest: "3.2.0" },
-			dist: {
-				integrity: "sha512-abc",
-				tarball: "https://example.com/effect.tgz",
-			},
+			"dist.integrity": "sha512-abc",
+			"dist.tarball": "https://registry.npmjs.org/effect/-/effect-3.2.0.tgz",
 		});
 		const runner = makeMockRunner(new Map([["name version dist-tags", npmOutput]]));
 		const layer = NpmRegistryLive.pipe(Layer.provide(runner));
@@ -103,7 +101,31 @@ describe("NpmRegistryLive", () => {
 		);
 		expect(result.name).toBe("effect");
 		expect(result.version).toBe("3.2.0");
+		expect(result.distTags).toEqual({ latest: "3.2.0" });
 		expect(result.integrity).toBe("sha512-abc");
+		expect(result.tarball).toBe("https://registry.npmjs.org/effect/-/effect-3.2.0.tgz");
+	});
+
+	it("getPackageInfo falls back to nested dist object", async () => {
+		const npmOutput = JSON.stringify({
+			name: "effect",
+			version: "3.2.0",
+			"dist-tags": { latest: "3.2.0" },
+			dist: {
+				integrity: "sha512-nested",
+				tarball: "https://example.com/effect.tgz",
+			},
+		});
+		const runner = makeMockRunner(new Map([["name version dist-tags", npmOutput]]));
+		const layer = NpmRegistryLive.pipe(Layer.provide(runner));
+		const result = await Effect.runPromise(
+			NpmRegistry.pipe(
+				Effect.flatMap((reg) => reg.getPackageInfo("effect")),
+				Effect.provide(layer),
+			),
+		);
+		expect(result.integrity).toBe("sha512-nested");
+		expect(result.tarball).toBe("https://example.com/effect.tgz");
 	});
 
 	it("getLatestVersion returns non-string data as string via String()", async () => {

--- a/src/layers/NpmRegistryLive.ts
+++ b/src/layers/NpmRegistryLive.ts
@@ -93,8 +93,8 @@ export const NpmRegistryLive: Layer.Layer<NpmRegistry, never, CommandRunner> = L
 							name: (d.name as string) ?? pkg,
 							version: (d.version as string) ?? "0.0.0",
 							distTags: (d["dist-tags"] as Record<string, string>) ?? {},
-							integrity: (d.dist as Record<string, string>)?.integrity,
-							tarball: (d.dist as Record<string, string>)?.tarball,
+							integrity: (d["dist.integrity"] as string | undefined) ?? (d.dist as Record<string, string>)?.integrity,
+							tarball: (d["dist.tarball"] as string | undefined) ?? (d.dist as Record<string, string>)?.tarball,
 						};
 					}),
 					Effect.withSpan("NpmRegistry.getPackageInfo", {


### PR DESCRIPTION
## Summary

- Fix NpmRegistry.getPackageInfo returning undefined for integrity and tarball fields
- npm view outputs flat dot-notation keys ("dist.integrity", "dist.tarball"), not nested objects
- Read flat keys first with fallback to nested format for compatibility

Closes #21

## Test plan

- [x] Test with realistic flat dot-notation npm view output (new test)
- [x] Test fallback to nested dist object format (new test)
- [x] All 829 existing tests pass
- [x] Typecheck clean

Signed-off-by: C. Spencer Beggs <spencer@savvyweb.systems>