### PR TITLE
fix(github-app): authenticate GET /users in resolveAppIdentity with installation token

### DIFF
--- a/.changeset/silent-token-fix.md
+++ b/.changeset/silent-token-fix.md
@@ -1,0 +1,7 @@
+---
+"@savvy-web/github-action-effects": patch
+---
+
+## Bug Fixes
+
+Fix `botIdentity()` silently falling back to `github-actions[bot]` when the App's identity could not be resolved. The `/users/{username}` lookup was authenticated with the App JWT, which GitHub rejects on public user endpoints — causing a 401 and a silent fallback. The lookup now uses the installation token, which has the correct permissions. An additional guard prevents a nonsensical `/users/[bot]` request when `GET /app` returns no slug. Consumers that sign commits via the Git Data API will now get the correct author identity (`<appUserId>+<appSlug>[bot]@users.noreply.github.com`) and avoid DCO mismatches.

--- a/.claude/design/github-action-effects/layers.md
+++ b/.claude/design/github-action-effects/layers.md
@@ -3,8 +3,8 @@ status: current
 module: github-action-effects
 category: architecture
 created: 2026-03-06
-updated: 2026-05-15
-last-synced: 2026-05-15
+updated: 2026-05-16
+last-synced: 2026-05-16
 completeness: 95
 related:
   - ./index.md
@@ -284,7 +284,7 @@ of construction mode.
 
 ### GitHubAppLive
 
-`Layer.Layer<GitHubApp, never, OctokitAuthApp>`. Uses `Layer.effect` to yield `OctokitAuthApp` for JWT-based auth. Uses native `fetch` for listing installations, resolving installation IDs from `GITHUB_REPOSITORY` and token revocation. `resolveAppIdentity` makes two requests: `GET /app` with an App JWT to get the slug and name, then `GET /users/<slug>[bot]` to get the bot user ID. The users endpoint is public, but the request is sent with the same App JWT so it draws on the 5000 req/hour authenticated limit rather than the 60 req/hour unauthenticated IP limit. Fails with `GitHubAppError { operation: "identity" }` on any HTTP error. `botIdentity` delegates to `formatBotIdentity` from `src/utils/botIdentity.ts`.
+`Layer.Layer<GitHubApp, never, OctokitAuthApp>`. Uses `Layer.effect` to yield `OctokitAuthApp` for JWT-based auth. Uses native `fetch` for listing installations, resolving installation IDs from `GITHUB_REPOSITORY` and token revocation. `resolveAppIdentity` makes two requests: `GET /app` with an App JWT to get the slug and name, then `GET /users/<slug>[bot]` to get the bot user ID. `GET /users` is a public endpoint that rejects the App JWT with 401; when an `installationToken` is provided it is used as `Bearer` auth (5000 req/hr), otherwise the lookup runs unauthenticated (60 req/hr per IP). Fails with `GitHubAppError { operation: "identity" }` on any HTTP error or when `GET /app` returns no slug (skips the `/users/` lookup in that case). `botIdentity` delegates to `formatBotIdentity` from `src/utils/botIdentity.ts`.
 
 ### OctokitAuthAppLive
 

--- a/.claude/design/github-action-effects/services.md
+++ b/.claude/design/github-action-effects/services.md
@@ -3,8 +3,8 @@ status: current
 module: github-action-effects
 category: architecture
 created: 2026-03-06
-updated: 2026-05-15
-last-synced: 2026-05-15
+updated: 2026-05-16
+last-synced: 2026-05-16
 completeness: 97
 related:
   - ./index.md
