### PR TITLE
feat!: resolve and persist GitHub App identity (#112)

### DIFF
--- a/.changeset/github-token-identity.md
+++ b/.changeset/github-token-identity.md
@@ -1,0 +1,13 @@
+---
+"@savvy-web/github-action-effects": patch
+---
+
+## Breaking Changes
+
+- `GitHubApp.botIdentity` now takes `{ appSlug?, appUserId? }` instead of a bare slug string. Call sites passing a string must pass an object; it produces verified identities when both fields are present.
+
+## Features
+
+- `GitHubToken` now resolves and persists the GitHub App identity during the `pre` phase — best-effort, so a lookup failure degrades gracefully instead of failing the action.
+- New `GitHubToken.read()` exposes the persisted installation token, and `GitHubToken.botIdentity()` derives a verified commit identity (numeric-ID-prefixed email) from it.
+- New `GitHubApp.resolveAppIdentity` method performs the App slug and bot-user-ID lookup.

--- a/.changeset/github-token-identity.md
+++ b/.changeset/github-token-identity.md
@@ -1,5 +1,5 @@
 ---
-"@savvy-web/github-action-effects": patch
+"@savvy-web/github-action-effects": minor
 ---
 
 ## Breaking Changes

--- a/.claude/design/github-action-effects/errors-and-schemas.md
+++ b/.claude/design/github-action-effects/errors-and-schemas.md
@@ -59,7 +59,7 @@ No separate `Base` export is needed.
 | `ChangesetError` | ChangesetAnalyzer | operation, reason |
 | `GitHubClientError` | GitHubClient | operation, status (HTTP), reason, retryable (boolean) |
 | `GitHubGraphQLError` | GitHubGraphQL | operation, reason, errors array |
-| `GitHubAppError` | GitHubApp | operation, reason |
+| `GitHubAppError` | GitHubApp | operation (`"jwt"` \| `"token"` \| `"revoke"` \| `"identity"`), reason |
 | `GitBranchError` | GitBranch | operation, name, reason |
 | `GitCommitError` | GitCommit | operation, reason |
 | `GitTagError` | GitTag | operation, tag, reason |
@@ -173,7 +173,7 @@ TypeScript interfaces exported from service files:
 | `WorkspaceType` | `schemas/Workspace.ts` | Workspace type enum |
 | `WorkspaceInfo` | `schemas/Workspace.ts` | Detected workspace metadata |
 | `WorkspacePackage` | `schemas/Workspace.ts` | Individual workspace package |
-| `InstallationToken` | `services/GitHubApp.ts` | GitHub App installation token (Schema.Struct) |
+| `InstallationToken` | `services/GitHubApp.ts` | GitHub App installation token (Schema.Struct). Required fields: `token`, `expiresAt`, `installationId`. Optional identity fields: `appSlug`, `appUserId`, `appName` — populated by `GitHubToken.provision` when `resolveAppIdentity` succeeds. |
 
 ### Shared Decode Helpers
 
@@ -186,6 +186,10 @@ and shared by both `ActionStateLive` and `ActionStateTest`.
 `environmentMaps` in `layers/internal/environmentMaps.ts` provides shared
 environment variable mapping logic for `ActionEnvironmentLive` and
 `ActionEnvironmentTest`.
+
+### formatBotIdentity utility
+
+`formatBotIdentity` in `src/utils/botIdentity.ts` is a pure function that derives a `BotIdentity` from an optional `{ appSlug?, appUserId? }` source. When both fields are present it returns a verified identity (`<appSlug>[bot]` / `<appUserId>+<appSlug>[bot]@users.noreply.github.com`); otherwise it returns the well-known `github-actions[bot]` fallback. Both `GitHubApp.botIdentity` and `GitHubToken.botIdentity` delegate to this function.
 
 ---
 

--- a/.claude/design/github-action-effects/layers.md
+++ b/.claude/design/github-action-effects/layers.md
@@ -284,7 +284,7 @@ of construction mode.
 
 ### GitHubAppLive
 
-`Layer.Layer<GitHubApp, never, OctokitAuthApp>`. Uses `Layer.effect` to yield `OctokitAuthApp` for JWT-based auth. Uses native `fetch` for listing installations, resolving installation IDs from `GITHUB_REPOSITORY` and token revocation. `resolveAppIdentity` makes two requests: `GET /app` with an App JWT to get the slug and name, then `GET /users/<slug>[bot]` (public, no auth required) to get the bot user ID. Fails with `GitHubAppError { operation: "identity" }` on any HTTP error. `botIdentity` delegates to `formatBotIdentity` from `src/utils/botIdentity.ts`.
+`Layer.Layer<GitHubApp, never, OctokitAuthApp>`. Uses `Layer.effect` to yield `OctokitAuthApp` for JWT-based auth. Uses native `fetch` for listing installations, resolving installation IDs from `GITHUB_REPOSITORY` and token revocation. `resolveAppIdentity` makes two requests: `GET /app` with an App JWT to get the slug and name, then `GET /users/<slug>[bot]` to get the bot user ID. The users endpoint is public, but the request is sent with the same App JWT so it draws on the 5000 req/hour authenticated limit rather than the 60 req/hour unauthenticated IP limit. Fails with `GitHubAppError { operation: "identity" }` on any HTTP error. `botIdentity` delegates to `formatBotIdentity` from `src/utils/botIdentity.ts`.
 
 ### OctokitAuthAppLive
 

--- a/.claude/design/github-action-effects/layers.md
+++ b/.claude/design/github-action-effects/layers.md
@@ -98,8 +98,12 @@ GitHub API:
   GitHubIssueTest          — in-memory issue state
 
   GitHubAppLive            — Layer.effect depending on OctokitAuthApp; uses native fetch
-                             for installation resolution and token revocation
-  GitHubAppTest            — in-memory token state
+                             for installation resolution, App identity lookup and token
+                             revocation. Implements resolveAppIdentity via GET /app (App
+                             JWT) and GET /users/<slug>[bot].
+  GitHubAppTest            — in-memory token state; appIdentity field controls whether
+                             resolveAppIdentity succeeds (defaults to a test identity in
+                             .empty(), absent field causes controlled failure)
 
   OctokitAuthAppLive       — Layer.succeed; imports @octokit/auth-app directly
                              (one of only two layers importing external packages)
@@ -280,10 +284,7 @@ of construction mode.
 
 ### GitHubAppLive
 
-`Layer.Layer<GitHubApp, never, OctokitAuthApp>`. Uses `Layer.effect` to yield
-`OctokitAuthApp` for JWT-based auth. Uses native `fetch` for listing
-installations and resolving installation IDs from `GITHUB_REPOSITORY`.
-Token revocation also uses native `fetch`.
+`Layer.Layer<GitHubApp, never, OctokitAuthApp>`. Uses `Layer.effect` to yield `OctokitAuthApp` for JWT-based auth. Uses native `fetch` for listing installations, resolving installation IDs from `GITHUB_REPOSITORY` and token revocation. `resolveAppIdentity` makes two requests: `GET /app` with an App JWT to get the slug and name, then `GET /users/<slug>[bot]` (public, no auth required) to get the bot user ID. Fails with `GitHubAppError { operation: "identity" }` on any HTTP error. `botIdentity` delegates to `formatBotIdentity` from `src/utils/botIdentity.ts`.
 
 ### OctokitAuthAppLive
 

--- a/.claude/design/github-action-effects/services.md
+++ b/.claude/design/github-action-effects/services.md
@@ -5,7 +5,7 @@ category: architecture
 created: 2026-03-06
 updated: 2026-05-15
 last-synced: 2026-05-15
-completeness: 95
+completeness: 97
 related:
   - ./index.md
   - ./layers.md
@@ -120,11 +120,11 @@ single export, reducing barrel clutter and improving discoverability.
 the GitHub App installation-token lifecycle. See [GitHubToken Lifecycle](#githubtoken-lifecycle)
 below for the full pre/main/post data flow.
 
-- `GitHubToken.provision(options?)` -- `pre.ts`: generate an installation
-  token, optionally verify scopes, persist it to `ActionState`
-- `GitHubToken.client()` -- `main.ts`: build a `GitHubClient` layer from the
-  persisted token
-- `GitHubToken.dispose()` -- `post.ts`: revoke the persisted token
+- `GitHubToken.provision(options?)` -- `pre.ts`: generate an installation token, best-effort resolve App identity (wrapped in `Effect.option` so a network hiccup degrades gracefully), enrich the token with identity fields, persist it to `ActionState`.
+- `GitHubToken.client()` -- `main.ts`: build a `GitHubClient` layer from the persisted token.
+- `GitHubToken.dispose()` -- `post.ts`: revoke the persisted token.
+- `GitHubToken.read()` -- `Effect<InstallationToken, ActionStateError, ActionState>`: read the raw persisted token from `ActionState`. Available in any phase after `provision`.
+- `GitHubToken.botIdentity()` -- `Effect<BotIdentity, ActionStateError, ActionState>`: read the token and derive a `BotIdentity` via `formatBotIdentity`. Produces a verified identity when `appSlug` and `appUserId` were resolved by `provision`; falls back to `github-actions[bot]` otherwise.
 
 **`GithubMarkdown`** (from `src/utils/GithubMarkdown.ts`) groups GFM builders:
 
@@ -345,17 +345,16 @@ Issue management and linked issue queries.
 ### GitHubApp Service
 
 GitHub App authentication lifecycle. Uses `OctokitAuthApp` for JWT-based
-app auth and native `fetch` for installation resolution and token revocation.
+app auth and native `fetch` for installation resolution, identity lookup and
+token revocation.
 
 **Interface:**
 
-- `generateToken(appId, privateKey, installationId?)` -- Generate an
-  installation token. Auto-resolves installation ID from `GITHUB_REPOSITORY`
-  if not provided. Returns `InstallationToken`
-- `revokeToken(token)` -- Revoke a previously generated token via REST API
-- `botIdentity(appSlug?)` -- Get bot identity for commit attribution. Returns
-  `BotIdentity` (`{ name, email }`)
-- `withToken(appId, privateKey, effect)` -- Bracket: generate, run, revoke
+- `generateToken(appId, privateKey, installationId?)` -- Generate an installation token. Auto-resolves installation ID from `GITHUB_REPOSITORY` if not provided. Returns `InstallationToken` (without identity fields; call `resolveAppIdentity` separately to enrich).
+- `revokeToken(token)` -- Revoke a previously generated token via REST API.
+- `resolveAppIdentity(appId, privateKey)` -- Resolve the App's public identity via `GET /app` (App JWT) then `GET /users/<slug>[bot]` (public). Returns `{ appSlug, appUserId, appName }`. Fails with `GitHubAppError { operation: "identity" }` on HTTP error.
+- `botIdentity(source?)` -- Derive a `BotIdentity` for commit/tag attribution. `source` is `{ appSlug?, appUserId? }`. When both are present returns a verified identity with the numeric-ID email prefix GitHub recognises; otherwise falls back to the well-known `github-actions[bot]` identity. Delegates to `formatBotIdentity` from `src/utils/botIdentity.ts`.
+- `withToken(appId, privateKey, effect)` -- Bracket: generate, run, revoke.
 
 **Types:** `InstallationToken` (Schema), `BotIdentity` (interface)
 
@@ -687,24 +686,30 @@ multi-phase action. It holds no state of its own — it draws on `GitHubApp`,
 `ActionState` and `TokenPermissionChecker`, and uses `GitHubClientLive.fromToken`
 to build the client. All three helpers expose their dependencies in the `R` channel rather than self-providing them: `provision` and `dispose` require a `GitHubApp` layer in context and `client` requires `ActionState`. Consumers provide `GitHubAppLive` composed with `OctokitAuthAppLive` in production, or `GitHubAppTest` in their own tests.
 
-The three helpers communicate through a single internal `ActionState` key
+The helpers communicate through a single internal `ActionState` key
 (`github-action-effects/installation-token`) carrying the `InstallationToken`
 envelope (the schema exported from `GitHubApp.ts`):
 
 ```text
 pre.ts   GitHubToken.provision()  — resolve App credentials, generate token,
-                                    optionally verify scopes, persist envelope
+                                    best-effort resolve App identity, enrich
+                                    token with identity fields, optionally verify
+                                    scopes, persist enriched envelope
                                           │
                                           ▼  ActionState (GITHUB_STATE file)
                                           │
 main.ts  GitHubToken.client()     — read envelope, build GitHubClient layer
                                     via GitHubClientLive.fromToken
+         GitHubToken.read()       — read raw InstallationToken from state
+         GitHubToken.botIdentity() — derive BotIdentity from persisted token
                                           │
 post.ts  GitHubToken.dispose()    — read envelope, revoke token via GitHubApp
 ```
 
-- **`provision(options?)`** — `Effect<InstallationToken, GitHubAppError | TokenPermissionError | ActionStateError | ConfigError, ActionState | GitHubApp>`. Credentials are hybrid: `clientId` defaults to the `app-client-id` action input (`Config.string`) and `privateKey` to `app-private-key` (`Config.redacted`); the options object overrides both. Generates the token via `GitHubApp`, and when `permissions` are given runs `assertSufficient` against the token's own `permissions` (no API call) — failing with `TokenPermissionError` on a missing scope. Persists the envelope and returns the `InstallationToken`. Strict: fails if no credentials resolve.
+- **`provision(options?)`** — `Effect<InstallationToken, GitHubAppError | TokenPermissionError | ActionStateError | ConfigError, ActionState | GitHubApp>`. Credentials are hybrid: `clientId` defaults to the `app-client-id` action input (`Config.string`) and `privateKey` to `app-private-key` (`Config.redacted`); the options object overrides both. Generates the token via `GitHubApp.generateToken`, then calls `GitHubApp.resolveAppIdentity` wrapped in `Effect.option` — a failure degrades to a token without identity fields rather than crashing the action. When `permissions` are given runs `assertSufficient` against the token's own `permissions` (no API call). Persists the enriched envelope and returns it. Strict: fails if no credentials resolve.
 - **`client()`** — `Layer.Layer<GitHubClient, ActionStateError, ActionState>`. Reads the persisted envelope and delegates to `GitHubClientLive.fromToken`. Strict: fails with `ActionStateError` if nothing was provisioned.
+- **`read()`** — `Effect<InstallationToken, ActionStateError, ActionState>`. Reads the persisted envelope from `ActionState`. Available in any phase after `provision`.
+- **`botIdentity()`** — `Effect<BotIdentity, ActionStateError, ActionState>`. Reads the token via `read()` and derives a `BotIdentity` via `formatBotIdentity`. Produces a verified identity (with numeric user-ID email prefix) when `appSlug` and `appUserId` were resolved; falls back to `github-actions[bot]` otherwise.
 - **`dispose()`** — `Effect<void, GitHubAppError | ActionStateError, ActionState | GitHubApp>`. Reads the envelope via `ActionState.getOptional` and revokes it via `GitHubApp.revokeToken`. Deliberately a **no-op when nothing was persisted** — `post` steps run even when `pre`/`main` failed, so a cleanup step must not crash because there is nothing to revoke.
 
 `provision` and `dispose` require `GitHubApp` in their requirements channel exactly as `client` requires `ActionState` — the namespace exposes every dependency rather than hiding some. A consumer provides a `GitHubApp` layer alongside the helper: `GitHubAppLive` composed with `OctokitAuthAppLive` in production, or `GitHubAppTest` when unit-testing their own `pre.ts`/`post.ts` against a mock token.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,22 +1,17 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with
-code in this repository.
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
 ## Project Status
 
-Effect-based utility library for building robust, well-logged, and
-schema-validated GitHub Actions. Zero CJS dependencies — all `@actions/*`
-packages replaced with native ESM implementations using Effect primitives
-and the GitHub Actions runtime protocol.
+Effect-based utility library for building robust, well-logged, and schema-validated GitHub Actions. Zero CJS dependencies — all `@actions/*` packages replaced with native ESM implementations using Effect primitives and the GitHub Actions runtime protocol.
 
 ## Design Documentation
 
 **For architecture, service interfaces, and data flow:**
 -> `@./.claude/design/github-action-effects/index.md`
 
-Load when making architectural changes, adding new services, modifying layer
-composition, or understanding design decisions.
+Load when making architectural changes, adding new services, modifying layer composition, or understanding design decisions.
 
 **Do NOT load unless directly relevant to your task.**
 
@@ -77,8 +72,7 @@ src/
 
 ### Runtime Layer
 
-The `src/runtime/` directory contains the GitHub Actions runtime protocol
-implementations that replace `@actions/core`, `@actions/exec`, etc.:
+The `src/runtime/` directory contains the GitHub Actions runtime protocol implementations that replace `@actions/core`, `@actions/exec`, etc.:
 
 - `WorkflowCommand` — `::command::` protocol formatter with escaping
 - `RuntimeFile` — Env file appender (GITHUB_OUTPUT, GITHUB_ENV, etc.)
@@ -103,7 +97,7 @@ const name = yield* Config.string("name")      // reads INPUT_NAME
 const count = yield* Config.integer("count")    // reads INPUT_COUNT
 ```
 
-For GitHub App actions, `GitHubToken` provides phase-oriented installation-token helpers: `provision` (pre), `client` (main), `dispose` (post), with optional post-generation permission verification.
+For GitHub App actions, `GitHubToken` provides phase-oriented installation-token helpers: `provision` (pre), `client` (main), `dispose` (post), plus `read()` and `botIdentity()` accessors available in any phase after provisioning, with optional post-generation permission verification.
 
 ### Services
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ setup, project structure, and conventions you need to get started.
 ## Prerequisites
 
 - **Node.js 24** (24.11.0 or later)
-- **pnpm 10.32.1** -- enforced via the `packageManager` field in package.json
+- **pnpm 10.33.4** -- enforced via the `packageManager` field in package.json
 
 ## Getting Started
 

--- a/README.md
+++ b/README.md
@@ -110,7 +110,12 @@ const appLayer = Layer.provide(GitHubAppLive, OctokitAuthAppLive);
 Action.run(GitHubToken.dispose().pipe(Effect.provide(appLayer)));
 ```
 
-`provision` reads App credentials from its options object or, by default, from the `app-client-id` and `app-private-key` action inputs. Passing `permissions` verifies the generated token grants those scopes before it is persisted.
+`provision` reads App credentials from its options object or, by default, from the `app-client-id` and `app-private-key` action inputs. Passing `permissions` verifies the generated token grants those scopes before it is persisted. It also resolves the App's public identity (slug, bot user ID, name) best-effort and stores it on the token, so later phases can call `GitHubToken.botIdentity()` without an extra API call.
+
+Two additional accessors are available in any phase after `provision`:
+
+- `GitHubToken.read()` — an `Effect<InstallationToken, ActionStateError, ActionState>` that reads the full persisted token envelope, including the optional `appSlug`, `appUserId` and `appName` fields resolved during `provision`.
+- `GitHubToken.botIdentity()` — an `Effect<BotIdentity, ActionStateError, ActionState>` that derives a commit-attribution identity from the persisted token. When the App's slug and user ID were resolved, the returned email uses the `<userId>+<slug>[bot]@users.noreply.github.com` format that GitHub recognises for verified attribution; otherwise it falls back to the well-known `github-actions[bot]` identity.
 
 ## Documentation
 

--- a/docs/02-advanced-action.md
+++ b/docs/02-advanced-action.md
@@ -114,7 +114,7 @@ Action.run(program)
 ### What happens in pre.ts
 
 1. **ActionState.save** — persists the start timestamp as a Schema-encoded JSON string. GitHub Actions only carries plain key-value strings between phases; the Schema encode/decode layer serializes the struct for you.
-2. **GitHubToken.provision** — reads the App credentials from the `app-client-id` and `app-private-key` inputs, generates an installation token and saves it to `ActionState` under an internal key. The returned `InstallationToken` carries `token`, `expiresAt`, `installationId` and `permissions`, plus three optional identity fields — `appSlug`, `appUserId` and `appName` — populated best-effort via a `GET /app` call during `provision`. These fields let later phases call `GitHubToken.botIdentity()` without an additional API round-trip.
+2. **GitHubToken.provision** — reads the App credentials from the `app-client-id` and `app-private-key` inputs, generates an installation token and saves it to `ActionState` under an internal key. The returned `InstallationToken` carries `token`, `expiresAt`, `installationId` and `permissions`, plus three optional identity fields — `appSlug`, `appUserId` and `appName` — populated best-effort during `provision` by an App identity lookup (`GET /app` for the slug and name, then `GET /users/<slug>[bot]` for the bot user ID). These fields let later phases call `GitHubToken.botIdentity()` without an additional API round-trip.
 3. **Permission verification** — when you pass `permissions`, `provision` checks the new token against those scopes before it persists anything. A missing scope fails the action with `TokenPermissionError` and revokes the rejected token, so a misconfigured App installation surfaces in `pre` rather than mid-publish.
 
 ## Phase 2: main.ts

--- a/docs/02-advanced-action.md
+++ b/docs/02-advanced-action.md
@@ -114,7 +114,7 @@ Action.run(program)
 ### What happens in pre.ts
 
 1. **ActionState.save** — persists the start timestamp as a Schema-encoded JSON string. GitHub Actions only carries plain key-value strings between phases; the Schema encode/decode layer serializes the struct for you.
-2. **GitHubToken.provision** — reads the App credentials from the `app-client-id` and `app-private-key` inputs, generates an installation token and saves it to `ActionState` under an internal key. The returned `InstallationToken` carries `token`, `expiresAt`, `installationId` and `permissions`.
+2. **GitHubToken.provision** — reads the App credentials from the `app-client-id` and `app-private-key` inputs, generates an installation token and saves it to `ActionState` under an internal key. The returned `InstallationToken` carries `token`, `expiresAt`, `installationId` and `permissions`, plus three optional identity fields — `appSlug`, `appUserId` and `appName` — populated best-effort via a `GET /app` call during `provision`. These fields let later phases call `GitHubToken.botIdentity()` without an additional API round-trip.
 3. **Permission verification** — when you pass `permissions`, `provision` checks the new token against those scopes before it persists anything. A missing scope fails the action with `TokenPermissionError` and revokes the rejected token, so a misconfigured App installation surfaces in `pre` rather than mid-publish.
 
 ## Phase 2: main.ts

--- a/docs/03-services.md
+++ b/docs/03-services.md
@@ -422,6 +422,21 @@ const program = Effect.gen(function* () {
   // Revoke it when done
   yield* app.revokeToken(installation.token)
 
+  // Resolve the App's public identity (slug, bot user ID, display name)
+  const identity = yield* app.resolveAppIdentity(clientId, privateKey)
+  // identity.appSlug, identity.appUserId, identity.appName
+
+  // Derive a commit-attribution identity.
+  // With appSlug + appUserId, the email uses GitHub's verified-attribution format.
+  const bot = app.botIdentity({ appSlug: identity.appSlug, appUserId: identity.appUserId })
+  // bot.name  → "<appSlug>[bot]"
+  // bot.email → "<appUserId>+<appSlug>[bot]@users.noreply.github.com"
+
+  // Without source fields, falls back to the well-known github-actions[bot] identity
+  const fallback = app.botIdentity()
+  // fallback.name  → "github-actions[bot]"
+  // fallback.email → "41898282+github-actions[bot]@users.noreply.github.com"
+
   // Or use the bracket form: the callback receives the bare token string,
   // and the token is always revoked afterwards, even on failure
   yield* app.withToken(clientId, privateKey, (token) =>
@@ -473,7 +488,7 @@ const appLayer = Layer.provide(GitHubAppLive, OctokitAuthAppLive)
 
 ### GitHubToken
 
-`GitHubToken` is a top-level namespace, like `Action`, not an injected service. It coordinates one GitHub App installation token across the three action phases: `provision` in `pre`, `client` in `main`, `dispose` in `post`. It persists the token to `ActionState` internally, so you do not define a token schema yourself.
+`GitHubToken` is a top-level namespace, like `Action`, not an injected service. It coordinates one GitHub App installation token across the three action phases: `provision` in `pre`, `client` in `main`, `dispose` in `post`. Two additional accessors — `read` and `botIdentity` — are available in any phase after `provision`. The namespace persists the token to `ActionState` internally, so you do not define a token schema yourself.
 
 ```typescript
 import { Effect, Layer } from "effect"
@@ -506,10 +521,31 @@ Action.run(main)
 Action.run(GitHubToken.dispose().pipe(Effect.provide(appLayer)))
 ```
 
-The three members:
+Use `read` and `botIdentity` in any phase that runs after `provision`:
 
-- `provision(options?)` — generates an installation token and saves it. `clientId` defaults to the `app-client-id` action input and `privateKey` to `app-private-key`; pass them in `options` to override. With `permissions` set, the generated token is verified to grant those scopes before it is persisted — a missing scope fails with `TokenPermissionError` and revokes the rejected token. Returns the `InstallationToken`. Requires a `GitHubApp` layer and `ActionState`.
+```typescript
+import { Effect } from "effect"
+import { Action, ActionState, GitHubToken } from "@savvy-web/github-action-effects"
+
+// main.ts — read the full token envelope and derive a commit identity
+const main = Effect.gen(function* () {
+  const token = yield* GitHubToken.read()
+  // token.appSlug, token.appUserId, token.appName (populated best-effort)
+
+  const identity = yield* GitHubToken.botIdentity()
+  // identity.name  → "<appSlug>[bot]" or "github-actions[bot]"
+  // identity.email → "<appUserId>+<appSlug>[bot]@users.noreply.github.com" or fallback
+}).pipe(Effect.provide(GitHubToken.client()))
+
+Action.run(main)
+```
+
+The five members:
+
+- `provision(options?)` — generates an installation token and saves it. `clientId` defaults to the `app-client-id` action input and `privateKey` to `app-private-key`; pass them in `options` to override. With `permissions` set, the generated token is verified to grant those scopes before it is persisted — a missing scope fails with `TokenPermissionError` and revokes the rejected token. Also resolves the App's public identity (slug, bot user ID, name) best-effort and stores those fields on the token. Returns the `InstallationToken`. Requires a `GitHubApp` layer and `ActionState`.
 - `client()` — a `Layer<GitHubClient, ActionStateError, ActionState>` that reads the persisted token and builds a `GitHubClient` from it.
+- `read()` — an `Effect<InstallationToken, ActionStateError, ActionState>` that returns the full persisted token envelope, including the optional `appSlug`, `appUserId` and `appName` fields. Requires `ActionState`.
+- `botIdentity()` — an `Effect<BotIdentity, ActionStateError, ActionState>` that derives a commit-attribution identity from the persisted token. When `appSlug` and `appUserId` were resolved, the email uses the `<userId>+<slug>[bot]@users.noreply.github.com` format GitHub recognises for verified attribution; otherwise it falls back to the well-known `github-actions[bot]` identity. Requires `ActionState`.
 - `dispose()` — revokes the persisted token. A no-op if none was persisted. Requires a `GitHubApp` layer and `ActionState`.
 
 `provision` and `dispose` require a `GitHubApp` layer in context. Compose it once as `Layer.provide(GitHubAppLive, OctokitAuthAppLive)` and provide it to each effect. In tests, provide `GitHubAppTest.layer(GitHubAppTest.empty())` instead.

--- a/docs/07-architecture.md
+++ b/docs/07-architecture.md
@@ -271,19 +271,21 @@ const program = Effect.gen(function* () {
 
 ### GitHubToken namespace
 
-`GitHubToken` (in `src/GitHubToken.ts`) coordinates a single GitHub App installation token across the three phases of an action — `pre`, `main` and `post`. It is a namespace object with three members:
+`GitHubToken` (in `src/GitHubToken.ts`) coordinates a single GitHub App installation token across the three phases of an action — `pre`, `main` and `post`. It is a namespace object with five members:
 
 | Member | Signature | Phase |
 | --- | --- | --- |
 | `provision` | `(options?: ProvisionOptions) => Effect<InstallationToken, ..., ActionState \| GitHubApp>` | `pre` |
 | `client` | `() => Layer<GitHubClient, ActionStateError, ActionState>` | `main` |
+| `read` | `() => Effect<InstallationToken, ActionStateError, ActionState>` | any post-provision |
+| `botIdentity` | `() => Effect<BotIdentity, ActionStateError, ActionState>` | any post-provision |
 | `dispose` | `() => Effect<void, ..., ActionState \| GitHubApp>` | `post` |
 
-`provision` generates an installation token, optionally verifies its `permissions` against a required set, then persists the token envelope to `ActionState` under an internal key. By default it reads App credentials from the `app-client-id` and `app-private-key` action inputs; pass `clientId` and `privateKey` on the options object to override. If verification or persistence fails the token is revoked, so a rejected token is never left orphaned.
+`provision` generates an installation token, optionally verifies its `permissions` against a required set, then persists the token envelope to `ActionState` under an internal key. It also calls `GET /app` best-effort to resolve the App's public identity (slug, bot user ID, display name) and stores those fields — `appSlug`, `appUserId`, `appName` — on the persisted token. By default it reads App credentials from the `app-client-id` and `app-private-key` action inputs; pass `clientId` and `privateKey` on the options object to override. If verification or persistence fails the token is revoked, so a rejected token is never left orphaned.
 
-`client` reads the persisted token back out of `ActionState` and returns a `GitHubClient` layer built via `GitHubClientLive.fromToken`. `dispose` reads the token and revokes it, doing nothing if no token was persisted.
+`client` reads the persisted token back out of `ActionState` and returns a `GitHubClient` layer built via `GitHubClientLive.fromToken`. `read` returns the full `InstallationToken` envelope including the optional identity fields. `botIdentity` derives a `BotIdentity` (name + email) suitable for Git commit attribution — using the App-specific verified format when `appSlug` and `appUserId` are present, falling back to the well-known `github-actions[bot]` identity otherwise. `dispose` reads the token and revokes it, doing nothing if no token was persisted.
 
-`provision` and `dispose` need a `GitHubApp` layer in their requirements channel — `GitHubAppLive` composed with `OctokitAuthAppLive` in production, `GitHubAppTest` in tests. `client` needs only `ActionState`, which `ActionsRuntime.Default` already provides.
+`provision` and `dispose` need a `GitHubApp` layer in their requirements channel — `GitHubAppLive` composed with `OctokitAuthAppLive` in production, `GitHubAppTest` in tests. `client`, `read` and `botIdentity` need only `ActionState`, which `ActionsRuntime.Default` already provides.
 
 ### Package management services
 

--- a/docs/08-testing.md
+++ b/docs/08-testing.md
@@ -356,17 +356,18 @@ A `rest`, `graphql` or `paginate` call with no recorded entry fails with a `GitH
 
 ## Testing GitHub App token lifecycle
 
-Actions that use `GitHubToken` need `GitHubApp` and `ActionState` in context. Provide `GitHubAppTest` and `ActionStateTest` to exercise `provision`, `client` and `dispose` without a real GitHub App.
+Actions that use `GitHubToken` need `GitHubApp` and `ActionState` in context. Provide `GitHubAppTest` and `ActionStateTest` to exercise `provision`, `client`, `read`, `botIdentity` and `dispose` without a real GitHub App.
 
-`GitHubAppTest` follows the `empty()`/`layer()` pattern. Its state has three fields:
+`GitHubAppTest` follows the `empty()`/`layer()` pattern. Its state has four fields:
 
 | Field | Type | Description |
 | --- | --- | --- |
 | `generateCalls` | `Array<{ appId, privateKey, installationId? }>` | Recorded `generateToken` calls |
 | `revokeCalls` | `Array<string>` | Tokens passed to `revokeToken` |
 | `tokenToReturn` | `InstallationToken` | The token every `generateToken` call returns |
+| `appIdentity` | `{ appSlug, appUserId, appName } \| undefined` | Identity returned by `resolveAppIdentity`; when omitted, `resolveAppIdentity` fails — exercising `provision`'s best-effort degradation path |
 
-`GitHubAppTest.empty()` seeds `tokenToReturn` with a default token (`ghs_test_token_123`, empty `permissions`). Override `tokenToReturn` to test permission verification.
+`GitHubAppTest.empty()` seeds `tokenToReturn` with a default token (`ghs_test_token_123`, empty `permissions`) and `appIdentity` with `{ appSlug: "test-app", appUserId: 99999, appName: "Test App" }`. Override either field to test specific scenarios — for example, omit `appIdentity` to verify that `provision` still succeeds when identity resolution fails, or set `tokenToReturn.permissions` to exercise scope verification.
 
 Testing `provision` — supply the App credentials and assert the token was generated and persisted:
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -80,7 +80,7 @@ const program = Effect.gen(function* () {
 | Namespace | Purpose |
 | --- | --- |
 | `Action` | Top-level helpers: `run`, `formatCause`, `resolveLogLevel` |
-| `GitHubToken` | GitHub App installation-token lifecycle: `provision`, `client`, `dispose` |
+| `GitHubToken` | GitHub App installation-token lifecycle: `provision`, `client`, `read`, `botIdentity`, `dispose` |
 | `GitHubClientLive` | `GitHubClient` layer constructors: `fromEnv`, `fromToken`, `fromApp` |
 | `GithubMarkdown` | Pure GFM builder functions: `table`, `heading`, `bold`, `details`, `checklist`, etc. |
 | `AutoMerge` | Enable/disable PR auto-merge via GraphQL |

--- a/src/GitHubToken.test.ts
+++ b/src/GitHubToken.test.ts
@@ -5,6 +5,7 @@ import { ActionStateTest } from "./layers/ActionStateTest.js";
 import type { GitHubAppTestState } from "./layers/GitHubAppTest.js";
 import { GitHubAppTest } from "./layers/GitHubAppTest.js";
 import { ActionState } from "./services/ActionState.js";
+import type { BotIdentity } from "./services/GitHubApp.js";
 import { InstallationToken } from "./services/GitHubApp.js";
 import { GitHubClient } from "./services/GitHubClient.js";
 
@@ -23,10 +24,14 @@ vi.mock("@octokit/rest", async (importOriginal) => {
 const STATE_KEY = "github-action-effects/installation-token";
 
 /** Build a GitHubApp test state that returns the given installation token. */
-const appStateWith = (token: InstallationToken): GitHubAppTestState => ({
+const appStateWith = (
+	token: InstallationToken,
+	appIdentity?: { appSlug: string; appUserId: number; appName: string },
+): GitHubAppTestState => ({
 	generateCalls: [],
 	revokeCalls: [],
 	tokenToReturn: token,
+	...(appIdentity !== undefined ? { appIdentity } : {}),
 });
 
 beforeEach(() => {
@@ -133,6 +138,55 @@ describe("GitHubToken", () => {
 			expect(state.entries.has(STATE_KEY)).toBe(false);
 			expect(appState.revokeCalls).toContain("ghs_weak");
 		});
+
+		it("resolves and persists the App identity", async () => {
+			const appState = appStateWith(
+				{
+					token: "ghs_with_identity",
+					expiresAt: "2099-01-01T00:00:00Z",
+					installationId: 7,
+					permissions: {},
+				},
+				{ appSlug: "acme-bot", appUserId: 123456, appName: "Acme Bot" },
+			);
+			const state = ActionStateTest.empty();
+
+			const token = await Effect.runPromise(
+				Effect.provide(
+					GitHubToken.provision({ clientId: "Iv1.abc", privateKey: "pk", installationId: 7 }),
+					Layer.mergeAll(ActionStateTest.layer(state), GitHubAppTest.layer(appState)),
+				),
+			);
+
+			expect(token.appSlug).toBe("acme-bot");
+			expect(token.appUserId).toBe(123456);
+			expect(token.appName).toBe("Acme Bot");
+
+			const persisted = JSON.parse(state.entries.get(STATE_KEY) ?? "{}");
+			expect(persisted.appSlug).toBe("acme-bot");
+			expect(persisted.appUserId).toBe(123456);
+		});
+
+		it("persists the token without identity when resolution fails", async () => {
+			const appState = appStateWith({
+				token: "ghs_no_identity",
+				expiresAt: "2099-01-01T00:00:00Z",
+				installationId: 7,
+				permissions: {},
+			});
+			const state = ActionStateTest.empty();
+
+			const token = await Effect.runPromise(
+				Effect.provide(
+					GitHubToken.provision({ clientId: "Iv1.abc", privateKey: "pk", installationId: 7 }),
+					Layer.mergeAll(ActionStateTest.layer(state), GitHubAppTest.layer(appState)),
+				),
+			);
+
+			expect(token.token).toBe("ghs_no_identity");
+			expect(token.appSlug).toBeUndefined();
+			expect(state.entries.has(STATE_KEY)).toBe(true);
+		});
 	});
 
 	describe("client", () => {
@@ -218,6 +272,96 @@ describe("GitHubToken", () => {
 			);
 
 			expect(appState.revokeCalls).toHaveLength(0);
+		});
+	});
+
+	describe("read", () => {
+		it("returns the persisted installation token with identity fields", async () => {
+			const state = ActionStateTest.empty();
+			await Effect.runPromise(
+				Effect.provide(
+					Effect.flatMap(ActionState, (s) =>
+						s.save(
+							STATE_KEY,
+							{
+								token: "ghs_persisted",
+								expiresAt: "2099-01-01T00:00:00Z",
+								installationId: 7,
+								appSlug: "acme-bot",
+								appUserId: 123456,
+								appName: "Acme Bot",
+								permissions: {},
+							},
+							InstallationToken,
+						),
+					),
+					ActionStateTest.layer(state),
+				),
+			);
+
+			const token = await Effect.runPromise(Effect.provide(GitHubToken.read(), ActionStateTest.layer(state)));
+
+			expect(token.token).toBe("ghs_persisted");
+			expect(token.appSlug).toBe("acme-bot");
+			expect(token.appUserId).toBe(123456);
+			expect(token.appName).toBe("Acme Bot");
+		});
+
+		it("fails when no token was provisioned", async () => {
+			const state = ActionStateTest.empty();
+			const exit = await Effect.runPromise(
+				Effect.exit(Effect.provide(GitHubToken.read(), ActionStateTest.layer(state))),
+			);
+			expect(exit._tag).toBe("Failure");
+		});
+	});
+
+	describe("botIdentity", () => {
+		const persist = (state: ReturnType<typeof ActionStateTest.empty>, token: InstallationToken) =>
+			Effect.runPromise(
+				Effect.provide(
+					Effect.flatMap(ActionState, (s) => s.save(STATE_KEY, token, InstallationToken)),
+					ActionStateTest.layer(state),
+				),
+			);
+
+		it("derives a verified identity from the persisted token", async () => {
+			const state = ActionStateTest.empty();
+			await persist(state, {
+				token: "ghs_persisted",
+				expiresAt: "2099-01-01T00:00:00Z",
+				installationId: 7,
+				appSlug: "acme-bot",
+				appUserId: 123456,
+				appName: "Acme Bot",
+				permissions: {},
+			});
+
+			const identity: BotIdentity = await Effect.runPromise(
+				Effect.provide(GitHubToken.botIdentity(), ActionStateTest.layer(state)),
+			);
+
+			expect(identity).toEqual({
+				name: "acme-bot[bot]",
+				email: "123456+acme-bot[bot]@users.noreply.github.com",
+			});
+		});
+
+		it("falls back to github-actions[bot] when identity fields are absent", async () => {
+			const state = ActionStateTest.empty();
+			await persist(state, {
+				token: "ghs_persisted",
+				expiresAt: "2099-01-01T00:00:00Z",
+				installationId: 7,
+				permissions: {},
+			});
+
+			const identity = await Effect.runPromise(Effect.provide(GitHubToken.botIdentity(), ActionStateTest.layer(state)));
+
+			expect(identity).toEqual({
+				name: "github-actions[bot]",
+				email: "41898282+github-actions[bot]@users.noreply.github.com",
+			});
 		});
 	});
 });

--- a/src/GitHubToken.ts
+++ b/src/GitHubToken.ts
@@ -58,7 +58,16 @@ const provision = (
 
 					// Best-effort identity resolution: a GET hiccup degrades to a
 					// token without identity fields rather than failing the action.
-					const identity = yield* Effect.option(app.resolveAppIdentity(clientId, privateKey));
+					// The failure is logged so a misconfigured App surfaces in the
+					// workflow log instead of silently yielding the default identity.
+					const identity = yield* app.resolveAppIdentity(clientId, privateKey).pipe(
+						Effect.tapError((error) =>
+							Effect.logWarning(
+								`App identity resolution failed (${error.reason}); commits will fall back to the github-actions[bot] identity`,
+							),
+						),
+						Effect.option,
+					);
 					const enriched = Option.isSome(identity) ? { ...token, ...identity.value } : token;
 
 					const state = yield* ActionState;

--- a/src/GitHubToken.ts
+++ b/src/GitHubToken.ts
@@ -7,9 +7,11 @@ import { GitHubClientLive } from "./layers/GitHubClientLive.js";
 import { TokenPermissionCheckerLive } from "./layers/TokenPermissionCheckerLive.js";
 import type { PermissionLevel } from "./schemas/TokenPermission.js";
 import { ActionState } from "./services/ActionState.js";
+import type { BotIdentity } from "./services/GitHubApp.js";
 import { GitHubApp, InstallationToken } from "./services/GitHubApp.js";
 import type { GitHubClient } from "./services/GitHubClient.js";
 import { TokenPermissionChecker } from "./services/TokenPermissionChecker.js";
+import { formatBotIdentity } from "./utils/botIdentity.js";
 import { unwrapRedacted } from "./utils/unwrapRedacted.js";
 
 /** Internal ActionState key for the persisted installation-token envelope. */
@@ -54,10 +56,15 @@ const provision = (
 						);
 					}
 
-					const state = yield* ActionState;
-					yield* state.save(STATE_KEY, token, InstallationToken);
+					// Best-effort identity resolution: a GET hiccup degrades to a
+					// token without identity fields rather than failing the action.
+					const identity = yield* Effect.option(app.resolveAppIdentity(clientId, privateKey));
+					const enriched = Option.isSome(identity) ? { ...token, ...identity.value } : token;
 
-					return token;
+					const state = yield* ActionState;
+					yield* state.save(STATE_KEY, enriched, InstallationToken);
+
+					return enriched;
 				}),
 			(token, exit) => (Exit.isFailure(exit) ? Effect.ignore(app.revokeToken(token.token)) : Effect.void),
 		);
@@ -83,18 +90,29 @@ const dispose = (): Effect.Effect<void, GitHubAppError | ActionStateError, Actio
 		yield* app.revokeToken(persisted.value.token);
 	});
 
+const read = (): Effect.Effect<InstallationToken, ActionStateError, ActionState> =>
+	Effect.flatMap(ActionState, (state) => state.get(STATE_KEY, InstallationToken));
+
+const botIdentity = (): Effect.Effect<BotIdentity, ActionStateError, ActionState> =>
+	Effect.map(read(), (token) => formatBotIdentity({ appSlug: token.appSlug, appUserId: token.appUserId }));
+
 /**
  * Phase-oriented helpers for the GitHub App installation-token lifecycle:
- * `provision` in `pre`, `client` in `main`, `dispose` in `post`.
+ * `provision` in `pre`, `client` in `main`, `dispose` in `post`. `read` and
+ * `botIdentity` surface the persisted token (and a verified commit identity)
+ * to any phase after `provision`.
  *
  * `provision` and `dispose` require a `GitHubApp` layer in context — provide
  * `GitHubAppLive` (composed with `OctokitAuthAppLive`) in production, or
- * `GitHubAppTest` in tests. `client` requires `ActionState`.
+ * `GitHubAppTest` in tests. `client`, `read`, and `botIdentity` require
+ * `ActionState`.
  *
  * @public
  */
 export const GitHubToken = {
 	provision,
 	client,
+	read,
+	botIdentity,
 	dispose,
 } as const;

--- a/src/errors/GitHubAppError.ts
+++ b/src/errors/GitHubAppError.ts
@@ -5,7 +5,7 @@ import { Data } from "effect";
  */
 export class GitHubAppError extends Data.TaggedError("GitHubAppError")<{
 	/** The operation that failed. */
-	readonly operation: "jwt" | "token" | "revoke";
+	readonly operation: "jwt" | "token" | "revoke" | "identity";
 
 	/** Human-readable description. */
 	readonly reason: string;

--- a/src/layers/GitHubAppLive.test.ts
+++ b/src/layers/GitHubAppLive.test.ts
@@ -316,7 +316,12 @@ describe("GitHubAppLive", () => {
 					headers: expect.objectContaining({ Authorization: "Bearer jwt_for_app" }),
 				}),
 			);
-			expect(mockFetch).toHaveBeenCalledWith("https://api.github.com/users/acme-bot%5Bbot%5D", expect.anything());
+			expect(mockFetch).toHaveBeenCalledWith(
+				"https://api.github.com/users/acme-bot%5Bbot%5D",
+				expect.objectContaining({
+					headers: expect.objectContaining({ Authorization: "Bearer jwt_for_app" }),
+				}),
+			);
 		});
 
 		it("fails with GitHubAppError when GET /app errors", async () => {

--- a/src/layers/GitHubAppLive.test.ts
+++ b/src/layers/GitHubAppLive.test.ts
@@ -1,5 +1,6 @@
-import { Effect, Exit, Layer } from "effect";
+import { Cause, Effect, Exit, Layer } from "effect";
 import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { GitHubAppError } from "../errors/GitHubAppError.js";
 import { GitHubApp } from "../services/GitHubApp.js";
 import { OctokitAuthApp } from "../services/OctokitAuthApp.js";
 import { GitHubAppLive } from "./GitHubAppLive.js";
@@ -265,6 +266,96 @@ describe("GitHubAppLive", () => {
 			mockFetch.mockResolvedValue({ ok: false, status: 401 });
 			const exit = await runExit(Effect.flatMap(GitHubApp, (svc) => svc.revokeToken("ghs_bad")));
 			expect(exit._tag).toBe("Failure");
+		});
+	});
+
+	describe("botIdentity", () => {
+		it("returns a verified identity when slug and user ID are present", async () => {
+			const result = await run(
+				Effect.map(GitHubApp, (svc) => svc.botIdentity({ appSlug: "acme-bot", appUserId: 123456 })),
+			);
+			expect(result).toEqual({
+				name: "acme-bot[bot]",
+				email: "123456+acme-bot[bot]@users.noreply.github.com",
+			});
+		});
+
+		it("falls back to github-actions[bot] when no source is given", async () => {
+			const result = await run(Effect.map(GitHubApp, (svc) => svc.botIdentity()));
+			expect(result).toEqual({
+				name: "github-actions[bot]",
+				email: "41898282+github-actions[bot]@users.noreply.github.com",
+			});
+		});
+	});
+
+	describe("resolveAppIdentity", () => {
+		it("resolves slug, name, and bot user ID", async () => {
+			// GET /app
+			mockAuth.mockResolvedValueOnce({ token: "jwt_for_app" });
+			mockFetch.mockResolvedValueOnce({
+				ok: true,
+				status: 200,
+				json: async () => ({ slug: "acme-bot", name: "Acme Bot" }),
+			});
+			// GET /users/acme-bot[bot]
+			mockFetch.mockResolvedValueOnce({
+				ok: true,
+				status: 200,
+				json: async () => ({ id: 123456 }),
+			});
+
+			const result = await run(Effect.flatMap(GitHubApp, (svc) => svc.resolveAppIdentity("app-1", "pk")));
+
+			expect(result).toEqual({ appSlug: "acme-bot", appUserId: 123456, appName: "Acme Bot" });
+			expect(mockAuth).toHaveBeenCalledWith({ type: "app" });
+			expect(mockFetch).toHaveBeenCalledTimes(2);
+			expect(mockFetch).toHaveBeenCalledWith(
+				"https://api.github.com/app",
+				expect.objectContaining({
+					headers: expect.objectContaining({ Authorization: "Bearer jwt_for_app" }),
+				}),
+			);
+			expect(mockFetch).toHaveBeenCalledWith("https://api.github.com/users/acme-bot%5Bbot%5D", expect.anything());
+		});
+
+		it("fails with GitHubAppError when GET /app errors", async () => {
+			mockAuth.mockResolvedValueOnce({ token: "jwt_for_app" });
+			mockFetch.mockResolvedValueOnce({ ok: false, status: 404, json: async () => ({}) });
+
+			const exit = await runExit(Effect.flatMap(GitHubApp, (svc) => svc.resolveAppIdentity("app-1", "pk")));
+			expect(Exit.isFailure(exit)).toBe(true);
+			if (Exit.isFailure(exit)) {
+				const error = Cause.failureOption(exit.cause);
+				expect(error._tag).toBe("Some");
+				if (error._tag === "Some") {
+					expect(error.value).toBeInstanceOf(GitHubAppError);
+					expect((error.value as GitHubAppError).operation).toBe("identity");
+				}
+			}
+		});
+
+		it("fails with GitHubAppError when GET /users/<slug>[bot] errors", async () => {
+			mockAuth.mockResolvedValueOnce({ token: "jwt_for_app" });
+			// GET /app succeeds
+			mockFetch.mockResolvedValueOnce({
+				ok: true,
+				status: 200,
+				json: async () => ({ slug: "acme-bot", name: "Acme Bot" }),
+			});
+			// GET /users/acme-bot[bot] fails
+			mockFetch.mockResolvedValueOnce({ ok: false, status: 404, json: async () => ({}) });
+
+			const exit = await runExit(Effect.flatMap(GitHubApp, (svc) => svc.resolveAppIdentity("app-1", "pk")));
+			expect(Exit.isFailure(exit)).toBe(true);
+			if (Exit.isFailure(exit)) {
+				const error = Cause.failureOption(exit.cause);
+				expect(error._tag).toBe("Some");
+				if (error._tag === "Some") {
+					expect(error.value).toBeInstanceOf(GitHubAppError);
+					expect((error.value as GitHubAppError).operation).toBe("identity");
+				}
+			}
 		});
 	});
 

--- a/src/layers/GitHubAppLive.ts
+++ b/src/layers/GitHubAppLive.ts
@@ -4,6 +4,7 @@ import type { InstallationToken } from "../services/GitHubApp.js";
 import { GitHubApp } from "../services/GitHubApp.js";
 import type { AppAuth } from "../services/OctokitAuthApp.js";
 import { OctokitAuthApp } from "../services/OctokitAuthApp.js";
+import { formatBotIdentity } from "../utils/botIdentity.js";
 
 interface Installation {
 	readonly id: number;
@@ -85,6 +86,41 @@ const generateToken = (
 		catch: (error) => new GitHubAppError({ operation: "token", reason: String(error) }),
 	});
 
+const resolveAppIdentity = (
+	authApp: OctokitAuthApp["Type"],
+	appId: string,
+	privateKey: string,
+): Effect.Effect<{ appSlug: string; appUserId: number; appName: string }, GitHubAppError> =>
+	Effect.tryPromise({
+		try: async () => {
+			const auth = authApp.createAppAuth({ appId, privateKey });
+			const { token: jwt } = await auth({ type: "app" });
+
+			const appResponse = await fetch("https://api.github.com/app", {
+				headers: {
+					Authorization: `Bearer ${jwt}`,
+					Accept: "application/vnd.github+json",
+				},
+			});
+			if (!appResponse.ok) {
+				throw new Error(`GET /app failed: ${appResponse.status}`);
+			}
+			const appData = (await appResponse.json()) as { slug: string; name: string };
+
+			const botLogin = `${appData.slug}[bot]`;
+			const userResponse = await fetch(`https://api.github.com/users/${encodeURIComponent(botLogin)}`, {
+				headers: { Accept: "application/vnd.github+json" },
+			});
+			if (!userResponse.ok) {
+				throw new Error(`GET /users/<slug>[bot] failed: ${userResponse.status}`);
+			}
+			const userData = (await userResponse.json()) as { id: number };
+
+			return { appSlug: appData.slug, appUserId: userData.id, appName: appData.name };
+		},
+		catch: (error) => new GitHubAppError({ operation: "identity", reason: String(error) }),
+	});
+
 const revokeToken = (token: string): Effect.Effect<void, GitHubAppError> =>
 	Effect.tryPromise({
 		try: async () => {
@@ -115,15 +151,11 @@ export const GitHubAppLive: Layer.Layer<GitHubApp, never, OctokitAuthApp> = Laye
 		return {
 			generateToken: (appId, privateKey, installationId) => generateToken(authApp, appId, privateKey, installationId),
 
+			resolveAppIdentity: (appId, privateKey) => resolveAppIdentity(authApp, appId, privateKey),
+
 			revokeToken,
 
-			botIdentity: (appSlug) => {
-				const name = appSlug ? `${appSlug}[bot]` : "github-actions[bot]";
-				const email = appSlug
-					? `${name}@users.noreply.github.com`
-					: "41898282+github-actions[bot]@users.noreply.github.com";
-				return { name, email };
-			},
+			botIdentity: formatBotIdentity,
 
 			withToken: (appId, privateKey, effect) =>
 				Effect.acquireUseRelease(

--- a/src/layers/GitHubAppLive.ts
+++ b/src/layers/GitHubAppLive.ts
@@ -108,8 +108,14 @@ const resolveAppIdentity = (
 			const appData = (await appResponse.json()) as { slug: string; name: string };
 
 			const botLogin = `${appData.slug}[bot]`;
+			// Authenticate the public users lookup with the App JWT: an
+			// unauthenticated request shares the 60 req/hour IP rate limit,
+			// the JWT bumps it to 5000/hour at no extra cost.
 			const userResponse = await fetch(`https://api.github.com/users/${encodeURIComponent(botLogin)}`, {
-				headers: { Accept: "application/vnd.github+json" },
+				headers: {
+					Authorization: `Bearer ${jwt}`,
+					Accept: "application/vnd.github+json",
+				},
 			});
 			if (!userResponse.ok) {
 				throw new Error(`GET /users/<slug>[bot] failed: ${userResponse.status}`);

--- a/src/layers/GitHubAppTest.ts
+++ b/src/layers/GitHubAppTest.ts
@@ -1,6 +1,8 @@
 import { Effect, Layer } from "effect";
+import { GitHubAppError } from "../errors/GitHubAppError.js";
 import type { InstallationToken } from "../services/GitHubApp.js";
 import { GitHubApp } from "../services/GitHubApp.js";
+import { formatBotIdentity } from "../utils/botIdentity.js";
 
 /**
  * Test state for GitHubApp.
@@ -11,6 +13,11 @@ export interface GitHubAppTestState {
 	readonly generateCalls: Array<{ appId: string; privateKey: string; installationId?: number }>;
 	readonly revokeCalls: Array<string>;
 	readonly tokenToReturn: InstallationToken;
+	/**
+	 * Identity returned by `resolveAppIdentity`. When omitted, `resolveAppIdentity`
+	 * fails — exercising `provision`'s best-effort degradation path.
+	 */
+	readonly appIdentity?: { appSlug: string; appUserId: number; appName: string };
 }
 
 const makeTestGitHubApp = (state: GitHubAppTestState): typeof GitHubApp.Service => {
@@ -30,13 +37,17 @@ const makeTestGitHubApp = (state: GitHubAppTestState): typeof GitHubApp.Service 
 				state.revokeCalls.push(token);
 			}),
 
-		botIdentity: (appSlug) => {
-			const name = appSlug ? `${appSlug}[bot]` : "github-actions[bot]";
-			const email = appSlug
-				? `${name}@users.noreply.github.com`
-				: "41898282+github-actions[bot]@users.noreply.github.com";
-			return { name, email };
-		},
+		resolveAppIdentity: (_appId, _privateKey) =>
+			state.appIdentity !== undefined
+				? Effect.succeed(state.appIdentity)
+				: Effect.fail(
+						new GitHubAppError({
+							operation: "identity",
+							reason: "GitHubAppTest: no appIdentity configured in test state",
+						}),
+					),
+
+		botIdentity: formatBotIdentity,
 
 		withToken: (appId, privateKey, effect) =>
 			Effect.flatMap(impl.generateToken(appId, privateKey), (tokenInfo) =>
@@ -68,5 +79,6 @@ export const GitHubAppTest = {
 			installationId: 12345,
 			permissions: {},
 		},
+		appIdentity: { appSlug: "test-app", appUserId: 99999, appName: "Test App" },
 	}),
 } as const;

--- a/src/services/GitHubApp.test.ts
+++ b/src/services/GitHubApp.test.ts
@@ -1,8 +1,8 @@
-import { Data, Effect, Exit } from "effect";
+import { Data, Effect, Exit, Schema } from "effect";
 import { describe, expect, it } from "vitest";
 import { GitHubAppError } from "../errors/GitHubAppError.js";
 import { GitHubAppTest } from "../layers/GitHubAppTest.js";
-import { GitHubApp } from "./GitHubApp.js";
+import { GitHubApp, InstallationToken } from "./GitHubApp.js";
 
 // -- Shared provide helper --
 
@@ -101,17 +101,17 @@ describe("GitHubApp", () => {
 	});
 
 	describe("botIdentity", () => {
-		it("returns bot identity for a custom app slug", async () => {
+		it("returns a verified identity when both appSlug and appUserId are provided", async () => {
 			const state = GitHubAppTest.empty();
 			const result = await run(
 				state,
-				Effect.flatMap(GitHubApp, (svc) => Effect.succeed(svc.botIdentity("my-app"))),
+				Effect.flatMap(GitHubApp, (svc) => Effect.succeed(svc.botIdentity({ appSlug: "my-app", appUserId: 99 }))),
 			);
 			expect(result.name).toBe("my-app[bot]");
-			expect(result.email).toBe("my-app[bot]@users.noreply.github.com");
+			expect(result.email).toBe("99+my-app[bot]@users.noreply.github.com");
 		});
 
-		it("returns default github-actions bot when no slug", async () => {
+		it("returns default github-actions bot when no source is given", async () => {
 			const state = GitHubAppTest.empty();
 			const result = await run(
 				state,
@@ -132,5 +132,38 @@ describe("GitHubApp", () => {
 			expect(error.operation).toBe("token");
 			expect(error.reason).toBe("invalid key");
 		});
+	});
+});
+
+describe("InstallationToken schema", () => {
+	const decode = Schema.decodeUnknownSync(InstallationToken);
+
+	it("retains the optional identity fields when present", () => {
+		const result = decode({
+			token: "ghs_abc",
+			expiresAt: "2099-01-01T00:00:00Z",
+			installationId: 7,
+			appSlug: "acme-bot",
+			appUserId: 123456,
+			appName: "Acme Bot",
+			permissions: { contents: "write" },
+		});
+
+		expect(result.appSlug).toBe("acme-bot");
+		expect(result.appUserId).toBe(123456);
+		expect(result.appName).toBe("Acme Bot");
+	});
+
+	it("decodes a token with no identity fields (backward compatible)", () => {
+		const result = decode({
+			token: "ghs_abc",
+			expiresAt: "2099-01-01T00:00:00Z",
+			installationId: 7,
+		});
+
+		expect(result.appSlug).toBeUndefined();
+		expect(result.appUserId).toBeUndefined();
+		expect(result.appName).toBeUndefined();
+		expect(result.permissions).toEqual({});
 	});
 });

--- a/src/services/GitHubApp.ts
+++ b/src/services/GitHubApp.ts
@@ -21,6 +21,9 @@ export const InstallationToken = Schema.Struct({
 	token: Schema.String,
 	expiresAt: Schema.String,
 	installationId: Schema.Number,
+	appSlug: Schema.optional(Schema.String),
+	appUserId: Schema.optional(Schema.Number),
+	appName: Schema.optional(Schema.String),
 	permissions: Schema.optionalWith(Schema.Record({ key: Schema.String, value: Schema.String }), {
 		default: () => ({}),
 	}),
@@ -52,15 +55,27 @@ export class GitHubApp extends Context.Tag("github-action-effects/GitHubApp")<
 		readonly revokeToken: (token: string) => Effect.Effect<void, GitHubAppError>;
 
 		/**
-		 * Get bot identity for commit attribution from an app slug.
-		 *
-		 * When a custom `appSlug` is provided, the email uses the format
-		 * `appSlug[bot]@users.noreply.github.com` (without a numeric user-ID prefix).
-		 * This may prevent commits from appearing as "verified" on GitHub.
-		 * The default `github-actions[bot]` identity includes the well-known numeric
-		 * ID prefix (`41898282+`) that GitHub recognises for verified attribution.
+		 * Resolve the App's public identity — slug, bot user ID, and name —
+		 * via `GET /app` (App JWT) and `GET /users/<slug>[bot]`.
 		 */
-		readonly botIdentity: (appSlug?: string) => BotIdentity;
+		readonly resolveAppIdentity: (
+			appId: string,
+			privateKey: string,
+		) => Effect.Effect<{ appSlug: string; appUserId: number; appName: string }, GitHubAppError>;
+
+		/**
+		 * Derive a bot identity for commit/tag attribution.
+		 *
+		 * When both `appSlug` and `appUserId` are supplied, returns a verified
+		 * identity whose email carries the numeric user-ID prefix GitHub
+		 * recognises. Otherwise returns the well-known `github-actions[bot]`
+		 * identity. Read the persisted token via `GitHubToken.read()` to obtain
+		 * the resolved `appSlug` / `appUserId`.
+		 */
+		readonly botIdentity: (source?: {
+			readonly appSlug?: string | undefined;
+			readonly appUserId?: number | undefined;
+		}) => BotIdentity;
 
 		/**
 		 * Bracket pattern: generate token, run effect, then revoke.

--- a/src/utils/botIdentity.test.ts
+++ b/src/utils/botIdentity.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { formatBotIdentity } from "./botIdentity.js";
+
+describe("formatBotIdentity", () => {
+	it("returns a verified identity when slug and user ID are both present", () => {
+		expect(formatBotIdentity({ appSlug: "acme-bot", appUserId: 123456 })).toEqual({
+			name: "acme-bot[bot]",
+			email: "123456+acme-bot[bot]@users.noreply.github.com",
+		});
+	});
+
+	it("falls back to github-actions[bot] when no source is given", () => {
+		expect(formatBotIdentity()).toEqual({
+			name: "github-actions[bot]",
+			email: "41898282+github-actions[bot]@users.noreply.github.com",
+		});
+	});
+
+	it("falls back when only the slug is present", () => {
+		expect(formatBotIdentity({ appSlug: "acme-bot" })).toEqual({
+			name: "github-actions[bot]",
+			email: "41898282+github-actions[bot]@users.noreply.github.com",
+		});
+	});
+
+	it("falls back when only the user ID is present", () => {
+		expect(formatBotIdentity({ appUserId: 123456 })).toEqual({
+			name: "github-actions[bot]",
+			email: "41898282+github-actions[bot]@users.noreply.github.com",
+		});
+	});
+});

--- a/src/utils/botIdentity.ts
+++ b/src/utils/botIdentity.ts
@@ -1,0 +1,26 @@
+import type { BotIdentity } from "../services/GitHubApp.js";
+
+/** Source fields for deriving a {@link BotIdentity}. */
+interface BotIdentitySource {
+	readonly appSlug?: string | undefined;
+	readonly appUserId?: number | undefined;
+}
+
+/**
+ * Derive a bot identity for commit/tag attribution.
+ *
+ * When both `appSlug` and `appUserId` are present, returns a verified identity
+ * whose email carries the numeric user-ID prefix GitHub recognises for
+ * verified attribution. Otherwise falls back to the well-known
+ * `github-actions[bot]` identity (with the `41898282+` prefix).
+ */
+export const formatBotIdentity = (source?: BotIdentitySource): BotIdentity => {
+	if (source?.appSlug !== undefined && source.appUserId !== undefined) {
+		const name = `${source.appSlug}[bot]`;
+		return { name, email: `${source.appUserId}+${name}@users.noreply.github.com` };
+	}
+	return {
+		name: "github-actions[bot]",
+		email: "41898282+github-actions[bot]@users.noreply.github.com",
+	};
+};


### PR DESCRIPTION
## Summary

Resolves [#112](https://github.com/savvy-web/github-action-effects/issues/112). `GitHubToken.provision` now resolves and persists the GitHub App's identity (slug, bot user ID, name), and the token lifecycle exposes it for verified commit/tag attribution — closing the gap that left `botIdentity` "half a feature."

- `InstallationToken` gains optional `appSlug` / `appUserId` / `appName` fields.
- New `GitHubApp.resolveAppIdentity(appId, privateKey)` resolves identity via `GET /app` + `GET /users/<slug>[bot]`.
- `GitHubToken.read()` exposes the persisted token; `GitHubToken.botIdentity()` derives a verified `BotIdentity` from it (requires only `ActionState`).
- `provision` resolves identity best-effort — a lookup failure is logged and degrades gracefully rather than failing the action.
- A pure `formatBotIdentity` helper centralises identity formatting across the Live layer, Test layer, and `GitHubToken`.

## Breaking change

`GitHubApp.botIdentity` now takes `{ appSlug?, appUserId? }` instead of a bare slug string, and produces verified (numeric-ID-prefixed) identities when both fields are present. Released as a `minor` bump per the changeset — the maintainer owns all call sites.

## Test plan

- [x] `pnpm run lint` — clean
- [x] `pnpm run typecheck` — clean
- [x] `pnpm run test` — 830 passed
- [x] New tests cover `formatBotIdentity`, `resolveAppIdentity` (success + both fetch-failure paths), the `InstallationToken` schema round-trip, `provision` identity persistence + degradation, and `read`/`botIdentity`.

Signed-off-by: C. Spencer Beggs <spencer@savvyweb.systems>