@@ -120,7 +120,7 @@ single export, reducing barrel clutter and improving discoverability.
 the GitHub App installation-token lifecycle. See [GitHubToken Lifecycle](#githubtoken-lifecycle)
 below for the full pre/main/post data flow.
 
-- `GitHubToken.provision(options?)` -- `pre.ts`: generate an installation token, best-effort resolve App identity (wrapped in `Effect.option` so a network hiccup degrades gracefully), enrich the token with identity fields, persist it to `ActionState`.
+- `GitHubToken.provision(options?)` -- `pre.ts`: generate an installation token, best-effort resolve App identity by passing the token to `resolveAppIdentity` (so `GET /users` runs authenticated at 5000 req/hr rather than unauthenticated), enrich the token with identity fields, persist it to `ActionState`. Failure of identity resolution is wrapped in `Effect.option` so a network hiccup degrades gracefully.
 - `GitHubToken.client()` -- `main.ts`: build a `GitHubClient` layer from the persisted token.
 - `GitHubToken.dispose()` -- `post.ts`: revoke the persisted token.
 - `GitHubToken.read()` -- `Effect<InstallationToken, ActionStateError, ActionState>`: read the raw persisted token from `ActionState`. Available in any phase after `provision`.
@@ -352,7 +352,7 @@ token revocation.
 
 - `generateToken(appId, privateKey, installationId?)` -- Generate an installation token. Auto-resolves installation ID from `GITHUB_REPOSITORY` if not provided. Returns `InstallationToken` (without identity fields; call `resolveAppIdentity` separately to enrich).
 - `revokeToken(token)` -- Revoke a previously generated token via REST API.
-- `resolveAppIdentity(appId, privateKey)` -- Resolve the App's public identity via `GET /app` (App JWT) then `GET /users/<slug>[bot]` (public). Returns `{ appSlug, appUserId, appName }`. Fails with `GitHubAppError { operation: "identity" }` on HTTP error.
+- `resolveAppIdentity(appId, privateKey, installationToken?)` -- Resolve the App's public identity via `GET /app` (App JWT) then `GET /users/<slug>[bot]`. Returns `{ appSlug, appUserId, appName }`. Fails with `GitHubAppError { operation: "identity" }` on HTTP error or when `GET /app` returns no slug. `GET /users` is a public endpoint that rejects the App JWT; when `installationToken` is supplied it is used as `Bearer` auth (5000 req/hr), otherwise the lookup runs unauthenticated (60 req/hr per IP).
 - `botIdentity(source?)` -- Derive a `BotIdentity` for commit/tag attribution. `source` is `{ appSlug?, appUserId? }`. When both are present returns a verified identity with the numeric-ID email prefix GitHub recognises; otherwise falls back to the well-known `github-actions[bot]` identity. Delegates to `formatBotIdentity` from `src/utils/botIdentity.ts`.
 - `withToken(appId, privateKey, effect)` -- Bracket: generate, run, revoke.
 
@@ -706,7 +706,7 @@ main.ts  GitHubToken.client()     — read envelope, build GitHubClient layer
 post.ts  GitHubToken.dispose()    — read envelope, revoke token via GitHubApp
 ```
 
-- **`provision(options?)`** — `Effect<InstallationToken, GitHubAppError | TokenPermissionError | ActionStateError | ConfigError, ActionState | GitHubApp>`. Credentials are hybrid: `clientId` defaults to the `app-client-id` action input (`Config.string`) and `privateKey` to `app-private-key` (`Config.redacted`); the options object overrides both. Generates the token via `GitHubApp.generateToken`, then calls `GitHubApp.resolveAppIdentity` wrapped in `Effect.option` — a failure degrades to a token without identity fields rather than crashing the action. When `permissions` are given runs `assertSufficient` against the token's own `permissions` (no API call). Persists the enriched envelope and returns it. Strict: fails if no credentials resolve.
+- **`provision(options?)`** — `Effect<InstallationToken, GitHubAppError | TokenPermissionError | ActionStateError | ConfigError, ActionState | GitHubApp>`. Credentials are hybrid: `clientId` defaults to the `app-client-id` action input (`Config.string`) and `privateKey` to `app-private-key` (`Config.redacted`); the options object overrides both. Generates the token via `GitHubApp.generateToken`, then calls `GitHubApp.resolveAppIdentity(clientId, privateKey, token.token)` — passing the freshly-minted installation token as the third argument so the `GET /users` lookup runs authenticated at 5000 req/hr rather than unauthenticated. The call is wrapped in `Effect.option` so a failure degrades to a token without identity fields rather than crashing the action. When `permissions` are given runs `assertSufficient` against the token's own `permissions` (no API call). Persists the enriched envelope and returns it. Strict: fails if no credentials resolve.
 - **`client()`** — `Layer.Layer<GitHubClient, ActionStateError, ActionState>`. Reads the persisted envelope and delegates to `GitHubClientLive.fromToken`. Strict: fails with `ActionStateError` if nothing was provisioned.
 - **`read()`** — `Effect<InstallationToken, ActionStateError, ActionState>`. Reads the persisted envelope from `ActionState`. Available in any phase after `provision`.
 - **`botIdentity()`** — `Effect<BotIdentity, ActionStateError, ActionState>`. Reads the token via `read()` and derives a `BotIdentity` via `formatBotIdentity`. Produces a verified identity (with numeric user-ID email prefix) when `appSlug` and `appUserId` were resolved; falls back to `github-actions[bot]` otherwise.

--- a/docs/03-services.md
+++ b/docs/03-services.md
@@ -422,8 +422,10 @@ const program = Effect.gen(function* () {
   // Revoke it when done
   yield* app.revokeToken(installation.token)
 
-  // Resolve the App's public identity (slug, bot user ID, display name)
-  const identity = yield* app.resolveAppIdentity(clientId, privateKey)
+  // Resolve the App's public identity (slug, bot user ID, display name).
+  // Pass the installation token as the third argument to authenticate the
+  // /users/{slug}[bot] lookup (5000 req/hr); omit it to run unauthenticated (60 req/hr).
+  const identity = yield* app.resolveAppIdentity(clientId, privateKey, installation.token)
   // identity.appSlug, identity.appUserId, identity.appName
 
   // Derive a commit-attribution identity.

--- a/src/GitHubToken.ts
+++ b/src/GitHubToken.ts
@@ -60,7 +60,7 @@ const provision = (
 					// token without identity fields rather than failing the action.
 					// The failure is logged so a misconfigured App surfaces in the
 					// workflow log instead of silently yielding the default identity.
-					const identity = yield* app.resolveAppIdentity(clientId, privateKey).pipe(
+					const identity = yield* app.resolveAppIdentity(clientId, privateKey, token.token).pipe(
 						Effect.tapError((error) =>
 							Effect.logWarning(
 								`App identity resolution failed (${error.reason}); commits will fall back to the github-actions[bot] identity`,

--- a/src/layers/GitHubAppLive.test.ts
+++ b/src/layers/GitHubAppLive.test.ts
@@ -290,7 +290,13 @@ describe("GitHubAppLive", () => {
 	});
 
 	describe("resolveAppIdentity", () => {
-		it("resolves slug, name, and bot user ID", async () => {
+		/** Find the `fetch` call whose URL targets the `/users/` endpoint. */
+		const usersCall = () =>
+			mockFetch.mock.calls.find(([url]) => String(url).includes("/users/")) as
+				| [string, RequestInit | undefined]
+				| undefined;
+
+		it("authenticates GET /app with the App JWT but leaves GET /users unauthenticated when no installation token is given", async () => {
 			// GET /app
 			mockAuth.mockResolvedValueOnce({ token: "jwt_for_app" });
 			mockFetch.mockResolvedValueOnce({
@@ -316,12 +322,50 @@ describe("GitHubAppLive", () => {
 					headers: expect.objectContaining({ Authorization: "Bearer jwt_for_app" }),
 				}),
 			);
-			expect(mockFetch).toHaveBeenCalledWith(
-				"https://api.github.com/users/acme-bot%5Bbot%5D",
-				expect.objectContaining({
-					headers: expect.objectContaining({ Authorization: "Bearer jwt_for_app" }),
-				}),
+			// The App JWT is not a valid credential on the public /users endpoint
+			// (it 401s); with no installation token the lookup must be unauthenticated.
+			const call = usersCall();
+			expect(call?.[0]).toBe("https://api.github.com/users/acme-bot%5Bbot%5D");
+			expect(call?.[1]?.headers ?? {}).not.toHaveProperty("Authorization");
+		});
+
+		it("authenticates GET /users with the installation token when one is provided", async () => {
+			mockAuth.mockResolvedValueOnce({ token: "jwt_for_app" });
+			mockFetch.mockResolvedValueOnce({
+				ok: true,
+				status: 200,
+				json: async () => ({ slug: "acme-bot", name: "Acme Bot" }),
+			});
+			mockFetch.mockResolvedValueOnce({
+				ok: true,
+				status: 200,
+				json: async () => ({ id: 123456 }),
+			});
+
+			const result = await run(
+				Effect.flatMap(GitHubApp, (svc) => svc.resolveAppIdentity("app-1", "pk", "ghs_installation_token")),
 			);
+
+			expect(result).toEqual({ appSlug: "acme-bot", appUserId: 123456, appName: "Acme Bot" });
+			const call = usersCall();
+			expect(call?.[0]).toBe("https://api.github.com/users/acme-bot%5Bbot%5D");
+			expect(call?.[1]?.headers).toMatchObject({ Authorization: "Bearer ghs_installation_token" });
+		});
+
+		it("skips the bot-user lookup and fails when GET /app returns no slug", async () => {
+			mockAuth.mockResolvedValueOnce({ token: "jwt_for_app" });
+			mockFetch.mockResolvedValueOnce({
+				ok: true,
+				status: 200,
+				json: async () => ({ slug: "", name: "Acme Bot" }),
+			});
+
+			const exit = await runExit(Effect.flatMap(GitHubApp, (svc) => svc.resolveAppIdentity("app-1", "pk")));
+
+			expect(Exit.isFailure(exit)).toBe(true);
+			// Only GET /app was attempted — no request to /users/<slug>[bot].
+			expect(mockFetch).toHaveBeenCalledTimes(1);
+			expect(usersCall()).toBeUndefined();
 		});
 
 		it("fails with GitHubAppError when GET /app errors", async () => {
@@ -340,7 +384,7 @@ describe("GitHubAppLive", () => {
 			}
 		});
 
-		it("fails with GitHubAppError when GET /users/<slug>[bot] errors", async () => {
+		it("fails with GitHubAppError naming the resolved bot login when GET /users errors", async () => {
 			mockAuth.mockResolvedValueOnce({ token: "jwt_for_app" });
 			// GET /app succeeds
 			mockFetch.mockResolvedValueOnce({
@@ -359,6 +403,9 @@ describe("GitHubAppLive", () => {
 				if (error._tag === "Some") {
 					expect(error.value).toBeInstanceOf(GitHubAppError);
 					expect((error.value as GitHubAppError).operation).toBe("identity");
+					// The error names the resolved login, not a literal "<slug>" placeholder.
+					expect((error.value as GitHubAppError).reason).toContain("acme-bot[bot]");
+					expect((error.value as GitHubAppError).reason).not.toContain("<slug>");
 				}
 			}
 		});

--- a/src/layers/GitHubAppLive.ts
+++ b/src/layers/GitHubAppLive.ts
@@ -90,6 +90,7 @@ const resolveAppIdentity = (
 	authApp: OctokitAuthApp["Type"],
 	appId: string,
 	privateKey: string,
+	installationToken?: string,
 ): Effect.Effect<{ appSlug: string; appUserId: number; appName: string }, GitHubAppError> =>
 	Effect.tryPromise({
 		try: async () => {
@@ -105,24 +106,32 @@ const resolveAppIdentity = (
 			if (!appResponse.ok) {
 				throw new Error(`GET /app failed: ${appResponse.status}`);
 			}
-			const appData = (await appResponse.json()) as { slug: string; name: string };
+			const appData = (await appResponse.json()) as { slug?: string; name?: string };
+
+			if (!appData.slug) {
+				throw new Error("GET /app returned no slug; cannot resolve the bot user identity");
+			}
 
 			const botLogin = `${appData.slug}[bot]`;
-			// Authenticate the public users lookup with the App JWT: an
-			// unauthenticated request shares the 60 req/hour IP rate limit,
-			// the JWT bumps it to 5000/hour at no extra cost.
+			// `GET /users/{username}` is a public endpoint, but the App JWT is
+			// NOT a valid credential there — only the App-management endpoints
+			// (`/app`, `/app/installations`) accept it, so a JWT-authenticated
+			// request 401s. Authenticate with the installation token when one
+			// is available (5000 req/hour); otherwise fall back to an
+			// unauthenticated request (60 req/hour, shared per runner IP).
+			const userHeaders: Record<string, string> = { Accept: "application/vnd.github+json" };
+			if (installationToken) {
+				userHeaders.Authorization = `Bearer ${installationToken}`;
+			}
 			const userResponse = await fetch(`https://api.github.com/users/${encodeURIComponent(botLogin)}`, {
-				headers: {
-					Authorization: `Bearer ${jwt}`,
-					Accept: "application/vnd.github+json",
-				},
+				headers: userHeaders,
 			});
 			if (!userResponse.ok) {
-				throw new Error(`GET /users/<slug>[bot] failed: ${userResponse.status}`);
+				throw new Error(`GET /users/${botLogin} failed: ${userResponse.status}`);
 			}
 			const userData = (await userResponse.json()) as { id: number };
 
-			return { appSlug: appData.slug, appUserId: userData.id, appName: appData.name };
+			return { appSlug: appData.slug, appUserId: userData.id, appName: appData.name ?? appData.slug };
 		},
 		catch: (error) => new GitHubAppError({ operation: "identity", reason: String(error) }),
 	});
@@ -157,7 +166,8 @@ export const GitHubAppLive: Layer.Layer<GitHubApp, never, OctokitAuthApp> = Laye
 		return {
 			generateToken: (appId, privateKey, installationId) => generateToken(authApp, appId, privateKey, installationId),
 
-			resolveAppIdentity: (appId, privateKey) => resolveAppIdentity(authApp, appId, privateKey),
+			resolveAppIdentity: (appId, privateKey, installationToken) =>
+				resolveAppIdentity(authApp, appId, privateKey, installationToken),
 
 			revokeToken,
 

--- a/src/services/GitHubApp.ts
+++ b/src/services/GitHubApp.ts
@@ -57,10 +57,15 @@ export class GitHubApp extends Context.Tag("github-action-effects/GitHubApp")<
 		/**
 		 * Resolve the App's public identity — slug, bot user ID, and name —
 		 * via `GET /app` (App JWT) and `GET /users/<slug>[bot]`.
+		 *
+		 * `GET /users` is a public endpoint that rejects the App JWT. Pass an
+		 * `installationToken` to authenticate that lookup (5000 req/hour);
+		 * when omitted, the lookup runs unauthenticated (60 req/hour per IP).
 		 */
 		readonly resolveAppIdentity: (
 			appId: string,
 			privateKey: string,
+			installationToken?: string,
 		) => Effect.Effect<{ appSlug: string; appUserId: number; appName: string }, GitHubAppError>;
 
 		/**


### PR DESCRIPTION
## Summary

- **Root cause:** `resolveAppIdentity` authenticated `GET /users/{slug}[bot]` with the App JWT — a credential GitHub only accepts on App-management endpoints. On the public `/users/{username}` endpoint it 401s, causing `provision`'s best-effort identity resolution to always fail and `botIdentity()` to silently fall back to `github-actions[bot]`.
- **Fix:** `resolveAppIdentity` now accepts an optional `installationToken?: string` parameter. `GitHubToken.provision` passes its already-generated installation token through (zero extra network calls, 5000 req/hr). When no token is supplied, the lookup is unauthenticated — the App JWT is explicitly absent, not just wrong.
- **Guard added:** If `GET /app` returns no slug, the function now fails before attempting a `/users/[bot]` lookup instead of issuing a nonsensical request.
- **Error message fixed:** Now interpolates the resolved bot login (`acme-bot[bot]`) instead of the literal `<slug>` placeholder.

**Impact:** `botIdentity()` now returns the App's verified `<appUserId>+<appSlug>[bot]@users.noreply.github.com` identity. Consumers using the Git Data API for commits no longer get a DCO mismatch between commit author and `Signed-off-by` trailer.

Closes #115

## Test plan

- [ ] `pnpm vitest run src/layers/GitHubAppLive.test.ts` — 18 tests, all pass; 3 new tests cover unauthenticated fallback, installation-token auth, and no-slug guard
- [ ] `pnpm vitest run src/GitHubToken.test.ts` — 14 tests pass
- [ ] `pnpm run typecheck` — clean
- [ ] `pnpm run lint` — clean (info only)
- [ ] Full suite: 832 tests pass

Signed-off-by: C. Spencer Beggs <spencer@beg.gs>