### PR TITLE
feat: port the publish chain to Effect with step-buffered logging

### DIFF
--- a/.changeset/upstream-port-publish-chain.md
+++ b/.changeset/upstream-port-publish-chain.md
@@ -1,0 +1,115 @@
+---
+"@savvy-web/github-action-effects": minor
+---
+
+## Features
+
+### New attestation stack — `Attest`, `SigstoreSigner`, `OidcTokenIssuer`, `Sbom`
+
+This branch introduces a complete artifact-attestation toolchain — every service, schema, and helper below is **new** (no equivalent existed on `main`):
+
+- **`Attest` service** — the end-to-end attest/sign/upload surface. `buildStatement` constructs an in-toto Statement v1 from subjects + a typed predicate; `buildBundle` signs it into a Sigstore bundle; `attest` does the full build → sign → `POST /repos/{owner}/{repo}/attestations` round trip and returns an `AttestationRecord` (statement + bundle + attestation id + UI URL); `provenance` and `sbom` are the SLSA-provenance and CycloneDX-SBOM convenience wrappers; `save` writes a statement or bundle to disk for inspection. Live and Test layers (`AttestLive`, `AttestTest`, with `AttestTestFullLayer` / `makeAttestTestState`) ship alongside.
+- **`SigstoreSigner` service** — signs an in-toto statement into a Sigstore v0.3 DSSE bundle via Fulcio + Rekor. Exports `IN_TOTO_PAYLOAD_TYPE`, `SIGSTORE_OIDC_AUDIENCE`, the `SigstoreSignerConfig` knobs (`fulcioBaseURL` / `rekorBaseURL`), and a `makeSigstoreSignerLive` factory. Backed by the new `@sigstore/sign` and `@sigstore/bundle` dependencies.
+- **`OidcTokenIssuer` service** — requests a GitHub Actions OIDC ID token for a given audience (e.g. `"sigstore"` for Fulcio cert issuance), reading `ACTIONS_ID_TOKEN_REQUEST_TOKEN` / `ACTIONS_ID_TOKEN_REQUEST_URL`. `saveToken` is exported for persisting the issued token. This is the `id-token: write` plumbing the signer depends on.
+- **`Sbom` service** — generates a CycloneDX 1.5 BOM from a resolved dependency graph (`generate`), serializes it to canonical JSON (`serializeJson`), and writes it to disk (`save`). Models `ResolvedDependency`, `InFlightPackage` (siblings released in the same wave that the registry can't see yet), `SbomInput`, and re-exports the `CycloneDXBom` model so callers don't depend on `@cyclonedx/cyclonedx-library` directly. Backed by the new `@cyclonedx/cyclonedx-library` dependency.
+
+Supporting public surface, also new:
+
+- **`Attestation` schema cluster** (`src/schemas/Attestation.ts`) — `InTotoStatement`, `InTotoSubject`, `SigstoreBundle`, the `AttestInput` / `AttestationRecord` shapes, and the predicate-type / media-type constants `IN_TOTO_STATEMENT_V1`, `SLSA_PROVENANCE_V1`, `CYCLONEDX_BOM`, `SPDX_V2_3`, `SIGSTORE_BUNDLE_V0_3_MEDIA_TYPE`.
+- **`intoto` helpers** (`src/utils/intoto.ts`) — pure, Effect-free constructors `buildStatement`, `subject`, `serializeStatement`, and the `npmPurl` PURL helper, for building and inspecting statements without the service plumbing.
+- **`slsa` helpers** (`src/utils/slsa.ts`) — `decodeJwtClaims` (extract OIDC claims from a runner-issued JWT without re-verifying) and `buildSLSAProvenancePredicate` (assemble a SLSA Provenance v1 predicate matching `@actions/attest`'s shape), plus the `GITHUB_BUILD_TYPE` constant and `OidcClaims` type.
+- **New error types** — `AttestError`, `SigstoreSignerError`, `OidcTokenError`, `SbomError`, and `SlsaError`.
+
+### New `GitHubContent`, `GitHubCommit`, and `GitHubArtifactMetadata` services
+
+Three new REST-backed services (all new files vs `main`), each with Live and Test layers:
+
+- **`GitHubContent`** — `getFile(path, ref?)` reads a repository file's decoded UTF-8 contents at a ref (default branch when `ref` omitted); fails with `GitHubContentError` when the path is not a file.
+- **`GitHubCommit`** — reads the GitHub commit graph (distinct from the local-`git` `GitCommit` service): `get(ref)`, `list(ref)`, and `compare(base, head)`, modeling `CommitSummary` / `CommitDetail` / `CommitFile` / `CommitComparison`. Fails with the new `GitHubCommitError`.
+- **`GitHubArtifactMetadata`** — `createStorageRecord(input)` writes a GitHub Packages artifact-metadata storage record (the `StorageRecordInput` shape: purl, digest, version, registry/artifact URLs) linking an attestation to a published artifact. Fails with the new `GitHubArtifactMetadataError`.
+
+### New `RegistryClassifier` utility namespace
+
+`src/utils/RegistryClassifier.ts` exports URL-safe registry classification: `getRegistryType`, `getRegistryDisplayName`, `generatePackageViewUrl`, the `isNpmRegistry` / `isGitHubPackagesRegistry` / `isJsrRegistry` / `isCustomRegistry` predicates, and the `RegistryType` type. All functions parse the URL and check the hostname (exact or subdomain match) rather than substring-matching, closing the CWE-20 spoofing vector (`http://evil-npmjs.org`, `http://npmjs.org.evil.com`).
+
+### New `Step` module — step-buffered logging primitive
+
+A new top-level `Step` namespace exports `withStep`, `success`, `collapse`, and `groupStep` for orchestrators that want one summary line per logical step with detail buffered for error spills. Behaviour summary:
+
+- `Step.withStep(name, effect)` opens a fresh debug buffer for the step, runs the effect, emits `✅ <name>: <line>` on success (line set via `Step.success`), or `❌ <name>: <error>` + the spilled debug buffer on failure. Original error propagates untouched.
+- `Step.collapse(steps, reducer)` runs N steps in parallel; all-success → one collapsed info line; any failure or `null`-from-reducer → fall back to per-step nested lines.
+- `Step.groupStep(name, effect)` wraps `withStep` inside `ActionLogger.group` — the right shape for phase-level entry points.
+
+Inside a `withStep` envelope, `Effect.logDebug` and `Effect.logInfo` are buffered; only the success line emits live on the happy path. Warnings and errors pass through (they map to GitHub Actions annotations). Outside a step, the existing logger semantics are unchanged.
+
+### `Attest.listForSubject` for idempotent attestation reuse
+
+Part of the new `Attest` service (above). Probes `GET /repos/{owner}/{repo}/attestations/sha256:{hex}` for existing attestations on a tarball digest, parses each bundle's in-toto statement to extract the predicate type, and returns the matching attestation URLs. Empty list on 404. Lets the orchestrator skip re-writing attestations on a recovery run where the tarball already has them.
+
+### `Attest.sbom` accepts a pre-built BOM document
+
+The new `Attest` service's `sbom` method's options carry a `bomDocument` field. Pass a parsed CycloneDX BOM and the library attests it verbatim, replacing the prior dependency-array path that produced a sparse BOM with no components. The dependency-array path still works for callers that have not migrated.
+
+### `PackagePublish` redesign for the self-recovering publish chain
+
+- `pack` now returns `{ tarballPath, digest, sha256Hex, name, version, packedSize, unpackedSize, fileCount }`. `digest` is the npm `sha512-<base64>` integrity format (matches `dist.integrity`); `sha256Hex` is the lowercase hex sha256 of the tarball file (the format the GitHub artifact-metadata and attestation APIs accept). The two are produced from the same on-disk tarball and are not interchangeable.
+- New `publishTarball(tarballPath, options)` method publishes a pre-packed tarball to a specific registry. Lets the orchestrator pack once per build directory and publish the identical bytes to N registries without a second pack.
+- New `packageManager` option on `publish` and `publishIdempotent.options` dispatches `npm publish` through the active manager's executor (`pnpm dlx npm`, `yarn npm`, `bun x npm`, or bare `npm`). The non-default dispatchers fetch a fresh npm 11.5.1+ rather than the runner's bundled npm 10.x — critical for npm trusted publishing's OIDC token exchange.
+- `npm publish` invocations now always include `--loglevel verbose` and stream to the runner log via `runner.exec({ streaming: true })`. The verbose flag surfaces the OIDC token-exchange request that would otherwise be invisible on failure.
+- `publishIdempotent` is now deprecated. Its fused probe-then-publish logic hardcoded the default registry and could not recover from a partial publish across multiple registries. New callers should compose `pack` + `NpmRegistry.getPublishedIntegrity` + `publishTarball` themselves.
+
+### `NpmRegistry` per-target probe
+
+- `getVersions(pkg, options?)` and `getPackageInfo(pkg, version?, options?)` accept an optional `{ registry }` override; appends `--registry <url>` to the `npm view` invocation. The prior signatures keep working with no override (default registry).
+- New `getPublishedIntegrity(packageName, version, { registry })` method. Returns `Option.some(digest)` when the version is present with `dist.integrity`, `Option.none()` on E404 ("not published"). The single decision primitive for the self-recovering publish flow.
+
+### `Sbom` service supplier and author metadata
+
+On the new `Sbom` service (above), `Sbom.generate` accepts optional `supplier` and `authors` fields. Threaded onto the emitted BOM's `metadata.supplier` and `metadata.authors`, satisfying NTIA minimum-elements compliance for a caller that supplies the template.
+
+### Existing GitHub services gained methods and fields
+
+Additive only — every existing signature still type-checks:
+
+- **`GitHubIssue`** — new `get(issueNumber)` returning `IssueData`; `IssueData` gained optional `htmlUrl` and `nodeId`.
+- **`CheckRun`** — new `get(checkRunId)` and a new `CheckRunData` shape (`id` / `name` / `status` / `conclusion` / `htmlUrl`). `create` now resolves to `CheckRunData` rather than a bare check-run id, so callers get the full record without a follow-up `get`.
+- **`GitHubRelease`** — new `updateRelease(releaseId, options)` (returns the updated `ReleaseData`) and `listReleaseAssets(releaseId)`.
+- **`PullRequest`** — new `listFiles(number)` and `listAssociatedWithCommit(sha)`, plus a new `PullRequestFile` shape. `PullRequestInfo` gained optional `mergedAt`, `body`, `mergeCommitSha`, and `baseSha` fields.
+
+### `PackagePublishError` carries the source error
+
+`PackagePublishError` gained an optional `cause` field holding the underlying error (e.g. the `CommandRunnerError` from a failed `npm` invocation, with its `stderr` / `exitCode` / `args`), and its `operation` union grew `publishTarball`, `publishIdempotent`, and `dryRun` to match the redesigned service. The `message` getter (see below) reads `cause` to append the command output.
+
+## Bug Fixes
+
+### `GitTag` resolves annotated tags to commit SHAs
+
+`GitTag.list` switched from `git.listMatchingRefs` to `repos.listTags` to surface annotated tags consistently. `GitTag.resolve` now peels through annotated-tag indirections up to `MAX_TAG_PEEL` hops; exhausting the peel loop yields a typed `GitTagError` instead of returning a tag-object SHA where a commit SHA was expected.
+
+### Stderr-tail truncation in error messages
+
+`CommandRunnerError.message` and `PackagePublishError.message` now show the LAST 2000 characters of stderr when truncated, with a `...[N chars truncated from head]...` marker. The prior head-truncation hid the actual `npm error` lines (which sit at the END of stderr after the warnings and notice block) behind the noise. `CommandRunnerError` also gained an optional `stdout` field — populated on non-zero exit — so the formatter can fall back to stdout when stderr is empty (some CLIs route error context there).
+
+### `NpmRegistryError.message` and `PackagePublishError.message` getters
+
+`Data.TaggedError` does not synthesise a `message` getter from its fields. Without it, callers that caught these errors into a generic `{ error: e.message }` shape saw empty strings — the publish orchestrator's "integrity probe failed" line read "failed —" with nothing after the dash. Both classes now produce a useful `[<operation>] <pkg-or-cmd>: <reason>` message string.
+
+### `PackagePublish.dryRun` parses both npm output shapes
+
+`npm publish --dry-run --json` emits a single JSON object; the prior `dryRun` implementation parsed only the array form. Now tolerates both, so dry-run packed/unpacked sizes and file counts populate correctly.
+
+### Octokit deprecation-warning suppression
+
+The `@octokit/plugin-request-log` plugin emits a `POST /repos/... - 422 ...` line to stdout on every non-2xx HTTP response, bypassing the Effect logger. A custom `log` object on the Octokit constructor now routes these through `WorkflowCommand.issue("debug", ...)`, so idempotent-recovery 422s (existing tag, existing release) no longer leak past `Step.withStep`'s buffer. The structured `GitHubClientError` still carries the full context on real failures.
+
+The newer `predicate_type` query parameter on `GET /repos/.../attestations/{digest}` is deprecated as of 2026-03-10 (removal 2028-03-10). `Attest.listForSubject` no longer sends it — the library already re-filters client-side on the parsed in-toto `predicateType` for an authoritative match, so the server-side query was redundant.
+
+## Maintenance
+
+### New runtime dependencies for the attestation stack
+
+The attestation toolchain adds three direct dependencies: `@sigstore/sign` and `@sigstore/bundle` (Sigstore DSSE bundle construction, used by `SigstoreSigner`) and `@cyclonedx/cyclonedx-library` (CycloneDX BOM model + JSON serialization, used by `Sbom`). All are pure-ESM and carry no `@actions/*` transitive dependencies, preserving the zero-CJS posture.
+
+### `Action.run` and test-runtime cast adjustments
+
+Pre-existing `tsgo` strict-mode errors at the `Effect.runPromise` seam are pinned with explicit `as Effect.Effect<A, E, never>` casts at the run boundary. The casts are safe because `ActionsRuntime.Default` resolves every transitive context requirement; the casts are needed because `tsgo` does not always narrow `Effect.provide`'s requires-channel to `never` through layer composition.

--- a/.claude/design/github-action-effects/errors-and-schemas.md
+++ b/.claude/design/github-action-effects/errors-and-schemas.md
@@ -3,8 +3,8 @@ status: current
 module: github-action-effects
 category: architecture
 created: 2026-03-06
-updated: 2026-05-15
-last-synced: 2026-05-15
+updated: 2026-05-20
+last-synced: 2026-05-20
 completeness: 95
 related:
   - ./index.md
@@ -46,18 +46,20 @@ No separate `Base` export is needed.
 
 ### Error Types
 
-| Error | Service | Key Fields |
+See `src/errors/` for all tagged error definitions. Key types:
+
+| Error | Service | Notes |
 | --- | --- | --- |
 | `ActionInputError` | (Config validation) | input name, raw value, schema validation issues |
 | `ActionOutputError` | ActionOutputs | output name, reason |
 | `ActionStateError` | ActionState | key name, reason, optional raw value |
 | `ActionEnvironmentError` | ActionEnvironment | variable name, reason |
-| `ActionCacheError` | ActionCache | key, operation (save/restore), reason |
+| `ActionCacheError` | ActionCache | key, operation, reason |
 | `RuntimeEnvironmentError` | RuntimeFile | variable name, message |
-| `CommandRunnerError` | CommandRunner | command, args, exitCode, stderr, reason |
+| `CommandRunnerError` | CommandRunner | command, exitCode, reason; surfaces tail of long stderr for diagnostics |
 | `ConfigLoaderError` | ConfigLoader | path, operation, reason |
 | `ChangesetError` | ChangesetAnalyzer | operation, reason |
-| `GitHubClientError` | GitHubClient | operation, status (HTTP), reason, retryable (boolean) |
+| `GitHubClientError` | GitHubClient | operation, status (HTTP), reason, retryable |
 | `GitHubGraphQLError` | GitHubGraphQL | operation, reason, errors array |
 | `GitHubAppError` | GitHubApp | operation (`"jwt"` \| `"token"` \| `"revoke"` \| `"identity"`), reason |
 | `GitBranchError` | GitBranch | operation, name, reason |
@@ -70,13 +72,20 @@ No separate `Base` export is needed.
 | `PullRequestError` | PullRequest | operation, prNumber (optional), reason |
 | `RateLimitError` | RateLimiter | reason |
 | `WorkflowDispatchError` | WorkflowDispatch | operation, workflow, reason |
-| `NpmRegistryError` | NpmRegistry | pkg, operation, reason |
-| `PackagePublishError` | PackagePublish | operation, pkg, registry, reason |
+| `NpmRegistryError` | NpmRegistry | pkg, operation, reason; carries a `message` getter |
+| `PackagePublishError` | PackagePublish | operation, pkg, registry, reason; carries `message` getter, source `cause`, and stderr tail |
 | `PackageManagerError` | PackageManagerAdapter | operation, reason |
 | `WorkspaceDetectorError` | WorkspaceDetector | operation, reason |
 | `ToolInstallerError` | ToolInstaller | operation, tool, version, reason |
 | `TokenPermissionError` | TokenPermissionChecker | missing permissions array |
 | `SemverResolverError` | SemverResolver | operation, version, reason |
+| `GitHubContentError` | GitHubContent | path, ref, reason |
+| `GitHubCommitError` | GitHubCommit | ref, operation, reason |
+| `GitHubArtifactMetadataError` | GitHubArtifactMetadata | operation, reason |
+| `AttestError` | Attest | operation, reason |
+| `OidcTokenError` | OidcTokenIssuer | audience, reason |
+| `SigstoreSignerError` | SigstoreSigner | reason |
+| `SbomError` | Sbom | operation, reason |
 
 ### RuntimeEnvironmentError
 
@@ -101,9 +110,14 @@ to their own domain-specific error type:
 - `WorkflowDispatchError` wraps with dispatch-specific context
 - `RateLimitError` wraps with rate-limit context
 - `PullRequestError` wraps with PR-specific context
+- `GitHubContentError` wraps with content-fetch context
+- `GitHubCommitError` wraps with commit-graph context
+- `GitHubArtifactMetadataError` wraps with artifact-metadata context
+- `AttestError` wraps with attestation context
 
-The `retryable` flag on `GitHubClientError` is `true` for 429 (rate limit)
-and 5xx status codes, enabling consumers to implement retry logic.
+The `retryable` flag on `GitHubClientError` is `true` for 429 (rate limit) and 5xx status codes, enabling consumers to implement retry logic.
+
+`NpmRegistryError` and `PackagePublishError` both carry a `message` getter so caught errors remain readable at the surface (e.g. in `console.error` or workflow command output) without forcing callers to destructure the tagged error. `PackagePublishError` also carries the source error as `cause` and surfaces the tail of long stderr output to aid diagnostics in CI logs. HTTP errors from `OidcTokenIssuerLive` route through `Effect.logDebug` so they appear in the step's debug buffer (visible on failure) rather than cluttering the success log.
 
 ---
 
@@ -120,20 +134,40 @@ TypeScript interfaces exported from service files:
 | --- | --- | --- |
 | `AppAuth` | `services/OctokitAuthApp.ts` | Callable auth function for app/installation tokens |
 | `BotIdentity` | `services/GitHubApp.ts` | Bot identity for commit attribution (`name`, `email`) |
-| `PullRequestInfo` | `services/PullRequest.ts` | PR data (number, url, nodeId, title, state, head, base, draft, merged) |
+| `PullRequestInfo` | `services/PullRequest.ts` | PR data (number, url, nodeId, title, state, head, base, draft, merged, mergedAt?, body?, mergeCommitSha?, baseSha?) |
 | `PullRequestListOptions` | `services/PullRequest.ts` | PR list filter options |
+| `PullRequestFile` | `services/PullRequest.ts` | File changed in a PR (filename, status) |
 | `ExecOptions` | `services/CommandRunner.ts` | Command execution options (cwd, env, timeout) |
 | `ExecOutput` | `services/CommandRunner.ts` | Command execution result (exitCode, stdout, stderr) |
 | `CommentRecord` | `services/PullRequestComment.ts` | PR comment data (id, body) |
-| `IssueData` | `services/GitHubIssue.ts` | Issue data (number, title, state, labels) |
+| `IssueData` | `services/GitHubIssue.ts` | Issue data (number, title, state, labels, htmlUrl?, nodeId?) |
 | `ReleaseData` | `services/GitHubRelease.ts` | Release data |
 | `ReleaseAsset` | `services/GitHubRelease.ts` | Release asset data |
 | `TagRef` | `services/GitTag.ts` | Tag reference (tag, sha) |
-| `PackResult` | `services/PackagePublish.ts` | Pack result (tarball, digest) |
+| `PackResult` | `services/PackagePublish.ts` | Pack result: tarballPath, digest (sha512-base64 integrity), sha256Hex (hex SHA-256 for attestation), name, version, packedSize, unpackedSize, fileCount |
 | `RegistryTarget` | `services/PackagePublish.ts` | Registry publishing target |
+| `IdempotentPublishInput` | `services/PackagePublish.ts` | Input for publishIdempotent |
+| `IdempotentPublishResult` | `services/PackagePublish.ts` | Outcome of publishIdempotent (published or skipped) |
+| `DryRunResult` | `services/PackagePublish.ts` | Result of npm publish --dry-run |
 | `InstallOptions` | `services/PackageManagerAdapter.ts` | PM install options |
 | `PollOptions` | `services/WorkflowDispatch.ts` | Workflow dispatch poll options |
 | `WorkflowRunStatus` | `services/WorkflowDispatch.ts` | Workflow run status |
+| `CheckRunData` | `services/CheckRun.ts` | Check run record returned from create/get (id, name, status, conclusion, htmlUrl) |
+| `CommitSummary` | `services/GitHubCommit.ts` | Commit summary (sha, message, author) |
+| `CommitDetail` | `services/GitHubCommit.ts` | Commit with parent SHAs |
+| `CommitFile` | `services/GitHubCommit.ts` | File changed between commits (filename, status) |
+| `CommitComparison` | `services/GitHubCommit.ts` | Compare result (commits, files) |
+| `StorageRecordInput` | `services/GitHubArtifactMetadata.ts` | Input for createStorageRecord |
+| `AttestationListEntry` | `services/Attest.ts` | Entry from listForSubject (attestationUrl, predicateType) |
+| `SbomAttestationInput` | `services/Attest.ts` | Input for Attest.sbom; accepts dependencies or pre-built bomDocument |
+| `ProvenanceAttestationInput` | `services/Attest.ts` | Input for Attest.provenance |
+| `ResolvedDependency` | `services/Sbom.ts` | Dependency for SBOM generation |
+| `InFlightPackage` | `services/Sbom.ts` | In-flight workspace package for SBOM generation |
+| `SbomSupplier` | `services/Sbom.ts` | NTIA supplier metadata |
+| `SbomAuthor` | `services/Sbom.ts` | NTIA author-of-SBOM-data metadata |
+| `SbomContact` | `services/Sbom.ts` | Supplier/author contact info |
+| `SbomInput` | `services/Sbom.ts` | Input for Sbom.generate |
+| `SigstoreSignerConfig` | `services/SigstoreSigner.ts` | Fulcio/Rekor URL overrides |
 
 ### Action Run Interfaces
 
@@ -174,6 +208,11 @@ TypeScript interfaces exported from service files:
 | `WorkspaceInfo` | `schemas/Workspace.ts` | Detected workspace metadata |
 | `WorkspacePackage` | `schemas/Workspace.ts` | Individual workspace package |
 | `InstallationToken` | `services/GitHubApp.ts` | GitHub App installation token (Schema.Struct). Required fields: `token`, `expiresAt`, `installationId`. Optional identity fields: `appSlug`, `appUserId`, `appName` — populated by `GitHubToken.provision` when `resolveAppIdentity` succeeds. |
+| `InTotoSubject` | `schemas/Attestation.ts` | Subject of an in-toto statement: `name` (PURL) + `digest` (algorithm → hex map) |
+| `InTotoStatement` | `schemas/Attestation.ts` | In-toto Statement v1: `_type`, `subject[]`, `predicateType`, `predicate` (unknown) |
+| `SigstoreBundle` | `schemas/Attestation.ts` | Sigstore bundle v0.3 wire format: `mediaType`, `verificationMaterial`, `dsseEnvelope` (both unknown) |
+| `AttestInput` | `schemas/Attestation.ts` | Input for Attest.buildStatement: `subjects`, `predicateType`, `predicate` |
+| `AttestationRecord` | `schemas/Attestation.ts` | Full attestation result: `statement`, `bundle`, `attestationId`, `attestationUrl` |
 
 ### Shared Decode Helpers
 
@@ -298,14 +337,35 @@ TokenPermissionChecker.assertSufficient(requirements)
   -> fails with TokenPermissionError if missing permissions
 ```
 
+### Attestation Flow
+
+```text
+Attest.attest(input)
+  -> buildStatement(input)           — pure; assembles InTotoStatement
+  -> SigstoreSigner.signStatement()  — fetches OIDC token (audience: "sigstore")
+                                       via OidcTokenIssuer, signs through Fulcio,
+                                       witnesses on Rekor, returns SigstoreBundle
+  -> POST /repos/{owner}/{repo}/attestations
+  -> returns AttestationRecord (statement + bundle + id + url)
+
+Attest.sbom(input)
+  -> if bomDocument provided: use as predicate verbatim
+  -> else: Sbom.generate(input) -> CycloneDXBom -> Sbom.serializeJson() -> predicate
+  -> Attest.attest({ subjects, predicateType: CYCLONEDX_BOM, predicate })
+
+Attest.listForSubject(sha256Hex, options?)
+  -> GET /repos/{owner}/{repo}/attestations/sha256:{hex}
+  -> 404 -> return []
+  -> parse each bundle's dsseEnvelope to extract predicateType
+  -> client-side filter by options.predicateType if provided
+  -> returns Array<AttestationListEntry>
+```
+
 ---
 
 ## Current State
 
-All 29 error types and 25+ schemas are fully defined and in use across the
-service catalog. The error hierarchy with domain-specific wrapping of
-`GitHubClientError` is stable. `RuntimeEnvironmentError` is new, used by
-the runtime layer for missing environment variables.
+All error types and schemas are fully defined and in use across the service catalog. The error hierarchy with domain-specific wrapping of `GitHubClientError` is stable. The attestation cluster added `AttestError`, `OidcTokenError`, `SigstoreSignerError` and `SbomError` plus the `schemas/Attestation.ts` cluster (`InTotoSubject`, `InTotoStatement`, `SigstoreBundle`, predicate-type URI constants). `NpmRegistryError` and `PackagePublishError` gained `message` getters for readable error surfaces. `CommandRunnerError` and `PackagePublishError` surface stderr tails. `PackResult` gained `sha256Hex` for attestation API compatibility. `IssueData` gained `htmlUrl` and `nodeId`. `PullRequestInfo` gained `mergedAt`, `body`, `mergeCommitSha` and `baseSha`. `CheckRunData` is now returned from `CheckRun.create` (was just a number).
 
 ## Rationale
 

--- a/.claude/design/github-action-effects/index.md
+++ b/.claude/design/github-action-effects/index.md
@@ -3,8 +3,8 @@ status: current
 module: github-action-effects
 category: architecture
 created: 2026-03-06
-updated: 2026-05-15
-last-synced: 2026-05-15
+updated: 2026-05-20
+last-synced: 2026-05-20
 completeness: 95
 related:
   - ./services.md
@@ -34,10 +34,10 @@ Effect primitives and the GitHub Actions runtime protocol.
 
 ## Current State
 
-The library provides 29 Effect service interfaces plus 6 namespace/utility
+The library provides 37 Effect service interfaces plus 6 namespace/utility
 objects spanning core action I/O, GitHub API integration, git operations,
-build tooling, and a runtime layer that implements the GitHub Actions protocol
-natively (no `@actions/*` packages).
+build tooling, attestation, and a runtime layer that implements the GitHub
+Actions protocol natively (no `@actions/*` packages).
 
 ## Overview
 
@@ -49,19 +49,21 @@ building blocks.
 
 ### Scope
 
-The library provides 29 service interfaces, 6 utility namespaces, 29 error
-types, and 11 schema modules. Services cover five domains:
+The library provides 37 service interfaces, 6 utility namespaces, and a growing
+error and schema catalog. Services cover six domains:
 
 - **Core action I/O** -- outputs, state, logging, environment, cache
 - **Git operations** -- branches, commits, tags via Git Data API
 - **GitHub API** -- REST client, GraphQL, releases, issues, PR lifecycle, PR
-  comments, check runs, workflow dispatch, app auth, rate limiting
+  comments, check runs, workflow dispatch, app auth, rate limiting, content
+  reading, commit graph, artifact metadata
 - **Build tooling** -- command execution, npm registry, package publishing,
   workspace detection, package manager adaptation, tool installation, changeset
   analysis, config loading
+- **Attestation** -- in-toto/SLSA statement construction, Sigstore signing, CycloneDX SBOM generation, full attest-and-upload workflow
 - **Runtime layer** -- native implementations of the GitHub Actions workflow
   command protocol, environment file appending, ConfigProvider for `INPUT_*`
-  variables, and Effect Logger integration
+  variables, Effect Logger integration, and the Step buffered-logging primitive
 
 ### Problem Statement
 
@@ -113,6 +115,9 @@ Actions runtime protocol, replacing all `@actions/*` packages:
 - **`ActionsRuntime.Default`** -- Single convenience Layer wiring everything
   together: ConfigProvider, Logger, ActionLogger, ActionOutputs, ActionState,
   ActionEnvironment, and NodeFileSystem.
+- **`Step`** -- Step-buffered logging primitive. `Step.withStep(name, effect)` opens a per-step debug buffer, emits one `✅ <name>: <line>` info line on success (discarding the buffer) and spills the buffer as `│ [DEBUG]` / `│ [INFO]` lines under a `❌ <name>: <error>` header on failure. Nested calls track depth via a fiber-local stack (`StepStack`). Warnings and errors always pass through to GitHub Actions workflow commands — buffering only applies to debug and info. `Step.success(line)` sets the custom success summary for the current step. `Step.collapse(steps, reducer)` runs N steps in parallel; if the reducer returns a string, one collapsed line is emitted instead of N per-step lines. `Step.groupStep(name, effect)` wraps an effect in both `ActionLogger.group` and `withStep`.
+
+The Step buffering logger replaces all pre-installed loggers (including `ActionsLogger`) for the duration of a step via `Effect.locally(FiberRef.currentLoggers, ...)` so debug lines are not double-printed.
 
 Consumer pattern:
 

--- a/.claude/design/github-action-effects/integration-points.md
+++ b/.claude/design/github-action-effects/integration-points.md
@@ -3,8 +3,8 @@ status: current
 module: github-action-effects
 category: architecture
 created: 2026-03-06
-updated: 2026-05-15
-last-synced: 2026-05-15
+updated: 2026-05-20
+last-synced: 2026-05-20
 completeness: 95
 related:
   - ./index.md
@@ -46,6 +46,8 @@ PackagePublish) depend on `FileSystem` from `@effect/platform`.
 | `@octokit/rest` | GitHub REST + GraphQL API client | `GitHubClientLive` |
 | `@octokit/auth-app` | GitHub App JWT authentication | `OctokitAuthAppLive` |
 | `@azure/storage-blob` | Azure Blob Storage upload/download for cache | `ActionCacheLive` |
+| `@sigstore/sign` | Sigstore DSSE signing (Fulcio + Rekor) | `SigstoreSignerLive` |
+| `@cyclonedx/cyclonedx-library` | CycloneDX 1.5 BOM model + JSON serialization | `SbomLive` |
 | `jsonc-effect` | JSONC parsing with Effect | `ConfigLoaderLive` |
 | `semver-effect` | Semver operations with Effect | `SemverResolver` |
 | `yaml-effect` | YAML parsing with Effect | `ConfigLoaderLive` |

--- a/.claude/design/github-action-effects/layers.md
+++ b/.claude/design/github-action-effects/layers.md
@@ -3,8 +3,8 @@ status: current
 module: github-action-effects
 category: architecture
 created: 2026-03-06
-updated: 2026-05-16
-last-synced: 2026-05-16
+updated: 2026-05-20
+last-synced: 2026-05-20
 completeness: 95
 related:
   - ./index.md
@@ -29,9 +29,11 @@ This document describes the layer architecture for all services. Each domain
 service has a `Live` layer and a `Test` layer backed by in-memory state for
 unit testing. All `@actions/*` packages have been removed. The runtime layer
 (`src/runtime/`) provides native implementations of the GitHub Actions
-protocol. Three Live layers import external packages directly:
+protocol. Four Live layers import external packages directly:
 `GitHubClientLive` imports `@octokit/rest`, `OctokitAuthAppLive` imports
-`@octokit/auth-app`, and `ActionCacheLive` imports `@azure/storage-blob`.
+`@octokit/auth-app`, `ActionCacheLive` imports `@azure/storage-blob`, and
+`SigstoreSignerLive` imports `@sigstore/sign`. `SbomLive` imports
+`@cyclonedx/cyclonedx-library`.
 
 ---
 
@@ -46,6 +48,10 @@ Runtime Layer (src/runtime/ — replaces @actions/*):
   ActionsRuntime.Default   — Layer.mergeAll of ConfigProvider, Logger,
                              ActionLoggerLive, ActionOutputsLive, ActionStateLive,
                              ActionEnvironmentLive, NodeFileSystem.layer
+  Step (module, not a Layer) — withStep/success/collapse/groupStep; fiber-local
+                             StepStack FiberRef tracks depth; installs a per-step
+                             buffering logger via Effect.locally that replaces all
+                             pre-installed loggers for that scope
 
 Core Action I/O:
   ActionLoggerLive         — Layer.succeed; uses WorkflowCommand for group markers,
@@ -70,7 +76,7 @@ Core Action I/O:
                              (absolute-names) to preserve absolute paths. Windows
                              extract uses -k to skip locked files.
                              Uses @azure/storage-blob for Azure Blob upload/download.
-  ActionCacheTest           — in-memory Map for cache simulation (always-miss when empty)
+  ActionCacheTest          — in-memory Map for cache simulation (always-miss when empty)
 
 Git Operations:
   GitBranchLive            — Layer.effect depending on GitHubClient
@@ -106,13 +112,12 @@ GitHub API:
                              .empty(), absent field causes controlled failure)
 
   OctokitAuthAppLive       — Layer.succeed; imports @octokit/auth-app directly
-                             (one of only two layers importing external packages)
 
   CheckRunLive             — Layer.effect depending on GitHubClient; caps annotations at 50
   CheckRunTest             — in-memory CheckRunRecord array; resets ID counter on .empty()
 
   PullRequestLive          — Layer.effect depending on GitHubClient + GitHubGraphQL
-  PullRequestTest          — in-memory PR state with CRUD, merge, labels, reviewers
+  PullRequestTest          — in-memory PR state with CRUD, merge, labels, reviewers, files
 
   PullRequestCommentLive   — Layer.effect depending on GitHubClient; uses Issues API
   PullRequestCommentTest   — in-memory Map<prNumber, comments[]>; instance-scoped nextId
@@ -123,15 +128,30 @@ GitHub API:
   WorkflowDispatchLive     — Layer.effect depending on GitHubClient
   WorkflowDispatchTest     — in-memory dispatch records
 
+  GitHubContentLive        — Layer.effect depending on GitHubClient
+  GitHubContentTest        — in-memory file map
+
+  GitHubCommitLive         — Layer.effect depending on GitHubClient
+  GitHubCommitTest         — in-memory commit/compare state
+
+  GitHubArtifactMetadataLive — Layer.effect depending on GitHubClient
+  GitHubArtifactMetadataTest — in-memory record state
+
 Build Tooling:
   CommandRunnerLive        — Layer.succeed; uses node:child_process spawn directly.
-                             No service dependencies.
+                             No service dependencies. Surfaces tail of long stderr in
+                             CommandRunnerError for diagnostics.
   CommandRunnerTest        — Map<string, { exitCode, stdout, stderr }> keyed by command string
 
-  NpmRegistryLive          — depends on CommandRunner; runs npm view --json
+  NpmRegistryLive          — depends on CommandRunner; runs npm view --json.
+                             getPublishedIntegrity collapses E404 to Option.none().
   NpmRegistryTest          — in-memory package metadata
 
-  PackagePublishLive       — depends on CommandRunner + NpmRegistry + FileSystem
+  PackagePublishLive       — depends on CommandRunner + NpmRegistry + FileSystem.
+                             pack computes sha256Hex from the tarball file.
+                             publish routes through PM executor for OIDC-capable npm versions.
+                             publishTarball uploads an already-packed tarball.
+                             setupAuth strips the URL scheme from the .npmrc key.
   PackagePublishTest       — in-memory publish state
 
   PackageManagerAdapterLive — depends on CommandRunner + FileSystem
@@ -160,6 +180,25 @@ Build Tooling:
   TokenPermissionCheckerLive — depends on GitHubApp
   TokenPermissionCheckerTest — in-memory permission state
 
+Attestation:
+  OidcTokenIssuerLive      — Layer.succeed; reads ACTIONS_ID_TOKEN_REQUEST_TOKEN +
+                             ACTIONS_ID_TOKEN_REQUEST_URL from env; uses native fetch.
+                             No service dependencies.
+  OidcTokenIssuerTest      — in-memory token state
+
+  SigstoreSignerLive       — Layer.effect depending on OidcTokenIssuer;
+                             imports @sigstore/sign directly.
+  SigstoreSignerTest       — in-memory signing state
+
+  SbomLive                 — Layer.effect depending on FileSystem;
+                             imports @cyclonedx/cyclonedx-library directly.
+  SbomTest                 — in-memory BOM state
+
+  AttestLive               — Layer.effect depending on GitHubClient;
+                             delegates signing to SigstoreSigner + OidcTokenIssuer,
+                             BOM generation to Sbom.
+  AttestTest               — in-memory attestation state
+
 Platform:
   NodeFileSystem.layer     — @effect/platform-node: FileSystem
                              (provided by ActionsRuntime.Default)
@@ -169,16 +208,15 @@ Platform:
 
 ## Import Pattern
 
-Three Live layers import external packages directly:
+Five Live layers import external packages directly:
 
 - `GitHubClientLive` -- `import { Octokit } from "@octokit/rest"`
 - `OctokitAuthAppLive` -- `import { createAppAuth } from "@octokit/auth-app"`
 - `ActionCacheLive` -- `import { BlobClient, BlockBlobClient } from "@azure/storage-blob"`
+- `SigstoreSignerLive` -- `import` from `@sigstore/sign`
+- `SbomLive` -- `import` from `@cyclonedx/cyclonedx-library`
 
-All other Live layers either have no external imports or depend on Effect
-services via `Layer.effect` and `yield*`. The runtime layer modules
-(`WorkflowCommand`, `RuntimeFile`, `ActionsConfigProvider`, `ActionsLogger`)
-use only Node.js built-ins and Effect APIs.
+All other Live layers either have no external imports or depend on Effect services via `Layer.effect` and `yield*`. The runtime layer modules (`WorkflowCommand`, `RuntimeFile`, `ActionsConfigProvider`, `ActionsLogger`) use only Node.js built-ins and Effect APIs.
 
 Several Live layers use `Layer.succeed` (no dependencies) because they
 interact directly with process environment, stdout, or Node.js built-ins:
@@ -262,18 +300,9 @@ project-wide for api-extractor compatibility). All three modes resolve a token,
 then call a shared internal `makeClient(token)` builder that wraps an `Octokit`
 instance from `@octokit/rest`. See `src/layers/GitHubClientLive.ts`.
 
-- `fromEnv` — `Layer.Layer<GitHubClient, GitHubClientError>`. Reads the ambient
-  `process.env.GITHUB_TOKEN`, the weak repo-scoped default; fails when it is
-  unset. The self-describing call site is the explicit opt-in to ambient
-  credentials.
-- `fromToken(token)` — `Layer.Layer<GitHubClient>`. Builds from an explicit
-  token (`string` or `Redacted<string>`); no `process.env` dependency and no
-  failure channel — a provided token cannot be missing.
-- `fromApp({ clientId, privateKey, installationId? })` —
-  `Layer.Layer<GitHubClient, GitHubAppError>`. Generates a fresh GitHub App
-  installation token, composing `OctokitAuthAppLive` + `GitHubAppLive`
-  internally. Suits single-phase actions; for a token shared across pre/main/post
-  phases use the `GitHubToken` namespace instead.
+- `fromEnv` — `Layer.Layer<GitHubClient, GitHubClientError>`. Reads the ambient `process.env.GITHUB_TOKEN`, the weak repo-scoped default; fails when it is unset. The self-describing call site is the explicit opt-in to ambient credentials.
+- `fromToken(token)` — `Layer.Layer<GitHubClient>`. Builds from an explicit token (`string` or `Redacted<string>`); no `process.env` dependency and no failure channel — a provided token cannot be missing.
+- `fromApp({ clientId, privateKey, installationId? })` — `Layer.Layer<GitHubClient, GitHubAppError>`. Generates a fresh GitHub App installation token, composing `OctokitAuthAppLive` + `GitHubAppLive` internally. Suits single-phase actions; for a token shared across pre/main/post phases use the `GitHubToken` namespace instead.
 
 REST calls use `Effect.tryPromise`, GraphQL uses `octokit.graphql()`.
 Pagination handles page incrementing and empty-page termination. Error mapping
@@ -340,8 +369,15 @@ Issues API. Marker pattern uses `<!-- savvy-web:KEY -->` HTML comments.
 - `GitCommitLive` -- `Layer<GitCommit, never, GitHubClient>`
 - `RateLimiterLive` -- `Layer<RateLimiter, never, GitHubClient>`
 - `WorkflowDispatchLive` -- `Layer<WorkflowDispatch, never, GitHubClient>`
+- `GitHubContentLive` -- `Layer<GitHubContent, never, GitHubClient>`
+- `GitHubCommitLive` -- `Layer<GitHubCommit, never, GitHubClient>`
+- `GitHubArtifactMetadataLive` -- `Layer<GitHubArtifactMetadata, never, GitHubClient>`
 - `PackagePublishLive` -- `Layer<PackagePublish, never, CommandRunner | NpmRegistry | FileSystem>`
 - `TokenPermissionCheckerLive` -- `Layer<TokenPermissionChecker, never, GitHubApp>`
+- `OidcTokenIssuerLive` -- `Layer<OidcTokenIssuer>` (no service dependencies)
+- `SigstoreSignerLive` -- `Layer<SigstoreSigner, never, OidcTokenIssuer>`
+- `SbomLive` -- `Layer<Sbom, never, FileSystem>`
+- `AttestLive` -- `Layer<Attest, never, GitHubClient>`
 
 ---
 
@@ -365,8 +401,7 @@ Test layers use the namespace object pattern for ergonomic test setup:
 
 **GitHub API:**
 
-- `GitHubClientTest.empty()` / `GitHubClientTest.layer(state)` -- default
-  test repo `{ owner: "test-owner", repo: "test-repo" }`
+- `GitHubClientTest.empty()` / `GitHubClientTest.layer(state)` -- default test repo `{ owner: "test-owner", repo: "test-repo" }`
 - `GitHubGraphQLTest.empty()` / `GitHubGraphQLTest.layer(state)`
 - `GitHubReleaseTest.empty()` / `GitHubReleaseTest.layer(state)`
 - `GitHubIssueTest.empty()` / `GitHubIssueTest.layer(state)`
@@ -390,6 +425,19 @@ Test layers use the namespace object pattern for ergonomic test setup:
 - `DryRunTest.empty()` / `DryRunTest.layer(state)` -- always dry, records guarded labels
 - `TokenPermissionCheckerTest.empty()` / `TokenPermissionCheckerTest.layer(state)`
 
+**Attestation:**
+
+- `OidcTokenIssuerTest.empty()` / `OidcTokenIssuerTest.layer(state)`
+- `SigstoreSignerTest.empty()` / `SigstoreSignerTest.layer(state)`
+- `SbomTest.empty()` / `SbomTest.layer(state)`
+- `AttestTest.empty()` / `AttestTest.layer(state)`
+
+**GitHub API (new):**
+
+- `GitHubContentTest.empty()` / `GitHubContentTest.layer(state)`
+- `GitHubCommitTest.empty()` / `GitHubCommitTest.layer(state)`
+- `GitHubArtifactMetadataTest.empty()` / `GitHubArtifactMetadataTest.layer(state)`
+
 Test layers for services like CheckRun, PullRequestComment, GitBranch, etc.
 do NOT depend on GitHubClient -- they operate entirely in-memory.
 
@@ -400,8 +448,8 @@ do NOT depend on GitHubClient -- they operate entirely in-memory.
 ```text
 Tier 0 — No service dependencies (use Node.js built-ins / native APIs directly):
   ActionLogger, ActionEnvironment, CommandRunner,
-  ToolInstaller, DryRun,
-  GithubMarkdown, SemverResolver, ErrorAccumulator, ReportBuilder
+  ToolInstaller, DryRun, OidcTokenIssuer,
+  GithubMarkdown, SemverResolver, ErrorAccumulator, ReportBuilder, RegistryClassifier
 
 Tier 0 — External package import (no service dependencies):
   OctokitAuthApp            <- imports @octokit/auth-app
@@ -413,6 +461,7 @@ Tier 0 — External package import (no service dependencies):
 Tier 0.5 — Depends on FileSystem (from @effect/platform):
   ActionOutputs             <- depends on FileSystem
   ActionState               <- depends on FileSystem
+  Sbom                      <- depends on FileSystem (for save)
 
 Tier 1 — Single service dependency:
   GitHubApp                 <- depends on OctokitAuthApp
@@ -420,6 +469,7 @@ Tier 1 — Single service dependency:
   ChangesetAnalyzer         <- depends on FileSystem
   ConfigLoader              <- depends on FileSystem
   TokenPermissionChecker    <- depends on GitHubApp
+  SigstoreSigner            <- depends on OidcTokenIssuer
 
 Tier 2 — GitHubClient dependents:
   GitHubGraphQL             <- depends on GitHubClient
@@ -431,6 +481,10 @@ Tier 2 — GitHubClient dependents:
   PullRequestComment        <- depends on GitHubClient
   RateLimiter               <- depends on GitHubClient
   WorkflowDispatch          <- depends on GitHubClient
+  GitHubContent             <- depends on GitHubClient
+  GitHubCommit              <- depends on GitHubClient
+  GitHubArtifactMetadata    <- depends on GitHubClient
+  Attest                    <- depends on GitHubClient
   GitHubIssue               <- depends on GitHubClient + GitHubGraphQL
   PullRequest               <- depends on GitHubClient + GitHubGraphQL
 
@@ -447,9 +501,7 @@ Tier 3 — Composed dependencies:
 
 ## Layer Composition Example
 
-Users compose layers as needed. `Action.run()` provides
-`ActionsRuntime.Default` automatically. Extra layers are passed via the
-`layer` option:
+Users compose layers as needed. `Action.run()` provides `ActionsRuntime.Default` automatically. Extra layers are passed via the `layer` option:
 
 ```typescript
 import { Action, GitHubClientLive, CheckRunLive }
@@ -484,11 +536,7 @@ identity is provided.
 
 ## Current State
 
-All 29 services have both live and test layer implementations. The runtime
-layer provides native implementations of the GitHub Actions protocol. The
-dependency graph is simplified from the previous architecture (no platform
-wrapper tier). Many Live layers now have zero service dependencies since
-they use Node.js built-ins directly.
+All 37 services have both live and test layer implementations. The runtime layer provides native implementations of the GitHub Actions protocol. The dependency graph is simplified from the previous architecture (no platform wrapper tier). Many Live layers now have zero service dependencies since they use Node.js built-ins directly. The attestation cluster (`Attest`, `OidcTokenIssuer`, `SigstoreSigner`, `Sbom`) and three new GitHub API services (`GitHubContent`, `GitHubCommit`, `GitHubArtifactMetadata`) are fully wired with live and test layers.
 
 ## Rationale
 

--- a/.claude/design/github-action-effects/services.md
+++ b/.claude/design/github-action-effects/services.md
@@ -3,8 +3,8 @@ status: current
 module: github-action-effects
 category: architecture
 created: 2026-03-06
-updated: 2026-05-16
-last-synced: 2026-05-16
+updated: 2026-05-20
+last-synced: 2026-05-20
 completeness: 97
 related:
   - ./index.md
@@ -26,7 +26,7 @@ See [layers.md](./layers.md) for live and test layer implementations.
 
 ## Overview
 
-Twenty-nine service modules plus six namespace/utility objects, each
+Thirty-seven service modules plus six namespace/utility objects, each
 independently usable. `Action.run()` automatically provides
 `ActionsRuntime.Default`, which includes `NodeFileSystem.layer` from
 `@effect/platform-node`. Programs also have access to Node.js platform
@@ -40,11 +40,12 @@ by `ActionsLogger`.
 ```text
 @savvy-web/github-action-effects
 ├── Runtime Layer (replaces @actions/*)
-│   ├── WorkflowCommand     — ::command:: protocol formatter with escaping
+│   ├── WorkflowCommand      — ::command:: protocol formatter with escaping
 │   ├── RuntimeFile          — Env file appender (GITHUB_OUTPUT, GITHUB_ENV, etc.)
 │   ├── ActionsConfigProvider — ConfigProvider reading INPUT_* env vars
 │   ├── ActionsLogger        — Effect Logger emitting workflow commands
-│   └── ActionsRuntime       — Single convenience Layer wiring everything
+│   ├── ActionsRuntime       — Single convenience Layer wiring everything
+│   └── Step                 — Step-buffered logging (withStep, success, collapse, groupStep)
 │
 ├── Core Action I/O
 │   ├── ActionLogger        — Log groups + buffered output
@@ -61,20 +62,23 @@ by `ActionsLogger`.
 ├── GitHub API
 │   ├── GitHubClient        — Direct @octokit/rest; namespace layer (fromEnv/fromToken/fromApp)
 │   ├── GitHubGraphQL       — GitHub GraphQL API operations
-│   ├── GitHubRelease       — Create/manage GitHub releases
+│   ├── GitHubRelease       — Create/manage GitHub releases + assets
 │   ├── GitHubIssue         — Issue management + linked issues
 │   ├── GitHubApp           — GitHub App authentication lifecycle
 │   ├── OctokitAuthApp      — Wrapper for @octokit/auth-app createAppAuth
-│   ├── CheckRun            — Check runs with bracket pattern
-│   ├── PullRequest         — PR lifecycle (CRUD, merge, labels, reviewers)
+│   ├── CheckRun            — Check runs with bracket pattern + get
+│   ├── PullRequest         — PR lifecycle (CRUD, merge, labels, reviewers, files)
 │   ├── PullRequestComment  — Sticky (upsert) PR comments
 │   ├── RateLimiter         — Rate limit awareness and retry
-│   └── WorkflowDispatch    — Trigger and monitor workflow runs
+│   ├── WorkflowDispatch    — Trigger and monitor workflow runs
+│   ├── GitHubContent       — Read repository file contents at a ref
+│   ├── GitHubCommit        — Read the commit graph (get/list/compare)
+│   └── GitHubArtifactMetadata — GitHub Packages artifact-metadata storage records
 │
 ├── Build Tooling
 │   ├── CommandRunner       — Structured shell execution (node:child_process)
-│   ├── NpmRegistry         — npm registry queries
-│   ├── PackagePublish      — Multi-registry package publishing
+│   ├── NpmRegistry         — npm registry queries + per-registry integrity probe
+│   ├── PackagePublish      — Multi-registry publishing (pack/publish/publishTarball/dryRun/publishIdempotent)
 │   ├── PackageManagerAdapter — Unified PM operations (npm/pnpm/yarn/bun)
 │   ├── WorkspaceDetector   — Monorepo workspace detection
 │   ├── ToolInstaller       — Low-level tool binary management (native fetch + child_process)
@@ -82,6 +86,12 @@ by `ActionsLogger`.
 │   ├── ConfigLoader        — JSON/JSONC/YAML config loading with schema validation
 │   ├── TokenPermissionChecker — Token permission validation + enforcement
 │   └── DryRun              — Mutation interception for dry-run mode
+│
+├── Attestation
+│   ├── Attest              — End-to-end attest/sign/upload + listForSubject
+│   ├── OidcTokenIssuer     — GitHub Actions OIDC token for Sigstore
+│   ├── SigstoreSigner      — Sign an in-toto statement → Sigstore bundle
+│   └── Sbom                — CycloneDX 1.5 BOM generation and serialization
 │
 ├── Namespace Objects
 │   ├── Action.*            — run, resolveLogLevel, formatCause
@@ -92,7 +102,8 @@ by `ActionsLogger`.
     ├── AutoMerge           — PR auto-merge enable/disable via GraphQL
     ├── SemverResolver      — Semver comparison, parsing, resolution
     ├── ErrorAccumulator    — Process-all-collect-failures pattern
-    └── ReportBuilder       — Fluent markdown report builder
+    ├── ReportBuilder       — Fluent markdown report builder
+    └── RegistryClassifier  — URL-safe registry detection and display utilities
 ```
 
 ---
@@ -104,17 +115,9 @@ single export, reducing barrel clutter and improving discoverability.
 
 **`Action`** (from `src/Action.ts`) groups top-level action helpers:
 
-- `Action.run(program)` / `Action.run(program, options?)` -- Run a GitHub
-  Action program with standard boilerplate. Provides `ActionsRuntime.Default`
-  (ConfigProvider, Logger, ActionLogger, ActionOutputs, ActionState,
-  ActionEnvironment, FileSystem). Wraps the program in
-  `ActionLogger.withBuffer` for buffered output. Catches all errors via
-  `Effect.catchAllCause` and emits `::error::` workflow commands using
-  `WorkflowCommand.issue`. `options` accepts a `layer` field for additional
-  services to merge.
+- `Action.run(program)` / `Action.run(program, options?)` -- Run a GitHub Action program with standard boilerplate. Provides `ActionsRuntime.Default` (ConfigProvider, Logger, ActionLogger, ActionOutputs, ActionState, ActionEnvironment, FileSystem). Wraps the program in `ActionLogger.withBuffer` for buffered output. Catches all errors via `Effect.catchAllCause` and emits `::error::` workflow commands using `WorkflowCommand.issue`. `options` accepts a `layer` field for additional services to merge.
 - `Action.resolveLogLevel(input)` -- Resolve LogLevelInput to ActionLogLevel
-- `Action.formatCause(cause)` -- Extract human-readable error message from an
-  Effect `Cause` using a `[Tag] message` fallback chain
+- `Action.formatCause(cause)` -- Extract human-readable error message from an Effect `Cause` using a `[Tag] message` fallback chain
 
 **`GitHubToken`** (from `src/GitHubToken.ts`) groups phase-oriented helpers for
 the GitHub App installation-token lifecycle. See [GitHubToken Lifecycle](#githubtoken-lifecycle)
@@ -150,13 +153,8 @@ additional GitHub Actions-specific operations.
 
 **Interface:**
 
-- `group(name, effect)` -- Wraps an effect in a collapsible log group
-  (`::group::` / `::endgroup::`). If the wrapped effect fails and a buffer is
-  active, the buffered diagnostics are flushed *inside* the group, before
-  `::endgroup::`, so a failure's context stays within its own group.
-- `withBuffer(label, effect)` -- Captures verbose output in memory; on
-  success the buffer is discarded; on failure the buffer is flushed before
-  the error is reported. At Debug log level, passes through without buffering.
+- `group(name, effect)` -- Wraps an effect in a collapsible log group (`::group::` / `::endgroup::`). If the wrapped effect fails and a buffer is active, the buffered diagnostics are flushed *inside* the group, before `::endgroup::`, so a failure's context stays within its own group.
+- `withBuffer(label, effect)` -- Captures verbose output in memory; on success the buffer is discarded; on failure the buffer is flushed before the error is reported. At Debug log level, passes through without buffering.
 
 The buffer is fiber-scoped (a module-level `FiberRef`), so nested `group`
 calls and the outer `withBuffer` boundary share one buffer. Each buffered chunk
@@ -176,11 +174,9 @@ WorkflowCommand.
 - `set(name, value)` -- Set an output value (appends to `GITHUB_OUTPUT` file)
 - `setJson(name, value, schema)` -- Serialize and set a JSON output
 - `summary(content)` -- Write to `$GITHUB_STEP_SUMMARY`
-- `exportVariable(name, value)` -- Export an environment variable (appends to
-  `GITHUB_ENV` file)
+- `exportVariable(name, value)` -- Export an environment variable (appends to `GITHUB_ENV` file)
 - `addPath(path)` -- Add to PATH (appends to `GITHUB_PATH` file)
-- `setFailed(message)` -- Mark the action as failed via `::error::` command
-  and `process.exitCode = 1`
+- `setFailed(message)` -- Mark the action as failed via `::error::` command and `process.exitCode = 1`
 - `setSecret(value)` -- Mask a runtime value in logs via `::add-mask::` command
 
 **Error type:** `ActionOutputError`
@@ -223,13 +219,8 @@ dependency on `@actions/cache`.
 
 **Interface:**
 
-- `save(paths, key)` -- Create tar.gz archive of paths with `-P` (absolute-names)
-  to preserve absolute paths, upload via `CreateCacheEntry` + Azure Blob
-  `BlockBlobClient.uploadFile()` + `FinalizeCacheEntryUpload`
-- `restore(paths, primaryKey, restoreKeys?)` -- Look up cache entry via
-  `GetCacheEntryDownloadURL`, download via Azure Blob `BlobClient.downloadToFile()`,
-  extract with `-P` to restore absolute paths correctly. Returns `Option<string>`
-  (matched key or none on miss)
+- `save(paths, key)` -- Create tar.gz archive of paths with `-P` (absolute-names) to preserve absolute paths, upload via `CreateCacheEntry` + Azure Blob `BlockBlobClient.uploadFile()` + `FinalizeCacheEntryUpload`
+- `restore(paths, primaryKey, restoreKeys?)` -- Look up cache entry via `GetCacheEntryDownloadURL`, download via Azure Blob `BlobClient.downloadToFile()`, extract with `-P` to restore absolute paths correctly. Returns `Option<string>` (matched key or none on miss)
 
 **Error type:** `ActionCacheError`
 
@@ -257,9 +248,7 @@ additions/updates and file deletions.
 - `createTree(entries, baseTree?)` -- Create a tree object, return SHA
 - `createCommit(message, treeSha, parentShas)` -- Create a commit object
 - `updateRef(ref, sha, force?)` -- Update a ref to point at a new SHA
-- `commitFiles(branch, message, files)` -- Convenience: commit files to a
-  branch. Each file is a `FileChange` (union of `FileChangeContent` for
-  add/update and `FileChangeDeletion` with `sha: null` for deletion)
+- `commitFiles(branch, message, files)` -- Convenience: commit files to a branch. Each file is a `FileChange` (union of `FileChangeContent` for add/update and `FileChangeDeletion` with `sha: null` for deletion)
 
 **Error type:** `GitCommitError`
 
@@ -272,7 +261,7 @@ Tag management via the GitHub Git refs API.
 - `create(tag, sha)` -- Create a lightweight tag pointing at the given SHA
 - `delete(tag)` -- Delete a tag
 - `list(prefix?)` -- List tags, optionally filtered by prefix. Returns `Array<TagRef>`
-- `resolve(tag)` -- Resolve a tag to its SHA
+- `resolve(tag)` -- Resolve a tag to its commit SHA. Annotated tags are unwrapped: when the ref object type is `tag` the implementation dereferences the tag object to retrieve the target commit SHA, so the result is always a commit SHA regardless of tag type
 
 **Types:** `TagRef` -- `{ tag: string; sha: string }`
 
@@ -287,10 +276,8 @@ Uses `@octokit/rest` directly.
 
 - `rest(operation, fn)` -- Execute a REST API call via callback
 - `graphql(query, variables?)` -- Execute a GraphQL query
-- `paginate(operation, fn, options?)` -- Paginate a REST API call, collecting
-  all results. Options: `{ perPage?, maxPages? }`
-- `repo` -- Get the repository context (`{ owner, repo }`) from
-  `GITHUB_REPOSITORY` env var
+- `paginate(operation, fn, options?)` -- Paginate a REST API call, collecting all results. Options: `{ perPage?, maxPages? }`
+- `repo` -- Get the repository context (`{ owner, repo }`) from `GITHUB_REPOSITORY` env var
 
 **Error type:** `GitHubClientError` -- includes `retryable` flag for 429/5xx
 
@@ -318,10 +305,11 @@ Create and manage GitHub releases via the REST API.
 **Interface:**
 
 - `create(options)` -- Create a new release. Returns `ReleaseData`
-- `uploadAsset(releaseId, name, data, contentType)` -- Upload an asset.
-  Returns `ReleaseAsset`
+- `uploadAsset(releaseId, name, data, contentType)` -- Upload an asset. Returns `ReleaseAsset`
 - `getByTag(tag)` -- Get a release by tag name. Returns `ReleaseData`
 - `list(options?)` -- List releases. Returns `Array<ReleaseData>`
+- `updateRelease(releaseId, options)` -- Update an existing release's fields. Returns updated `ReleaseData`
+- `listReleaseAssets(releaseId)` -- List all assets attached to a release. Returns `Array<ReleaseAsset>`
 
 **Types:** `ReleaseData`, `ReleaseAsset`
 
@@ -334,11 +322,12 @@ Issue management and linked issue queries.
 **Interface:**
 
 - `list(options?)` -- List issues filtered by state, labels, milestone
+- `get(issueNumber)` -- Get a single issue by number
 - `close(issueNumber, reason?)` -- Close an issue
 - `comment(issueNumber, body)` -- Add a comment
 - `getLinkedIssues(prNumber)` -- Get issues linked to a PR via closing references
 
-**Types:** `IssueData` -- `{ number, title, state, labels }`
+**Types:** `IssueData` -- `{ number, title, state, labels, htmlUrl?, nodeId? }`
 
 **Error type:** `GitHubIssueError`
 
@@ -362,13 +351,11 @@ token revocation.
 
 ### OctokitAuthApp Service
 
-Wrapper service for `@octokit/auth-app`. This is the only service that
-imports `@octokit/auth-app` directly (via `OctokitAuthAppLive`).
+Wrapper service for `@octokit/auth-app`. This is the only service that imports `@octokit/auth-app` directly (via `OctokitAuthAppLive`).
 
 **Interface:**
 
-- `createAppAuth(options)` -- Create an `AppAuth` callable for JWT-based
-  app and installation authentication
+- `createAppAuth(options)` -- Create an `AppAuth` callable for JWT-based app and installation authentication
 
 **Types:** `AppAuth` -- callable interface for app/installation auth
 
@@ -378,13 +365,13 @@ Create, update, and complete GitHub check runs with bracket pattern.
 
 **Interface:**
 
-- `create(name, headSha)` -- Create a new check run. Returns check run ID
+- `create(name, headSha)` -- Create a new check run. Returns `CheckRunData` (id, name, status, conclusion, htmlUrl)
+- `get(checkRunId)` -- Get a check run by id. Returns `CheckRunData`
 - `update(checkRunId, output)` -- Update with output content
 - `complete(checkRunId, conclusion, output?)` -- Complete with conclusion
 - `withCheckRun(name, headSha, effect)` -- Bracket: create, run, complete
 
-**Types:** `CheckRunConclusion`, `AnnotationLevel`, `CheckRunAnnotation`,
-`CheckRunOutput`
+**Types:** `CheckRunConclusion`, `AnnotationLevel`, `CheckRunAnnotation`, `CheckRunOutput`, `CheckRunData`
 
 **Error type:** `CheckRunError`
 
@@ -396,6 +383,8 @@ Full pull request lifecycle management.
 
 - `get(number)` -- Get a single PR by number
 - `list(options?)` -- List PRs matching filters
+- `listFiles(number)` -- List files changed in a PR. Returns `Array<PullRequestFile>`
+- `listAssociatedWithCommit(sha)` -- List PRs associated with a commit SHA
 - `create(options)` -- Create a new PR
 - `update(number, options)` -- Update an existing PR
 - `getOrCreate(options)` -- Find existing PR for head->base or create one
@@ -403,7 +392,9 @@ Full pull request lifecycle management.
 - `addLabels(number, labels)` -- Add labels to a PR
 - `requestReviewers(number, options)` -- Request reviewers
 
-**Types:** `PullRequestInfo`, `PullRequestListOptions`
+**Types:** `PullRequestInfo`, `PullRequestListOptions`, `PullRequestFile`
+
+`PullRequestInfo` carries optional fields added in this cycle: `mergedAt`, `body`, `mergeCommitSha` and `baseSha`.
 
 **Error type:** `PullRequestError`
 
@@ -442,8 +433,7 @@ Trigger and monitor GitHub Actions workflow runs.
 **Interface:**
 
 - `dispatch(workflow, ref, inputs?)` -- Trigger a workflow run
-- `dispatchAndWait(workflow, ref, inputs?, pollOptions?)` -- Trigger and poll
-  until completion
+- `dispatchAndWait(workflow, ref, inputs?, pollOptions?)` -- Trigger and poll until completion
 - `getRunStatus(runId)` -- Get status of a workflow run
 
 **Types:** `WorkflowRunStatus`, `PollOptions`
@@ -461,8 +451,7 @@ Structured shell command execution via `node:child_process` `spawn`.
 - `execJson(command, args?, schema?)` -- Run, parse stdout as JSON, validate
 - `execLines(command, args?, options?)` -- Run and return stdout split into lines
 
-**Types:** `ExecOptions` -- `{ cwd?, env?, timeout?, silent?, streaming? }`,
-`ExecOutput` -- `{ exitCode, stdout, stderr }`
+**Types:** `ExecOptions` -- `{ cwd?, env?, timeout?, silent?, streaming? }`, `ExecOutput` -- `{ exitCode, stdout, stderr }`
 
 **Error type:** `CommandRunnerError`
 
@@ -474,10 +463,11 @@ Query npm registry for package metadata.
 
 - `getLatestVersion(pkg)` -- Get latest version string
 - `getDistTags(pkg)` -- Get dist-tags record
-- `getPackageInfo(pkg, version?)` -- Get package info
-- `getVersions(pkg)` -- Get all version strings
+- `getPackageInfo(pkg, version?, options?)` -- Get package info. `options.registry` routes to a specific registry
+- `getVersions(pkg, options?)` -- Get all version strings. `options.registry` routes to a specific registry
+- `getPublishedIntegrity(pkg, version, options)` -- Probe a specific registry for the published `dist.integrity` hash of a version. Returns `Option<string>` — `none` when the version is absent (404), `some(integrity)` when found. Other failures propagate as `NpmRegistryError`. `options.registry` is required
 
-**Error type:** `NpmRegistryError`
+**Error type:** `NpmRegistryError` (carries a `message` getter for readable error surfaces)
 
 ### PackagePublish Service
 
@@ -485,15 +475,18 @@ Multi-registry npm package publishing workflow.
 
 **Interface:**
 
-- `setupAuth(registry, token)` -- Configure npm authentication
-- `pack(packageDir)` -- Pack into tarball and compute digest
-- `publish(packageDir, options?)` -- Publish to a registry
-- `verifyIntegrity(packageName, version, expectedDigest)` -- Verify integrity
-- `publishToRegistries(packageDir, registries)` -- Publish to multiple registries
+- `setupAuth(registry, token)` -- Configure npm authentication. URL scheme is stripped from the key written to `.npmrc` (only the hostname+path is used, not `https://`)
+- `pack(packageDir)` -- Pack into a tarball; returns `PackResult` with `tarballPath`, `digest` (sha512-base64 integrity), `sha256Hex` (lowercase hex SHA-256 of the tarball for use with attestation APIs), `name`, `version`, `packedSize`, `unpackedSize`, `fileCount`
+- `publish(packageDir, options?)` -- Publish to a registry. `options.packageManager` routes through the active PM's executor (e.g. `pnpm dlx npm` or `yarn npm`) so callers can use npm ≥ 11.5.1 for OIDC trusted publishing regardless of which PM manages the workspace. Verbose npm logging is enabled so the OIDC exchange is visible in the action log
+- `publishTarball(tarballPath, options)` -- Upload a previously-packed tarball to a specific registry without re-packing. `options.registry` is required. Suitable for publishing byte-identical content to multiple registries
+- `verifyIntegrity(packageName, version, expectedDigest)` -- Verify a published package's integrity hash against the expected digest
+- `publishToRegistries(packageDir, registries)` -- Publish to multiple registries in sequence
+- `publishIdempotent(input)` -- Skip when an identical version already exists; fail on content mismatch. Deprecated: new callers should compose `pack`, `NpmRegistry.getPublishedIntegrity` and `publishTarball` directly
+- `dryRun(packageDir, options?)` -- Simulate publishing via `npm publish --dry-run`. Returns `DryRunResult { ok, packedSize?, unpackedSize?, fileCount?, output }`. A non-zero exit is reported as `ok: false`, not as an error
 
-**Types:** `PackResult`, `RegistryTarget`
+**Types:** `PackResult`, `RegistryTarget`, `IdempotentPublishInput`, `IdempotentPublishResult`, `DryRunResult`
 
-**Error type:** `PackagePublishError`
+**Error type:** `PackagePublishError` (carries a `message` getter for readable error surfaces; captures the source error as `cause`; surfaces the tail of long stderr output)
 
 ### PackageManagerAdapter Service
 
@@ -589,6 +582,96 @@ Check GitHub token permissions against requirements.
 
 **Error type:** `TokenPermissionError`
 
+### GitHubContent Service
+
+Read repository file contents via the GitHub REST API.
+
+**Interface:**
+
+- `getFile(path, ref?)` -- Read a file's decoded UTF-8 contents at a ref. `ref` defaults to the repository's default branch. Fails when the path resolves to a directory, submodule, or is missing
+
+**Error type:** `GitHubContentError`
+
+### GitHubCommit Service
+
+Read the GitHub commit graph via the REST API. Distinct from `GitCommit`, which wraps the local `git` CLI — this service wraps `repos.getCommit` / `listCommits` / `compareCommits`.
+
+**Interface:**
+
+- `get(ref)` -- Get a single commit by ref (SHA or branch name). Returns `CommitDetail`
+- `list(ref)` -- List commits reachable from a ref, paginated. Returns `Array<CommitSummary>`
+- `compare(base, head)` -- Compare two commits/refs; returns the commits and changed files between base and head. Returns `CommitComparison`
+
+**Types:** `CommitSummary { sha, message, author }`, `CommitDetail extends CommitSummary { parents }`, `CommitFile { filename, status }`, `CommitComparison { commits, files }`
+
+**Error type:** `GitHubCommitError`
+
+### GitHubArtifactMetadata Service
+
+GitHub Packages artifact-metadata operations for linking attestations to published artifacts.
+
+**Interface:**
+
+- `createStorageRecord(input)` -- Create an artifact-metadata storage record linking an attestation to a published GitHub Packages artifact. Returns `ReadonlyArray<number>` (created record IDs). `input` carries `name` (purl), `digest`, `version`, `registryUrl`, `artifactUrl` and `repo`
+
+**Error type:** `GitHubArtifactMetadataError`
+
+### Attest Service
+
+End-to-end attestation: build in-toto statements, sign via Sigstore, upload to GitHub's attestation store, and query existing attestations.
+
+**Interface:**
+
+- `buildStatement(input)` -- Build an `InTotoStatement` from subjects + predicate. Pure aside from Effect wrapping
+- `save(data, path)` -- Write an in-toto statement or Sigstore bundle to disk. Requires `FileSystem`
+- `buildBundle(input)` -- Build a signed Sigstore bundle (no upload). Requires `SigstoreSigner | OidcTokenIssuer`
+- `attest(input)` -- Full end-to-end: build statement, sign, POST to `POST /repos/{owner}/{repo}/attestations`. Returns `AttestationRecord`. Requires `SigstoreSigner | OidcTokenIssuer | GitHubClient`
+- `sbom(input)` -- Generate a CycloneDX SBOM and attest it (`CYCLONEDX_BOM` predicateType). `input` accepts either `dependencies` (the service builds the BOM) or a pre-built `bomDocument` (attested verbatim). Requires `Sbom | SigstoreSigner | OidcTokenIssuer | GitHubClient`
+- `provenance(input)` -- Attest with a caller-supplied SLSA Provenance v1 predicate. Requires `SigstoreSigner | OidcTokenIssuer | GitHubClient`
+- `listForSubject(subjectSha256, options?)` -- List existing attestations for a tarball digest (`GET /repos/{owner}/{repo}/attestations/sha256:{hex}`). `options.predicateType` filters client-side. Returns an empty array on 404 (never-attested subject). Requires `GitHubClient`
+
+**Types:** `SbomAttestationInput`, `ProvenanceAttestationInput`, `AttestationListEntry { attestationUrl, predicateType }`, `AttestationRecord` (see `schemas/Attestation.ts`)
+
+**Error type:** `AttestError`
+
+### OidcTokenIssuer Service
+
+Fetch OIDC ID tokens from the GitHub Actions token service. Requires `id-token: write` in the workflow permissions.
+
+**Interface:**
+
+- `getToken(audience)` -- Request an OIDC ID token from `ACTIONS_ID_TOKEN_REQUEST_URL`. `audience` is the `aud` claim (e.g. `"sigstore"` for Fulcio cert issuance). Returns `Redacted<string>`
+
+**Error type:** `OidcTokenError`
+
+### SigstoreSigner Service
+
+Sign an in-toto statement to produce a Sigstore DSSE bundle.
+
+**Interface:**
+
+- `signStatement(statement)` -- Build a Sigstore bundle from an `InTotoStatement`. Fetches an OIDC token via `OidcTokenIssuer` (audience: `"sigstore"`), signs through Fulcio, and witnesses on Rekor. Returns `SigstoreBundle`. Requires `OidcTokenIssuer`
+
+**Constants:** `IN_TOTO_PAYLOAD_TYPE`, `SIGSTORE_OIDC_AUDIENCE`
+
+**Config:** `SigstoreSignerConfig { fulcioBaseURL?, rekorBaseURL? }` for overriding public-good defaults
+
+**Error type:** `SigstoreSignerError`
+
+### Sbom Service
+
+CycloneDX 1.5 SBOM generation for npm packages.
+
+**Interface:**
+
+- `generate(input)` -- Build an in-memory CycloneDX 1.5 BOM from a resolved dependency graph. `input` includes NTIA-required fields: `rootName`, `rootVersion`, `dependencies`, optional `supplier` (`SbomSupplier { name, url?, contact? }`) and `authors` (`Array<SbomAuthor>`) for NTIA "author of SBOM data". `inFlightPackages` handles workspace packages not yet on a registry
+- `serializeJson(bom)` -- Serialize a BOM to canonical CycloneDX JSON
+- `save(bom, path)` -- Write a BOM to disk as pretty-printed JSON. Requires `FileSystem`
+
+**Types:** `SbomInput`, `CycloneDXBom`, `ResolvedDependency`, `InFlightPackage`, `SbomSupplier`, `SbomContact`, `SbomAuthor`
+
+**Error type:** `SbomError`
+
 ---
 
 ## Utility Namespaces
@@ -628,17 +711,22 @@ Process-all-collect-failures pattern.
 
 Composable markdown report builder with multiple output targets.
 
-- `ReportBuilder.create(title)`, `report.stat(label, value)`,
-  `report.section(title, content)`, `report.details(summary, content)`,
-  `report.toMarkdown()`, `report.toSummary()`, `report.toComment(prNumber, markerKey)`,
-  `report.toCheckRun(checkRunId)`
+- `ReportBuilder.create(title)`, `report.stat(label, value)`, `report.section(title, content)`, `report.details(summary, content)`, `report.toMarkdown()`, `report.toSummary()`, `report.toComment(prNumber, markerKey)`, `report.toCheckRun(checkRunId)`
+
+### RegistryClassifier (Pure Functions)
+
+URL-safe registry detection. Parses URLs and checks hostnames (not substrings) to prevent CWE-20 bypass attacks.
+
+- `isNpmRegistry(url)`, `isGitHubPackagesRegistry(url)`, `isJsrRegistry(url)`, `isCustomRegistry(url)` -- boolean predicates
+- `getRegistryType(url)` -- returns `RegistryType` (`"npm" | "github-packages" | "jsr" | "custom"`)
+- `getRegistryDisplayName(url)` -- human-readable name; defaults to `"jsr.io"` when `url` is null/undefined
+- `generatePackageViewUrl(registry, packageName)` -- generates a browse URL for npm and GitHub Packages registries
 
 ---
 
 ## Action.run Helper
 
-Top-level convenience function that eliminates boilerplate for wiring Effect
-programs into GitHub Action entry points.
+Top-level convenience function that eliminates boilerplate for wiring Effect programs into GitHub Action entry points.
 
 **Signatures:**
 
@@ -718,11 +806,7 @@ post.ts  GitHubToken.dispose()    — read envelope, revoke token via GitHubApp
 
 ## Current State
 
-All 29 service modules and 6 namespace/utility objects are fully defined with
-interfaces, error types, and live layer implementations. All services also have
-test layer implementations. The runtime layer (`src/runtime/`) provides native
-implementations of the GitHub Actions protocol, eliminating all `@actions/*`
-dependencies.
+All 37 service modules and 6 namespace/utility objects are fully defined with interfaces, error types, and live layer implementations. All services also have test layer implementations. The runtime layer (`src/runtime/`) provides native implementations of the GitHub Actions protocol, eliminating all `@actions/*` dependencies. The attestation cluster (`Attest`, `OidcTokenIssuer`, `SigstoreSigner`, `Sbom`) and three new GitHub API services (`GitHubContent`, `GitHubCommit`, `GitHubArtifactMetadata`) landed in this cycle.
 
 ## Rationale
 

--- a/.claude/design/github-action-effects/services.md
+++ b/.claude/design/github-action-effects/services.md
@@ -480,7 +480,7 @@ Multi-registry npm package publishing workflow.
 - `publish(packageDir, options?)` -- Publish to a registry. `options.packageManager` routes through the active PM's executor (e.g. `pnpm dlx npm` or `yarn npm`) so callers can use npm ≥ 11.5.1 for OIDC trusted publishing regardless of which PM manages the workspace. Verbose npm logging is enabled so the OIDC exchange is visible in the action log
 - `publishTarball(tarballPath, options)` -- Upload a previously-packed tarball to a specific registry without re-packing. `options.registry` is required. Suitable for publishing byte-identical content to multiple registries
 - `verifyIntegrity(packageName, version, expectedDigest)` -- Verify a published package's integrity hash against the expected digest
-- `publishToRegistries(packageDir, registries)` -- Publish to multiple registries in sequence
+- `publishToRegistries(packageDir, registries)` -- Publish to multiple registries in sequence; each `RegistryTarget` carries an optional `packageManager` so per-registry publishes route through the same PM executor dispatch as `publish`
 - `publishIdempotent(input)` -- Skip when an identical version already exists; fail on content mismatch. Deprecated: new callers should compose `pack`, `NpmRegistry.getPublishedIntegrity` and `publishTarball` directly
 - `dryRun(packageDir, options?)` -- Simulate publishing via `npm publish --dry-run`. Returns `DryRunResult { ok, packedSize?, unpackedSize?, fileCount?, output }`. A non-zero exit is reported as `ok: false`, not as an error
 
@@ -718,8 +718,8 @@ Composable markdown report builder with multiple output targets.
 URL-safe registry detection. Parses URLs and checks hostnames (not substrings) to prevent CWE-20 bypass attacks.
 
 - `isNpmRegistry(url)`, `isGitHubPackagesRegistry(url)`, `isJsrRegistry(url)`, `isCustomRegistry(url)` -- boolean predicates
-- `getRegistryType(url)` -- returns `RegistryType` (`"npm" | "github-packages" | "jsr" | "custom"`)
-- `getRegistryDisplayName(url)` -- human-readable name; defaults to `"jsr.io"` when `url` is null/undefined
+- `getRegistryType(url)` -- returns `RegistryType` (`"npm" | "github-packages" | "jsr" | "custom"`); a null/undefined `url` resolves to `"npm"` (an absent registry is the public npm registry, this library's default)
+- `getRegistryDisplayName(url)` -- human-readable name; defaults to `"npm"` when `url` is null/undefined, matching `getRegistryType`
 - `generatePackageViewUrl(registry, packageName)` -- generates a browse URL for npm and GitHub Packages registries
 
 ---

--- a/.claude/design/github-action-effects/testing-strategy.md
+++ b/.claude/design/github-action-effects/testing-strategy.md
@@ -3,8 +3,8 @@ status: current
 module: github-action-effects
 category: architecture
 created: 2026-03-06
-updated: 2026-05-15
-last-synced: 2026-05-15
+updated: 2026-05-20
+last-synced: 2026-05-20
 completeness: 95
 related:
   - ./index.md

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ concurrency:
 jobs:
   workflow:
     name: Workflow
-    uses: savvy-web/.github/.github/workflows/release.yml@main
+    uses: savvy-web/.github/.github/workflows/release.yml@dev
     permissions:
       contents: write
       pull-requests: write
@@ -28,6 +28,7 @@ jobs:
       packages: write
       attestations: write
       checks: write
+      artifact-metadata: write
     with:
       dry-run: ${{ inputs.dry_run || false }}
       app-bot-id: ${{ vars.APP_BOT_ID }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,7 +51,7 @@ pnpm vitest run src/services/ActionOutputs.test.ts
 - **Build**: Rslib with dual output (`dist/dev/` and `dist/npm/`)
 - **Build Orchestration**: Turbo for caching and task dependencies
 - **Core Dependency**: Effect-TS for service composition, error handling, and schema validation
-- **Direct deps**: `@octokit/rest`, `@octokit/auth-app`, jsonc/semver/yaml-effect
+- **Direct deps**: `@octokit/rest`, `@octokit/auth-app`, `@sigstore/sign`, `@sigstore/bundle`, `@cyclonedx/cyclonedx-library`, jsonc/semver/yaml-effect
 - **Required peers**: `effect`, `@effect/platform`, `@effect/platform-node`
 
 ### Source Layout
@@ -61,7 +61,7 @@ src/
   Action.ts        -- Action namespace (run, resolveLogLevel, formatCause)
   GitHubToken.ts   -- GitHubToken namespace (App installation-token lifecycle)
   runtime/         -- ConfigProvider, Logger, WorkflowCommand, RuntimeFile, ActionsRuntime
-  services/        -- Effect service interfaces (27 services)
+  services/        -- Effect service interfaces (37 services)
   layers/          -- Live and Test layer implementations
   errors/          -- Tagged error types (Data.TaggedError)
   schemas/         -- Effect Schema definitions (LogLevel, Changeset, PackageManager, etc.)
@@ -79,6 +79,7 @@ The `src/runtime/` directory contains the GitHub Actions runtime protocol implem
 - `ActionsConfigProvider` — ConfigProvider reading INPUT_* env vars
 - `ActionsLogger` — Effect Logger emitting workflow commands
 - `ActionsRuntime.Default` — Single convenience Layer wiring everything
+- `Step` — Step-buffered logging: `Step.withStep(name, effect)` buffers debug/info, emits one success line on pass, spills buffer with `❌` header on failure; `Step.success(line)` sets custom success text; `Step.collapse(steps, reducer)` runs N steps in parallel with optional collapsed output; `Step.groupStep(name, effect)` wraps in both `ActionLogger.group` and `withStep`
 
 Consumer pattern:
 
@@ -112,12 +113,15 @@ For GitHub App actions, `GitHubToken` provides phase-oriented installation-token
 | GitHubClient | Octokit REST/GraphQL wrapper (direct @octokit/rest) |
 | GitHubGraphQL | Typed GraphQL query/mutation execution |
 | GitHubApp | App authentication lifecycle |
+| OctokitAuthApp | Wrapper for @octokit/auth-app createAppAuth |
 | GitHubIssue | Issue CRUD (list, get, create, update, label) |
-| GitHubRelease | Release + asset management |
+| GitHubRelease | Release + asset management (create, update, list assets) |
+| GitHubContent | Read repository file contents at a ref |
+| GitHubCommit | Read commit graph (get, list, compare) |
+| GitHubArtifactMetadata | GitHub Packages artifact-metadata storage records |
 | RateLimiter | API rate limit awareness + retry |
-| CheckRun | Check runs + annotations |
-| CommandRunner | Structured shell execution (node:child_process) |
-| PullRequest | PR lifecycle (CRUD, merge, labels, reviewers) |
+| CheckRun | Check runs + annotations; create/get return CheckRunData |
+| PullRequest | PR lifecycle (CRUD, merge, labels, reviewers, listFiles, baseSha, listAssociatedWithCommit) |
 | PullRequestComment | PR comment management |
 | WorkflowDispatch | Trigger + poll workflows |
 | TokenPermissionChecker | Token permission validation + enforcement |
@@ -127,10 +131,14 @@ For GitHub App actions, `GitHubToken` provides phase-oriented installation-token
 | GitTag | Tag CRUD via Git Data API |
 | ConfigLoader | JSON/JSONC/YAML config loading |
 | ToolInstaller | Tool binary management (native fetch + child_process) |
-| NpmRegistry | npm registry queries (versions, dist-tags, info) |
-| PackagePublish | Pack + publish to registries |
+| NpmRegistry | npm registry queries (versions, dist-tags, info, per-registry probe) |
+| PackagePublish | Pack + publish to registries (dryRun, publishIdempotent, publishTarball, sha256-hex result) |
 | PackageManagerAdapter | Unified PM interface |
 | WorkspaceDetector | Monorepo workspace detection + listing |
+| Attest | End-to-end attest/sign/upload + listForSubject |
+| OidcTokenIssuer | GitHub Actions OIDC token for Sigstore |
+| SigstoreSigner | Sign an in-toto statement into a Sigstore bundle |
+| Sbom | CycloneDX 1.5 BOM generation and serialization |
 
 ### Key Patterns
 
@@ -141,6 +149,7 @@ For GitHub App actions, `GitHubToken` provides phase-oriented installation-token
 - Test layers use namespace object pattern: `ActionLoggerTest.empty()` / `ActionLoggerTest.layer(state)`
 - Inputs via `Config.*` backed by `ActionsConfigProvider`
 - Logging via Effect `Logger` backed by `ActionsLogger`; `ActionLogger.group` flushes buffered verbose logs inside a failing group before `::endgroup::`
+- `Step.withStep` (runtime) buffers debug/info logs per-step, emits one success line or spills buffer on failure; warnings/errors always pass through
 
 ### Code Quality
 

--- a/README.md
+++ b/README.md
@@ -10,9 +10,11 @@
 ## Features
 
 - **Zero CJS dependencies** — native ESM implementations of the GitHub Actions runtime protocol replace all `@actions/*` packages
-- **29 composable services** — action I/O, GitHub API calls, git operations and package publishing, each with its own `Context.Tag`
+- **37 composable services** — action I/O, GitHub API calls, git operations, package publishing and software attestation, each with its own `Context.Tag`
 - **Schema-validated inputs** — read action inputs via Effect's `Config` API with built-in parsing and defaults
 - **Structured logging** — Effect Logger maps to workflow commands with collapsible groups; buffered verbose output flushes inside its group when a step fails
+- **Step-buffered execution** — `Step.withStep` buffers debug output per logical step, emits one success line on pass and spills the full buffer prefixed with the step name on failure
+- **Software attestation** — sign and upload SLSA provenance and CycloneDX SBOMs to GitHub's attestation store via the `Attest`, `SigstoreSigner`, `OidcTokenIssuer` and `Sbom` services
 - **In-memory test layers** — every service ships a test layer for fast, deterministic unit tests
 
 ## Install

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # github-action-effects documentation
 
-An Effect library for building GitHub Actions. It covers structured logging, typed outputs, GitHub API calls and package publishing, and every service ships a test layer. None of it depends on `@actions/*`: the GitHub Actions runtime protocol is reimplemented in native ESM.
+An Effect library for building GitHub Actions. It covers structured logging, typed outputs, GitHub API calls, package publishing and software attestation, and every service ships a test layer. None of it depends on `@actions/*`: the GitHub Actions runtime protocol is reimplemented in native ESM.
 
 ## Install
 
@@ -53,11 +53,14 @@ const program = Effect.gen(function* () {
 | ActionCache | Save/restore with withCache bracket pattern |
 | GitHubClient | Octokit REST/GraphQL with pagination (uses @octokit/rest directly) |
 | GitHubGraphQL | Typed GraphQL queries and mutations |
-| GitHubRelease | Create releases, upload assets, list/get by tag |
-| GitHubIssue | List, close, comment, get linked issues |
+| GitHubRelease | Create, update and list releases and assets |
+| GitHubIssue | List, close, comment and get issues |
+| GitHubContent | Read repository file contents at a ref |
+| GitHubCommit | Read the commit graph (get, list, compare) |
+| GitHubArtifactMetadata | Read and write GitHub Packages artifact-metadata storage records |
 | GitHubApp | GitHub App token lifecycle with bracket pattern |
-| CheckRun | Create, update, complete check runs with annotations |
-| PullRequest | PR lifecycle: get, list, create, update, merge, getOrCreate, labels, reviewers |
+| CheckRun | Create, update and complete check runs with annotations |
+| PullRequest | PR lifecycle: get, list, create, update, merge, listFiles, baseSha, labels, reviewers |
 | PullRequestComment | Sticky (upsert) PR comments with marker keys |
 | GitTag | CRUD for tags via Git Data API |
 | GitBranch | CRUD for branches via Git Data API |
@@ -65,21 +68,26 @@ const program = Effect.gen(function* () {
 | CommandRunner | Structured shell execution with capture and JSON parsing |
 | ConfigLoader | Load and validate JSON, JSONC, YAML config files |
 | DryRun | Mutation guard with fallback values |
-| NpmRegistry | Query npm for versions, dist-tags, package info |
-| PackagePublish | Auth, pack, publish, verify, multi-registry |
+| NpmRegistry | Query npm for versions, dist-tags, package info and per-registry version probes |
+| PackagePublish | Pack and publish to registries; supports `dryRun`, `publishIdempotent` and `publishTarball` |
 | PackageManagerAdapter | Auto-detect and use npm/pnpm/yarn/bun/deno |
 | WorkspaceDetector | Detect monorepo type and list packages |
 | ChangesetAnalyzer | Parse and generate changeset files |
-| TokenPermissionChecker | Check/assert GitHub token permissions |
+| TokenPermissionChecker | Check and assert GitHub token permissions |
 | RateLimiter | Rate limit guard with exponential backoff |
 | WorkflowDispatch | Trigger workflows and poll until completion |
-| ToolInstaller | Download, extract, cache tool binaries (archives and standalone binaries) |
+| ToolInstaller | Download, extract and cache tool binaries (archives and standalone binaries) |
+| Attest | Sign and upload SLSA provenance and SBOM attestations to GitHub's attestation store |
+| OidcTokenIssuer | Request a GitHub Actions OIDC token for use with Sigstore |
+| SigstoreSigner | Sign an in-toto statement into a Sigstore bundle |
+| Sbom | Generate and serialize CycloneDX 1.5 software bills of materials |
 
 ## Namespace objects
 
 | Namespace | Purpose |
 | --- | --- |
 | `Action` | Top-level helpers: `run`, `formatCause`, `resolveLogLevel` |
+| `Step` | Step-buffered execution: `withStep`, `success`, `collapse`, `groupStep` |
 | `GitHubToken` | GitHub App installation-token lifecycle: `provision`, `client`, `read`, `botIdentity`, `dispose` |
 | `GitHubClientLive` | `GitHubClient` layer constructors: `fromEnv`, `fromToken`, `fromApp` |
 | `GithubMarkdown` | Pure GFM builder functions: `table`, `heading`, `bold`, `details`, `checklist`, etc. |
@@ -87,6 +95,7 @@ const program = Effect.gen(function* () {
 | `SemverResolver` | Semver comparison, range satisfaction, increment, parse |
 | `ErrorAccumulator` | Process items collecting all successes and failures |
 | `ReportBuilder` | Fluent builder for markdown reports |
+| `RegistryClassifier` | Classify a registry URL as npm, GitHub Packages, a private registry or unknown |
 
 ## See also
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -57,7 +57,7 @@ const program = Effect.gen(function* () {
 | GitHubIssue | List, close, comment and get issues |
 | GitHubContent | Read repository file contents at a ref |
 | GitHubCommit | Read the commit graph (get, list, compare) |
-| GitHubArtifactMetadata | Read and write GitHub Packages artifact-metadata storage records |
+| GitHubArtifactMetadata | Create GitHub Packages artifact-metadata storage records |
 | GitHubApp | GitHub App token lifecycle with bracket pattern |
 | CheckRun | Create, update and complete check runs with annotations |
 | PullRequest | PR lifecycle: get, list, create, update, merge, listFiles, baseSha, labels, reviewers |

--- a/package.json
+++ b/package.json
@@ -58,8 +58,11 @@
 	},
 	"dependencies": {
 		"@azure/storage-blob": "^12.31.0",
+		"@cyclonedx/cyclonedx-library": "^10.0.0",
 		"@octokit/auth-app": "^8.2.0",
 		"@octokit/rest": "^22.0.1",
+		"@sigstore/bundle": "^4.0.0",
+		"@sigstore/sign": "^4.1.1",
 		"jsonc-effect": "^0.2.1",
 		"semver-effect": "^0.2.1",
 		"yaml-effect": "^0.6.0"
@@ -73,7 +76,7 @@
 		"@savvy-web/changesets": "^0.10.0",
 		"@savvy-web/commitlint": "^0.9.0",
 		"@savvy-web/lint-staged": "^1.0.1",
-		"@savvy-web/rslib-builder": "^0.20.3",
+		"@savvy-web/rslib-builder": "^0.20.4",
 		"@savvy-web/vitest": "^1.3.2",
 		"effect": "catalog:silk"
 	},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,12 +42,21 @@ importers:
       '@azure/storage-blob':
         specifier: ^12.31.0
         version: 12.31.0
+      '@cyclonedx/cyclonedx-library':
+        specifier: ^10.0.0
+        version: 10.0.0(ajv-formats@3.0.1(ajv@8.18.0))(ajv@8.18.0)
       '@octokit/auth-app':
         specifier: ^8.2.0
         version: 8.2.0
       '@octokit/rest':
         specifier: ^22.0.1
         version: 22.0.1
+      '@sigstore/bundle':
+        specifier: ^4.0.0
+        version: 4.0.0
+      '@sigstore/sign':
+        specifier: ^4.1.1
+        version: 4.1.1
       jsonc-effect:
         specifier: ^0.2.1
         version: 0.2.1(effect@3.21.2)
@@ -75,19 +84,19 @@ importers:
         version: 0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2)
       '@savvy-web/changesets':
         specifier: ^0.10.0
-        version: 0.10.0(@changesets/cli@2.31.0(@types/node@25.8.0))(@effect/cluster@0.58.2(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/workflow@0.18.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(effect@3.21.2))(effect@3.21.2))(@effect/printer-ansi@0.49.0(@effect/typeclass@0.40.0(effect@3.21.2))(effect@3.21.2))(@effect/printer@0.49.0(@effect/typeclass@0.40.0(effect@3.21.2))(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))
+        version: 0.10.0(@changesets/cli@2.31.0(@types/node@25.9.1))(@effect/cluster@0.58.2(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/workflow@0.18.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(effect@3.21.2))(effect@3.21.2))(@effect/printer-ansi@0.49.0(@effect/typeclass@0.40.0(effect@3.21.2))(effect@3.21.2))(@effect/printer@0.49.0(@effect/typeclass@0.40.0(effect@3.21.2))(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))
       '@savvy-web/commitlint':
         specifier: ^0.9.0
-        version: 0.9.0(@commitlint/cli@20.5.3(@types/node@25.8.0)(conventional-commits-parser@6.4.0)(typescript@5.9.3))(@commitlint/config-conventional@20.5.3)(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/typeclass@0.40.0(effect@3.21.2))(@effect/workflow@0.18.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(effect@3.21.2))(commitizen@4.3.1(@types/node@25.8.0)(typescript@5.9.3))(husky@9.1.7)
+        version: 0.9.0(@commitlint/cli@20.5.3(@types/node@25.9.1)(conventional-commits-parser@6.4.0)(typescript@5.9.3))(@commitlint/config-conventional@20.5.3)(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/typeclass@0.40.0(effect@3.21.2))(@effect/workflow@0.18.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(effect@3.21.2))(commitizen@4.3.1(@types/node@25.9.1)(typescript@5.9.3))(husky@9.1.7)
       '@savvy-web/lint-staged':
         specifier: ^1.0.1
-        version: 1.0.1(b3913e0c25b2ca92183434221f153154)
+        version: 1.0.1(f2a8555238dbf5cde762ee23c09148a2)
       '@savvy-web/rslib-builder':
-        specifier: ^0.20.3
-        version: 0.20.3(@pnpm/logger@1001.0.1)(@rslib/core@0.21.5(@microsoft/api-extractor@7.58.7(@types/node@25.8.0))(@typescript/native-preview@7.0.0-dev.20260515.1)(typescript@5.9.3))(@types/node@25.8.0)(@typescript/native-preview@7.0.0-dev.20260515.1)(jiti@2.6.1)(typescript@5.9.3)
+        specifier: ^0.20.4
+        version: 0.20.4(@pnpm/logger@1001.0.1)(@rslib/core@0.21.5(@microsoft/api-extractor@7.58.7(@types/node@25.9.1))(@typescript/native-preview@7.0.0-dev.20260519.1)(typescript@5.9.3))(@types/node@25.9.1)(@typescript/native-preview@7.0.0-dev.20260519.1)(jiti@2.6.1)(typescript@5.9.3)
       '@savvy-web/vitest':
         specifier: ^1.3.2
-        version: 1.3.2(003ae254b51b79a5e2095f7fac8ef1b5)
+        version: 1.3.2(89d6e39c26f70fd9d0b890d721f9ebe5)
       effect:
         specifier: catalog:silk
         version: 3.21.2
@@ -400,6 +409,33 @@ packages:
       conventional-commits-parser:
         optional: true
 
+  '@cyclonedx/cyclonedx-library@10.0.0':
+    resolution: {integrity: sha512-xDXf2eqzeFHdjamj6oBV3duRSfrlmsJ5+2z9tXp7q5qxJP5Awmjf4ABSutS4qkVHHj7JzKFL/EM0V0Nihc7zPg==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      ajv: ^8.12.0
+      ajv-formats: ^3.0.1
+      ajv-formats-draft2019: ^1.6.1
+      libxmljs2: ^0.35||^0.37
+      packageurl-js: '*'
+      spdx-expression-parse: '*'
+      xmlbuilder2: ^3.0.2||^4.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+      ajv-formats:
+        optional: true
+      ajv-formats-draft2019:
+        optional: true
+      libxmljs2:
+        optional: true
+      packageurl-js:
+        optional: true
+      spdx-expression-parse:
+        optional: true
+      xmlbuilder2:
+        optional: true
+
   '@effect/cli@0.75.1':
     resolution: {integrity: sha512-aDZ1OZzaFAb6NyBOrP+Bl52eICds5ERI9aa67LzloJELt5SCWeNwthtaEacBvvMkwVUcykJ+YHcGCkD1t47g8g==}
     peerDependencies:
@@ -538,6 +574,10 @@ packages:
     resolution: {integrity: sha512-rZAP3aVgB9ds9KOeUSL+zZ21hPmo8dh6fnIFwRQj5EAZl9gzR7wxYbYXYysAM8CTqGmUGyp2S4kUdV17MnGuWQ==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
+  '@gar/promise-retry@1.0.3':
+    resolution: {integrity: sha512-GmzA9ckNokPypTg10pgpeHNQe7ph+iIKKmhKu3Ob9ANkswreCx7R3cKmY781K8QK3AqVL3xVh9A42JvIAbkkSA==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
   '@gwhitney/detect-indent@7.0.1':
     resolution: {integrity: sha512-7bQW+gkKa2kKZPeJf6+c6gFK9ARxQfn+FKy9ScTBppyKRWH2KzsmweXUoklqeEiHiNVWaeP5csIdsNq6w7QhzA==}
     engines: {node: '>=12.20'}
@@ -666,6 +706,18 @@ packages:
   '@nodelib/fs.walk@1.2.8':
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
+
+  '@npmcli/agent@4.0.0':
+    resolution: {integrity: sha512-kAQTcEN9E8ERLVg5AsGwLNoFb+oEG6engbqAU2P43gD4JEIkNGMHdVQ096FsOAAYpZPB0RSt0zgInKIAS1l5QA==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
+  '@npmcli/fs@5.0.0':
+    resolution: {integrity: sha512-7OsC1gNORBEawOa5+j2pXN9vsicaIOH5cPXxoR6fJOmH6/EXpJB2CajXOu1fPRFun2m1lktEFX11+P89hqO/og==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
+  '@npmcli/redact@4.0.0':
+    resolution: {integrity: sha512-gOBg5YHMfZy+TfHArfVogwgfBeQnKbbGo3pSUyK/gSI0AVu+pEiDVcKlQb0D8Mg1LNRZILZ6XG8I5dJ4KuAd9Q==}
+    engines: {node: ^20.17.0 || >=22.9.0}
 
   '@octokit/auth-app@8.2.0':
     resolution: {integrity: sha512-vVjdtQQwomrZ4V46B9LaCsxsySxGoHsyw6IYBov/TqJVROrlYdyNgw5q6tQbB7KZt53v1l1W53RiqTvpzL907g==}
@@ -868,8 +920,8 @@ packages:
     resolution: {integrity: sha512-Zq7m0/2wT/9BgXtk0ue5OC6MeHk+KpbDICmSKybeSy7NQ7sWreiDXhRBnipRLDo21vY7nLuXRsRLopk+3cCmoQ==}
     engines: {node: '>=22.13'}
 
-  '@pnpm/deps.path@1100.0.3':
-    resolution: {integrity: sha512-kppGx/qLad54Pf1bJtEy6QL+g0FjUBcl12aYZ2pcvOoITcY6Zsk/ZDo2o9Bn2aBGPbIu+XdepAf95ppW5vfxRQ==}
+  '@pnpm/deps.path@1100.0.4':
+    resolution: {integrity: sha512-sEKQFk/EyickTHmDw1rkJ1PIUy8i76I5QsbocJ1/HeO+oLvm2vu7Jmf/7+hny/t6PkyoRioV/YRx4vWSsfuAgQ==}
     engines: {node: '>=22.13'}
 
   '@pnpm/error@1000.1.0':
@@ -884,8 +936,8 @@ packages:
     resolution: {integrity: sha512-rtUWmIKzloHwxgP16PYxTdr3+1lyuBH1JG5Gkgyca32dfmqy3Y55oEfkLywU2NYf/Zvk0C5gHaAMTFZOxuW8kg==}
     engines: {node: '>=18.12'}
 
-  '@pnpm/fetching.fetcher-base@1100.1.3':
-    resolution: {integrity: sha512-91W1zmxbLrKiAd3UM4x/gYeBwwMOdP7aFmykY3qPXE/VT1IyM05hDrhw7jdD8yZ/4wmq64u9meME3kB0/7kosw==}
+  '@pnpm/fetching.fetcher-base@1100.1.5':
+    resolution: {integrity: sha512-Lm8wpqg0AQDuFYNAaL/HddpjPF+JVRFk7IHsueNp8seLTybL4t9+W+45fTM/E5SYPJWlzue7cIHf0Zg9j78syA==}
     engines: {node: '>=22.13'}
 
   '@pnpm/fs.graceful-fs@1100.1.0':
@@ -896,26 +948,26 @@ packages:
     resolution: {integrity: sha512-EsMX4slK0qJN2AR0/AYohY5m0HQNYGMNe+jhN74O994zp22/WbX+PbkIKyw3UQn39yQm2+z6SgwklDxbeapsmQ==}
     engines: {node: '>=18.12'}
 
-  '@pnpm/hooks.types@1100.0.6':
-    resolution: {integrity: sha512-CA9HcnBT06gczl8c9kIrMahNI6g002mw2GePR6wpScrddiuS3BTQPB2pySPoJiq+6DEbYwxInGMEj+VH8KRL1g==}
+  '@pnpm/hooks.types@1100.0.8':
+    resolution: {integrity: sha512-6RIiwedtLCAac2gftDHsP1KZs70v6QFzn//PQ+hMcnYq2M9Kt8U5//x9bA9Wxt1aQtRZTamoCVKJBDgK8K7rIg==}
     engines: {node: '>=22.13'}
 
-  '@pnpm/lockfile.fs@1100.0.8':
-    resolution: {integrity: sha512-taYfHVfEfLtTw+pkjVl9iBuqIWb9/eQP56DZ58mO4dHQOiEU19f/njPLHmBU+amw3qZo4iu2iSQme1hA/yf4ng==}
+  '@pnpm/lockfile.fs@1100.1.1':
+    resolution: {integrity: sha512-+yDUe8hTE3+DIPkneh3O7+m+7F4vZRak/W202VSxPWAE1N2imQ4J9QahNYp/U/T7toFZnE7PumHaHScoicOYfw==}
     engines: {node: '>=22.13'}
     peerDependencies:
       '@pnpm/logger': '>=1001.0.0 <1002.0.0'
 
-  '@pnpm/lockfile.merger@1100.0.5':
-    resolution: {integrity: sha512-RxYdS61WzK0SjSk7kwaEF1fWsBvAta5olXNbaIgRxrV6ZO5Au/GTIZ4+BA9Pe7q5RWFSpcSdX6W2gjEX9QS+9Q==}
+  '@pnpm/lockfile.merger@1100.0.7':
+    resolution: {integrity: sha512-KIpQwRycrrMxlZFe1Y2tAa0cCynbdcskgA/Ng5iM23VpBKfrbhmYapivXpwVvU1QTezMOmA+ya5fjerEpsoWGA==}
     engines: {node: '>=22.13'}
 
-  '@pnpm/lockfile.types@1100.0.5':
-    resolution: {integrity: sha512-lAF9J34VKS7j+jWcM8h//EoNARmj/gG0YKFgqadTbj1+rCgep1N57xIo3kg4tbtlVLHXH9cM/yX7UxUtJt7mXQ==}
+  '@pnpm/lockfile.types@1100.0.7':
+    resolution: {integrity: sha512-IBaBsC4/zSLM105EBNvlHc4qXVBXgHz6L//+yi2EJDnnSYL8tp6SUn4ZR1RiZjNb7tF9x8UXwySsUqXJ4oWobA==}
     engines: {node: '>=22.13'}
 
-  '@pnpm/lockfile.utils@1100.0.7':
-    resolution: {integrity: sha512-BWWmNaHjaAxcLpfHaHo4pS+EfvszwnOww92gs3mynTQdv/Wnn5nY+4Uljgovc5wpqtV6tb7pEn/3A/6gHUwDKQ==}
+  '@pnpm/lockfile.utils@1100.0.9':
+    resolution: {integrity: sha512-AslLH4xnIVaeEHEcpCuIum9wkrm1uKHz0aU8cRgm44uAE3s7Vd++SgebQ7cKyClNyZ19/hsAHjXrHTZBp6TAKg==}
     engines: {node: '>=22.13'}
 
   '@pnpm/logger@1001.0.1':
@@ -953,8 +1005,8 @@ packages:
     resolution: {integrity: sha512-oxf+Y5lumvfNx9Igss/dvDb0t4iWtE0wjrmdDPFkVrXTlQbdWLujnyYSp3Obim/65K+r5RspoizJgjWJRe69nw==}
     engines: {node: '>=18.12'}
 
-  '@pnpm/resolving.resolver-base@1100.1.3':
-    resolution: {integrity: sha512-Phy0I8TnUbILfxwjFn6lTvud0zWUS8yWZooOPh8OFnuclcl0E3QmpvpirANJX6Xt5PhrxPydQ5xlLFnOY9gWlw==}
+  '@pnpm/resolving.resolver-base@1100.3.0':
+    resolution: {integrity: sha512-kHAf0nWq2hSHicdl6CxSJrGEOq1UM1ArggBUa78fmfztUJIvwUHMUDh+NLDXfU072WA5TkltfSBeWPkGi4qEAQ==}
     engines: {node: '>=22.13'}
 
   '@pnpm/semver.peer-range@1000.0.0':
@@ -973,8 +1025,8 @@ packages:
     resolution: {integrity: sha512-NLTXheat/u7OEGg5M5vF6Z85zx8uKUZE0+whtX/sbFV2XL48RdnOWGPTKYuVVkv8M+launaLUTgGEXNs/ess2w==}
     engines: {node: '>=18.12'}
 
-  '@pnpm/types@1101.1.0':
-    resolution: {integrity: sha512-GHsA28MMPIloKhcLC+EFBH8rUtfcailUsp6ms1jeYZsEXLsbgi8cnpftxohFx+A0W3i7+eQdMX6RXvdctZ7qWQ==}
+  '@pnpm/types@1101.1.1':
+    resolution: {integrity: sha512-uKcYehlSNA5OOHbWnuz0SAl/o/DKBkYqfDjD2FHJV59dP3xTPYR9J6XpZY4+ccKr1Tux2TomtrrPYbG5fXDQIw==}
     engines: {node: '>=22.13'}
 
   '@pnpm/util.lex-comparator@3.0.2':
@@ -1110,64 +1162,64 @@ packages:
       typescript:
         optional: true
 
-  '@rspack/binding-darwin-arm64@2.0.3':
-    resolution: {integrity: sha512-4UyCjLJwU/WxR6K1/gG4u3+jUsoaRHJ5rNu9fto/UbvrItwdlVNULChAApqZFw6mcSetMddSjSICeuj5pSB6sA==}
+  '@rspack/binding-darwin-arm64@2.0.4':
+    resolution: {integrity: sha512-0Q1QXFEsZfDc4opiDnb8q50KlBbC2VovViDaYlMJZBzvjAo325mh3itXPfz7YZ31M+TxRE7TUiJXH3ltiV1Hdg==}
     cpu: [arm64]
     os: [darwin]
 
-  '@rspack/binding-darwin-x64@2.0.3':
-    resolution: {integrity: sha512-K3evrbTgZNa8emEqk+AjDtbuoXZp5tPZz3pcEgETxuu3KanW8Zu+Fb+TUp1DEUcL0xOmHPPox8H2cZ3pF4Zmug==}
+  '@rspack/binding-darwin-x64@2.0.4':
+    resolution: {integrity: sha512-oO5J2QYf7+H+aYRj85EiGrDOoDEE9EDDl7NgXv46iWvIF0wXowEHXqnjMFxHxRq2Vf6scT+0yYQX9blWcvMWAA==}
     cpu: [x64]
     os: [darwin]
 
-  '@rspack/binding-linux-arm64-gnu@2.0.3':
-    resolution: {integrity: sha512-aPLDaaTtX1wqjLYAIHc2MGDQZtv1Hbjx47oaaefbWz5GbAnSA4P8jdYIeeGRyrqvQ0WqJXIWXgT0d/iXtes00A==}
+  '@rspack/binding-linux-arm64-gnu@2.0.4':
+    resolution: {integrity: sha512-BEk6mIYBK4BihW9qXXITJORrVXecTlkRjrqhgefili4xjXtLdcUnxAm9sN/2oJ8m378n2h33qDh4gr2orPBFWQ==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@rspack/binding-linux-arm64-musl@2.0.3':
-    resolution: {integrity: sha512-0WulUQPop6vmSDfrTxghmVlm+6crU8/XqD2f0dOWbEniZVuDZJ5/Y/cBqTRyk3rjl0vrmUv3lc87/t7UgQJQSw==}
+  '@rspack/binding-linux-arm64-musl@2.0.4':
+    resolution: {integrity: sha512-Hyt3z1RwNcSMIoaoWLN4Hb/696/O5JPukf8rXQASvf2UkC+X3ij7tr+8lMSYi3Zysi1QL375CnT4fNoABEW0JA==}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@rspack/binding-linux-x64-gnu@2.0.3':
-    resolution: {integrity: sha512-fAhiMuV5omT53YMft+f3Y9euAFgspuyBAk9ZpeW2buL2TkuUMwP07adhhvQfKdQ5gpELfzmjQaRDGqaIT8UWiA==}
+  '@rspack/binding-linux-x64-gnu@2.0.4':
+    resolution: {integrity: sha512-xHorBPBZAg0Pn9Q0k9dWZ9euowieDxcSOzQ9JhTCmhDY6wZH5M/kCBFlCs/OQeW5/NUArW3x3MwEdO/0QJHMxg==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@rspack/binding-linux-x64-musl@2.0.3':
-    resolution: {integrity: sha512-0kcuFoZ8vy2iNWoISFOZt+/Ujo7LRLrzE7h07AV5r+oN/mv+/v14Sd/8NUtDIScCkrYOszYq/QS31e6t0UrVfw==}
+  '@rspack/binding-linux-x64-musl@2.0.4':
+    resolution: {integrity: sha512-QLxEGUXofF0kVNU12Y2NT3Qi9lGs+WbnYpapVeb+2IXtrAXJfU7Rhy7lAp5GLMzYMQNrKKL9SVnTWKbODbNW9Q==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@rspack/binding-wasm32-wasi@2.0.3':
-    resolution: {integrity: sha512-x2fsw7GzNZEnw444ikj4/b8kVjM0Y0TllxmizHpYZ9gmaQrOk5OXo9RQdz+l4zzoGors0l2IZP5Cc4GJNCaSoQ==}
+  '@rspack/binding-wasm32-wasi@2.0.4':
+    resolution: {integrity: sha512-YhN8HkiH46ONU9tm5dyoXDImDWGpU7E4SPqGI4OyAVF0445uIChurIUmTIOYcD6cg81GGeIjozWJOcb635Dcqw==}
     cpu: [wasm32]
 
-  '@rspack/binding-win32-arm64-msvc@2.0.3':
-    resolution: {integrity: sha512-jqlxuVPdrgMuwj/HEjSkC/jmhl4fAuKyob36zJXq2uAusn2FRJ4kClGe1fLFpfxRXFVQAWwlAOwLJg8T0suuaA==}
+  '@rspack/binding-win32-arm64-msvc@2.0.4':
+    resolution: {integrity: sha512-MUlYIz82xQRN0aoiXXyEBrNVUwiOSSFRi7nuCgUKduaSdlbPWzCY31IdtOygZ06LVp5JIGUEtyqSrjQq4FrMRw==}
     cpu: [arm64]
     os: [win32]
 
-  '@rspack/binding-win32-ia32-msvc@2.0.3':
-    resolution: {integrity: sha512-QM4JEuyk5QaZ5gnvnAIaCwVQzCkrD2E4Sud77kx/MVGDsRkcOlMx3blMC5QNHPDamRmWGk+7314YOQvRhKuWyg==}
+  '@rspack/binding-win32-ia32-msvc@2.0.4':
+    resolution: {integrity: sha512-D7UcIFMzlY2yhhyuW4Ej15gBWmTwUM5DxuObl3Kv31qRv/pmV3MsqUeG5m2dqLbUxzqPH87qnp0cArbkJQ1b+w==}
     cpu: [ia32]
     os: [win32]
 
-  '@rspack/binding-win32-x64-msvc@2.0.3':
-    resolution: {integrity: sha512-vSQNnAy0wswG6AfNRuArTHQBiXOXl+A9ddQxBFup4PMHUzXxKtsBLQzw7BgFC0EgrPeHbt+30j7sXVZKYukj4A==}
+  '@rspack/binding-win32-x64-msvc@2.0.4':
+    resolution: {integrity: sha512-MnYKPfdrAEbtpKg/1SZ6cNtzreIRyQJK4APbxLLPXENdTH5QXQkaTjLMKEeJcJ51FRhI/+yNpOUm2oTHdCQ1Og==}
     cpu: [x64]
     os: [win32]
 
-  '@rspack/binding@2.0.3':
-    resolution: {integrity: sha512-4exVNhGhW5RFHjK87XeTKbkA/qAgI5NHJlT1jNqiJv0gcUXLqTOEU3w7f8+f9zUo4JMFvPc0c9veOi4M19YYTg==}
+  '@rspack/binding@2.0.4':
+    resolution: {integrity: sha512-/QeJDPUw/lWkBJESG264KA9u6/rAjvoJhKncU4rkTi5Ap45kue5HTgOzr0ufxKdd2Xl72fjFBuqlKmtFDD5LiQ==}
 
-  '@rspack/core@2.0.3':
-    resolution: {integrity: sha512-2ufO/8FHIA/lX6UOgSsKPhpDvHr0sh9lYq/n/LsIZsTwu3973BGbu2fg1Akvuu3rEnskPqXjsqH2EPBzEA42uA==}
+  '@rspack/core@2.0.4':
+    resolution: {integrity: sha512-OuxdQeeKWQpNvFBRDOcnoSaQvp6E4APM/6JJMM/k0p6oL1TEFQVGdNu3VGY4mRAsebnNBXapMVMhj+v66Bn2pg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
       '@module-federation/runtime-tools': ^0.24.1 || ^2.0.0
@@ -1242,15 +1294,15 @@ packages:
       '@biomejs/biome':
         optional: true
 
-  '@savvy-web/rslib-builder@0.20.3':
-    resolution: {integrity: sha512-K/ncsK4h/KG5q9bYvom67rc9S6C8HUtBU1Ld8vzNMOeyfd0Z27KXBfWfRtr+ImwnHiQMvYSRDTPcr35eO9WiqA==}
+  '@savvy-web/rslib-builder@0.20.4':
+    resolution: {integrity: sha512-6SreJCG2lYyfzfYctbRyJLSvtdEhvlcAvLsb1GVD6whQOfEbfJwZEs9VC1QPLCzBHbvjweYjYqp3xJ18gPUk8A==}
     peerDependencies:
       '@rsbuild/plugin-react': ^2.0.0
       '@rslib/core': ^0.21.0
       '@types/node': ^25.6.0
       '@types/react': ^19.2.0
       '@types/react-dom': ^19.2.0
-      '@typescript/native-preview': ^7.0.0-dev.20260124.1
+      '@typescript/native-preview': ^7.0.0-dev.20260513.1
       react: ^19.2.0
       react-dom: ^19.2.0
       typescript: ^6.0.0
@@ -1284,6 +1336,22 @@ packages:
 
   '@sec-ant/readable-stream@0.4.1':
     resolution: {integrity: sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==}
+
+  '@sigstore/bundle@4.0.0':
+    resolution: {integrity: sha512-NwCl5Y0V6Di0NexvkTqdoVfmjTaQwoLM236r89KEojGmq/jMls8S+zb7yOwAPdXvbwfKDlP+lmXgAL4vKSQT+A==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
+  '@sigstore/core@3.2.0':
+    resolution: {integrity: sha512-kxHrDQ9YgfrWUSXU0cjsQGv8JykOFZQ9ErNKbFPWzk3Hgpwu8x2hHrQ9IdA8yl+j9RTLTC3sAF3Tdq1IQCP4oA==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
+  '@sigstore/protobuf-specs@0.5.1':
+    resolution: {integrity: sha512-/ScWUhhoFasJsSRGTVBwId1loQjjnjAfE4djL6ZhrXRpNCmPTnUKF5Jokd58ILseOMjzET3UrMOtJPS9sYeI0g==}
+    engines: {node: ^18.17.0 || >=20.5.0}
+
+  '@sigstore/sign@4.1.1':
+    resolution: {integrity: sha512-Hf4xglukg0XXQ2RiD5vSoLjdPe8OBUPA8XeVjUObheuDcWdYWrnH/BNmxZCzkAy68MzmNCxXLeurJvs6hcP2OQ==}
+    engines: {node: ^20.17.0 || >=22.9.0}
 
   '@simple-libs/child-process-utils@1.0.2':
     resolution: {integrity: sha512-/4R8QKnd/8agJynkNdJmNw2MBxuFTRcNFnE5Sg/G+jkSsV8/UBgULMzhizWWW42p8L5H7flImV2ATi79Ove2Tw==}
@@ -1375,8 +1443,8 @@ packages:
   '@types/node@12.20.55':
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
 
-  '@types/node@25.8.0':
-    resolution: {integrity: sha512-TCFSk8IZh+iLX1xtksoBVtdmgL+1IX0fC9BeU4QqFSuNdN/K+HUlhqOzEmSYYpZUVsLYcPqc9KX+60iDuninSQ==}
+  '@types/node@25.9.1':
+    resolution: {integrity: sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==}
 
   '@types/parse-path@7.1.0':
     resolution: {integrity: sha512-EULJ8LApcVEPbrfND0cRQqutIOdiIgJ1Mgrhpy755r14xMohPTEpkV/k28SJvuOs9bHRFW8x+KeDAEPiGQPB9Q==}
@@ -1391,8 +1459,8 @@ packages:
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
 
-  '@typescript-eslint/parser@8.59.3':
-    resolution: {integrity: sha512-HPwA+hVkfcriajbNvTmZv4VRauibay+cWArYUYq7u7W7PmGShMxbPxLvrwDme55a6d5alG3nrYfhyJ/G28XlLg==}
+  '@typescript-eslint/parser@8.59.4':
+    resolution: {integrity: sha512-zORHqO/tuhxY1zWuTvMUqddRxpiFJ72xVfcNoWpqdLjs6lfPbuQBJuW4pk+49/uBMy7Ssr4bzgjiKmmDB1UbZQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
@@ -1404,8 +1472,8 @@ packages:
     peerDependencies:
       typescript: '>=4.8.4 <6.0.0'
 
-  '@typescript-eslint/project-service@8.59.3':
-    resolution: {integrity: sha512-ECiUWa/KYRGDFUqTNehaRgzDshnJfkTABJxVemHk4ko22gcr0ukloKjWvyQ64g8YCV/UI47kN1dbmjf/GaQYng==}
+  '@typescript-eslint/project-service@8.59.4':
+    resolution: {integrity: sha512-Ly00Vu4oAacfDeHp2Zg85ioNG6l8HG+tN1D7J+xTHSxu9y0awYKJ2zH1rFBn8ZSfuGK+7FxK3Cgl3uAz0aZZLg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '>=4.8.4 <6.1.0'
@@ -1414,8 +1482,8 @@ packages:
     resolution: {integrity: sha512-YAi4VDKcIZp0O4tz/haYKhmIDZFEUPOreKbfdAN3SzUDMcPhJ8QI99xQXqX+HoUVq8cs85eRKnD+rne2UAnj2w==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@typescript-eslint/scope-manager@8.59.3':
-    resolution: {integrity: sha512-t2LvZnoEfzKtnPjgeEu41xw5gxq9mQVfYy4OoZ4Vlt0sk3JwxmhCca/AR7DwOiHrjWgjAj6as4AhRLKSDfvZIA==}
+  '@typescript-eslint/scope-manager@8.59.4':
+    resolution: {integrity: sha512-mUeR/3H1WrTAddJrwut8OoPjfauaztMQmRwV5fQTUyNVJCLiUXXe4lGEyYIL2oFDpP7UtgbGJXCt72wT0z2S3Q==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@typescript-eslint/tsconfig-utils@8.56.1':
@@ -1424,8 +1492,8 @@ packages:
     peerDependencies:
       typescript: '>=4.8.4 <6.0.0'
 
-  '@typescript-eslint/tsconfig-utils@8.59.3':
-    resolution: {integrity: sha512-PcIJHjmaREXLgIAIzLnSY9VucEzz8FKXsRgFa1DmdGCK/5tJpW03TKJF01Q6VZd1lLdz2sIKPWaDUZN9dp//dw==}
+  '@typescript-eslint/tsconfig-utils@8.59.4':
+    resolution: {integrity: sha512-DLCpnKgD4alVxTBSKulK+gU1KCqOgUXfDRDXh2mZgzokQKa/70ax93I2uVO3m/LLvIAtWZIFoiifudmIqAxpMA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '>=4.8.4 <6.1.0'
@@ -1434,8 +1502,8 @@ packages:
     resolution: {integrity: sha512-dbMkdIUkIkchgGDIv7KLUpa0Mda4IYjo4IAMJUZ+3xNoUXxMsk9YtKpTHSChRS85o+H9ftm51gsK1dZReY9CVw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@typescript-eslint/types@8.59.3':
-    resolution: {integrity: sha512-ePFoH0g4ludssdRFqqDxQePCxU4WQyRa9+XVwjm7yLn0FKhMeoetC+qBEEI1Eyb1pGSDveTIT09Bvw2WhlGayg==}
+  '@typescript-eslint/types@8.59.4':
+    resolution: {integrity: sha512-F1o7WJcCq+bc8dwcO/YsSEOudAH8RDtaOhM6wcAQhcUsFhnWQl81JKy48q1hoxAU0qrzM89+31GYh1515Zde3Q==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@typescript-eslint/typescript-estree@8.56.1':
@@ -1444,8 +1512,8 @@ packages:
     peerDependencies:
       typescript: '>=4.8.4 <6.0.0'
 
-  '@typescript-eslint/typescript-estree@8.59.3':
-    resolution: {integrity: sha512-CbRjVRAf7Lr9Kr8RopKcbY45p2VfmmHrm0ygOCYFi7oU8q19m0Fs/6iHS7kNOmwpp+ob07ZVcAqlxUod9lYdmg==}
+  '@typescript-eslint/typescript-estree@8.59.4':
+    resolution: {integrity: sha512-F+RuOmcDXo4+TPdfd/TCLS3m2nw8gE9XXyZLrA3JBfaA5tz9TtdkyD3YJFmPxulyc2cKbEok/CvFE3MgSLWnag==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '>=4.8.4 <6.1.0'
@@ -1461,54 +1529,54 @@ packages:
     resolution: {integrity: sha512-KiROIzYdEV85YygXw6BI/Dx4fnBlFQu6Mq4QE4MOH9fFnhohw6wX/OAvDY2/C+ut0I3RSPKenvZJIVYqJNkhEw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@typescript-eslint/visitor-keys@8.59.3':
-    resolution: {integrity: sha512-f1UQF7ggd42YiwI5wGrRaPsa+P0CINBlrkLPmGfpq/u/I/oVtecoEIfFR9ag/oa1sLOsRNZ6xehf6qMZhQGBDg==}
+  '@typescript-eslint/visitor-keys@8.59.4':
+    resolution: {integrity: sha512-U3gxVaDVnuZKhSspW/MzMxE1kq7zOdc072FcSNoqA1I9p8HyKbBFfEHoWckBAMgNMph4MamwS5iTVzFmrnt8TQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260515.1':
-    resolution: {integrity: sha512-CSvyLkNV0k4Ro0B6nzNdDXFrRD8aa6sDvXSGla2FTmBio+JLKqNuJXq1ppyj42j9pAwdUhDZV/PNdjeHRCBjWQ==}
+  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260519.1':
+    resolution: {integrity: sha512-c9zdG6sGJf25Jpz04JgE23zhYeprqFypDGuqiX94yMTvR8IWXjq3R2oMnim66YLBDon/V1nCEy6cFixeSd/4fg==}
     engines: {node: '>=16.20.0'}
     cpu: [arm64]
     os: [darwin]
 
-  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260515.1':
-    resolution: {integrity: sha512-QTmm0dpF6CC3hrfudAyVcIvbr1tlBTZ7aGQHIs4PYmi+tnTi2R8jy6gDBCJWlDBSXqjPWlQZrdiOxRBCSlShSA==}
+  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260519.1':
+    resolution: {integrity: sha512-N16V3wiM0tsNmSSA7nZrxqXXt5OCJxBwiCVn35rnA7fr4WzJw6rJmwf9heNNhZ6Gh4ne3+Pexajf5akzuHR75Q==}
     engines: {node: '>=16.20.0'}
     cpu: [x64]
     os: [darwin]
 
-  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260515.1':
-    resolution: {integrity: sha512-bH/CYrtXURXr3YwqJmlKblQ858wuJ0Qw2VSMvlsWwYZpb8eOd07T2bl1Ba6QxGBuL6EotcDQFd2OYJIj0uvM7A==}
+  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260519.1':
+    resolution: {integrity: sha512-ltf91vAwKdbu0SlRQbFgi1h5ZrLLrBn6a4qIeN2VILGbtYrCXnARHRznLBv81yUETQ7aVr/LSQcmsWo1ejCK0w==}
     engines: {node: '>=16.20.0'}
     cpu: [arm64]
     os: [linux]
 
-  '@typescript/native-preview-linux-arm@7.0.0-dev.20260515.1':
-    resolution: {integrity: sha512-0b+Sxh8JUNMqvw06wfIoh45+G68/ikCW+aRqHGipU2uc9M9dWUKvI3zDyzP1rF6FOJ7xMKMbTbi5b2IvcRqh8g==}
+  '@typescript/native-preview-linux-arm@7.0.0-dev.20260519.1':
+    resolution: {integrity: sha512-8v4BExeeuCTrhaSGfeIJqm3qQkTzlZix/Qd/FkPlWoz9f7d7COvXb3Z4qhbaVolL0MMnUvQ7m005Z4kYsZ645A==}
     engines: {node: '>=16.20.0'}
     cpu: [arm]
     os: [linux]
 
-  '@typescript/native-preview-linux-x64@7.0.0-dev.20260515.1':
-    resolution: {integrity: sha512-eXgYE6pmkCiEEX7T43TYeF24uiY8+h9mbi9YSvnCoRp4BLgn9b7uJagh4ctSGCNxUy3QSDeoznkWfSVlrvJ5pA==}
+  '@typescript/native-preview-linux-x64@7.0.0-dev.20260519.1':
+    resolution: {integrity: sha512-AVD0tczTtFCHNa4RQRVPvu8Hnw4P3hQ+OlUAjnz/lHowvc6o1pYB46elMqfDuaoWqIpv+EAkAPP4ipFCofJ5IA==}
     engines: {node: '>=16.20.0'}
     cpu: [x64]
     os: [linux]
 
-  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260515.1':
-    resolution: {integrity: sha512-K1YJimcOr3/lFTJyOChT1GnRdfvoHtIvG/qcwHhHpeCBzpGfG7u2aH9MkBgsXqNJHAXHLnQRuON2uYgU8wWDzw==}
+  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260519.1':
+    resolution: {integrity: sha512-TM+qatljyejqjHevCta3WIH53i0oGC7K8SoJ6t+mf4cGMTpZTyd7NhC1ts7e6/aydZnG53Bsta2iQi1SMIlQEw==}
     engines: {node: '>=16.20.0'}
     cpu: [arm64]
     os: [win32]
 
-  '@typescript/native-preview-win32-x64@7.0.0-dev.20260515.1':
-    resolution: {integrity: sha512-1cGEWLao/d2+Q3yMvtnDES85sM9HuI6J6PBmrcjwXzsQxnjXJkujStdp+LB6JZfY+VSDi+cpaCZmrKU6sYUfkg==}
+  '@typescript/native-preview-win32-x64@7.0.0-dev.20260519.1':
+    resolution: {integrity: sha512-r9LEsoY7JC/82gXo8hlOmpQaUXcqmngCVOv+mUx1UeMt9f+1S6oNO0W48o75mlBqqC7jfcMHqw8YS4LfVxPRGw==}
     engines: {node: '>=16.20.0'}
     cpu: [x64]
     os: [win32]
 
-  '@typescript/native-preview@7.0.0-dev.20260515.1':
-    resolution: {integrity: sha512-dWhzJGb9iJfCDsjz/LzPkbMj5XDbFWyZmDyTixcmQPgX5zFOPZ+sAdlCpTZFGEJhA7OqXG+lZyajbJfjYvQorA==}
+  '@typescript/native-preview@7.0.0-dev.20260519.1':
+    resolution: {integrity: sha512-VVER7vFUDdfm5k3jbH5765tVEJa7+0rTUkFeXyGYrXPxpw9BIjA0QDxdtdlRyaU8MCZV9IKZUo6doxeAQRAjPg==}
     engines: {node: '>=16.20.0'}
     hasBin: true
 
@@ -1516,20 +1584,20 @@ packages:
     resolution: {integrity: sha512-yURCknZhvywvQItHMMmFSo+fq5arCUIyz/CVk7jD89MSai7dkaX8ufjCWp3NttLojoTVbcE72ri+be/TnEbMHw==}
     engines: {node: '>=20.0.0'}
 
-  '@vitest/coverage-v8@4.1.6':
-    resolution: {integrity: sha512-36l628fQ/9a/8ihy97eOtEnvWQEdqULQOJtcaxtoNq0G1w3Mxd4szSahOaMM9/NGyZ+hyKcMtIW/WIxq0XQViQ==}
+  '@vitest/coverage-v8@4.1.7':
+    resolution: {integrity: sha512-qsYPeXc5Q9dFLd1i8Ap+Bx8sQgcp+rFVQo4R0dDsWNBzl26ldVF1qOO+RL24K7FDrR6pA+50XedRLSoSG24bVQ==}
     peerDependencies:
-      '@vitest/browser': 4.1.6
-      vitest: 4.1.6
+      '@vitest/browser': 4.1.7
+      vitest: 4.1.7
     peerDependenciesMeta:
       '@vitest/browser':
         optional: true
 
-  '@vitest/expect@4.1.6':
-    resolution: {integrity: sha512-7EHDquPthALSV0jhhjgEW8FXaviMx7rSqu8W6oqCoAuOhKov814P99QDV1pxMA3QPv21YudvJngIhjrNI4opLg==}
+  '@vitest/expect@4.1.7':
+    resolution: {integrity: sha512-1R+tw0ortHEbZDGMymm+pN7/AFQ/RkFFdtd7EN+VBpynKmLbP8A3rpEXdshBJ7+8hQ9zBJh/i1s0yKNtxAnU7w==}
 
-  '@vitest/mocker@4.1.6':
-    resolution: {integrity: sha512-MCFc63czMjEInOlcY2cpQCvCN+KgbAn+60xu9cMgP4sKaLC5JNAKw7JH8QdAnoAC88hW1IiSNZ+GgVXlN1UcMQ==}
+  '@vitest/mocker@4.1.7':
+    resolution: {integrity: sha512-vY7nuamKgfvpA1Koa3oYIw/k7D6kZnpGyNMZW8loow2bsBYla1TFdqTaXncWdRn4pgwNs+90RhnXhJScDwQeJA==}
     peerDependencies:
       msw: ^2.4.9
       vite: ^6.0.0 || ^7.0.0 || ^8.0.0
@@ -1539,20 +1607,20 @@ packages:
       vite:
         optional: true
 
-  '@vitest/pretty-format@4.1.6':
-    resolution: {integrity: sha512-h5SxD/IzNhZYnrSZRsUZQIC+vD0GY8cUvq0iwsmkFKixRCKLLWqCXa/FIQ4S1R+sI+PGoojkHsdNrbZiM9Qpgw==}
+  '@vitest/pretty-format@4.1.7':
+    resolution: {integrity: sha512-umgCarTOYQWIaDMvGDRZij+6b9oVeLIyJzfN+AS88e0ZOU3QTgNNSTtjQOpcvWr3np1N0j4WgZj+sb3oYBDscw==}
 
-  '@vitest/runner@4.1.6':
-    resolution: {integrity: sha512-nOPCmn2+yD0ZNmKdsXGv/UxMMWbMuKeD6GyYncNwdkYDxpQvrPSKYj2rWuDjC2Y4b6w6hjip5dBKFzEUuZe3vA==}
+  '@vitest/runner@4.1.7':
+    resolution: {integrity: sha512-BapjmAQ2aI78WdMEfeUWivnfVzB+VPGwWRQcJE0OUq7qEeEcBsCSf+0T5iREBNE5nBb4wA5Ya0W6IA+sghdEFw==}
 
-  '@vitest/snapshot@4.1.6':
-    resolution: {integrity: sha512-YhsdE6xAVfTDmzjxL2ZDUvjj+ZsgyOKe+TdQzqkD72wIOmHka8NuGQ6NpTNZv9D2Z63fbwWKJPeVpEw4EQgYxw==}
+  '@vitest/snapshot@4.1.7':
+    resolution: {integrity: sha512-ZacLzja+TmJeZ1h14xW2FB/WpeimUD3haBXQPyJqxvo8jQTmfeA8zv58mtjN2C7EHXZDYVcVYdYmAxjkWVvKCw==}
 
-  '@vitest/spy@4.1.6':
-    resolution: {integrity: sha512-JFKxMx6udhwKh/Ldo270e17QX710vgunMkuPAvXjHSvC6oqLWAHhVhjg/I71q0u0CBSErIODV1Kjv0FQNSWjdg==}
+  '@vitest/spy@4.1.7':
+    resolution: {integrity: sha512-kbkI5LMWakyuTIvs6fUJ5qdIVb1XVKsYJAT4OJ938cHMROYMSfmoQdZy0aaAnjbbc8F61vkoTqz/Az+/HiIu5Q==}
 
-  '@vitest/utils@4.1.6':
-    resolution: {integrity: sha512-FxIY+U81R3LGKCxaHHFRQ5+g6/iRgGLmeHWdp2Amj4ljQRrEIWHmZyDfDYBRZlpyqA7qKxtS9DD1dhk8RnRIVQ==}
+  '@vitest/utils@4.1.7':
+    resolution: {integrity: sha512-T532WBu791cBxJlCl6SO+J14l81DQx6uQHm1bQbmCDY7nqlEIgkza/UFnSBNaUtSf41unldDFjdOBYEQC4b5Hw==}
 
   '@yarnpkg/lockfile@1.1.0':
     resolution: {integrity: sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==}
@@ -1728,6 +1796,10 @@ packages:
   bytes@3.1.2:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
     engines: {node: '>= 0.8'}
+
+  cacache@20.0.4:
+    resolution: {integrity: sha512-M3Lab8NPYlZU2exsL3bMVvMrMqgwCnMWfdZbK28bn3pK6APT/Te/I8hjRPNu1uwORY9a1eEQoifXbKPQMfMTOA==}
+    engines: {node: ^20.17.0 || >=22.9.0}
 
   cachedir@2.3.0:
     resolution: {integrity: sha512-A+Fezp4zxnit6FanDmv9EqXNAi3vt9DWp51/71UEhXukb7QUuvtv9344h91dyAxuTLoSYJFU299qzR3tzwPAhw==}
@@ -2324,6 +2396,10 @@ packages:
     resolution: {integrity: sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==}
     engines: {node: '>=10'}
 
+  fs-minipass@3.0.3:
+    resolution: {integrity: sha512-XUBA9XClHbnJWSfBzjkm6RvPsyg3sryZt06BEQoXcF7EK/xpGaQYJgQKDJSUH5SGZ76Y7pFx1QBnXz09rU5Fbw==}
+    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
@@ -2453,12 +2529,15 @@ packages:
     resolution: {integrity: sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==}
     engines: {node: '>=0.10.0'}
 
-  hono@4.12.18:
-    resolution: {integrity: sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==}
+  hono@4.12.21:
+    resolution: {integrity: sha512-uV63apnb0kyPtAUwoWgaGh9HyIFcv8lgmzPZSiTBQAFOFGIzka5EZ1dZocmGnn0XdX0+XTqJ6Tqv7selMuGLRQ==}
     engines: {node: '>=16.9.0'}
 
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
+
+  http-cache-semantics@4.2.0:
+    resolution: {integrity: sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==}
 
   http-errors@2.0.1:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
@@ -2790,8 +2869,8 @@ packages:
     resolution: {integrity: sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==}
     engines: {node: '>=0.10.0'}
 
-  katex@0.16.46:
-    resolution: {integrity: sha512-WHy4Coo+bGZyH7NwJKHkS04YFsFcarWbAEOAC3EMndzdN6VSZqklLLIgfxzyaW9jDoeGYJX9SWbJPKpecox0Uw==}
+  katex@0.16.47:
+    resolution: {integrity: sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==}
     hasBin: true
 
   keyv@4.5.4:
@@ -2925,8 +3004,8 @@ packages:
     resolution: {integrity: sha512-Ajzxb8CM6WAnFjgiloPsI3bF+WCxcvhdIG3KNA2KN962+tdBsHcuQ4k4qX/EcS/2CRkcc0iAkR956Nib6aXU/Q==}
     engines: {node: '>=0.10.0'}
 
-  lru-cache@11.3.6:
-    resolution: {integrity: sha512-Gf/KoL3C/MlI7Bt0PGI9I+TeTC/I6r/csU58N4BSNc4lppLBeKsOdFYkK+dX0ABDUMJNfCHTyPpzwwO21Awd3A==}
+  lru-cache@11.5.0:
+    resolution: {integrity: sha512-5YgH9UJd7wVb9hIouI2adWpgqrrICkt070Dnj8EUY1+B4B2P9eRLPAkAAo6NICA7CEhOIeBHl46u9zSNpNu7zA==}
     engines: {node: 20 || >=22}
 
   magic-string@0.30.21:
@@ -2938,6 +3017,10 @@ packages:
   make-dir@4.0.0:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
     engines: {node: '>=10'}
+
+  make-fetch-happen@15.0.5:
+    resolution: {integrity: sha512-uCbIa8jWWmQZt4dSnEStkVC6gdakiinAm4PiGsywIkguF0eWMdcjDz0ECYhUolFU3pFLOev9VNPCEygydXnddg==}
+    engines: {node: ^20.17.0 || >=22.9.0}
 
   markdown-it@14.1.1:
     resolution: {integrity: sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==}
@@ -3156,9 +3239,37 @@ packages:
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
 
+  minipass-collect@2.0.1:
+    resolution: {integrity: sha512-D7V8PO9oaz7PWGLbCACuI1qEOsq7UKfLotx/C0Aet43fCUB/wfQ7DYeq2oR/svFJGYDHPr38SHATeaj/ZoKHKw==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
+  minipass-fetch@5.0.2:
+    resolution: {integrity: sha512-2d0q2a8eCi2IRg/IGubCNRJoYbA1+YPXAzQVRFmB45gdGZafyivnZ5YSEfo3JikbjGxOdntGFvBQGqaSMXlAFQ==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
+  minipass-flush@1.0.7:
+    resolution: {integrity: sha512-TbqTz9cUwWyHS2Dy89P3ocAGUGxKjjLuR9z8w4WUTGAVgEj17/4nhgo2Du56i0Fm3Pm30g4iA8Lcqctc76jCzA==}
+    engines: {node: '>= 8'}
+
+  minipass-pipeline@1.2.4:
+    resolution: {integrity: sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==}
+    engines: {node: '>=8'}
+
+  minipass-sized@2.0.0:
+    resolution: {integrity: sha512-zSsHhto5BcUVM2m1LurnXY6M//cGhVaegT71OfOXoprxT6o780GZd792ea6FfrQkuU4usHZIUczAQMRUE2plzA==}
+    engines: {node: '>=8'}
+
+  minipass@3.3.6:
+    resolution: {integrity: sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==}
+    engines: {node: '>=8'}
+
   minipass@7.1.3:
     resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
     engines: {node: '>=16 || 14 >=14.17'}
+
+  minizlib@3.1.0:
+    resolution: {integrity: sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==}
+    engines: {node: '>= 18'}
 
   mkdirp-classic@0.5.3:
     resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
@@ -3307,6 +3418,10 @@ packages:
     resolution: {integrity: sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==}
     engines: {node: '>=6'}
 
+  p-map@7.0.4:
+    resolution: {integrity: sha512-tkAQEw8ysMzmkhgw8k+1U/iPhWNhykKnSk4Rd5zLoPJCuJaGRPo6YposrZgaxHKzDHdDWWZvE/Sk7hsL2X/CpQ==}
+    engines: {node: '>=18'}
+
   p-try@2.2.0:
     resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
     engines: {node: '>=6'}
@@ -3407,8 +3522,8 @@ packages:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
 
-  postcss@8.5.14:
-    resolution: {integrity: sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==}
+  postcss@8.5.15:
+    resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
     engines: {node: ^10 || ^12 || >=14}
 
   prebuild-install@7.1.3:
@@ -3435,6 +3550,10 @@ packages:
     resolution: {integrity: sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==}
     engines: {node: '>=18'}
 
+  proc-log@6.1.0:
+    resolution: {integrity: sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
   protocols@2.0.2:
     resolution: {integrity: sha512-hHVTzba3wboROl0/aWRRG9dMytgH6ow//STBZh43l/wQgmMhYhOFi0EHWAPtoCz9IAUymsyP0TSBHkhgMEGNnQ==}
 
@@ -3456,8 +3575,8 @@ packages:
   pure-rand@6.1.0:
     resolution: {integrity: sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==}
 
-  qs@6.15.1:
-    resolution: {integrity: sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==}
+  qs@6.15.2:
+    resolution: {integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==}
     engines: {node: '>=0.6'}
 
   quansync@0.2.11:
@@ -3689,9 +3808,21 @@ packages:
     resolution: {integrity: sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg==}
     engines: {node: '>=20'}
 
+  smart-buffer@4.2.0:
+    resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
+    engines: {node: '>= 6.0.0', npm: '>= 3.0.0'}
+
   smol-toml@1.6.1:
     resolution: {integrity: sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg==}
     engines: {node: '>= 18'}
+
+  socks-proxy-agent@8.0.5:
+    resolution: {integrity: sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==}
+    engines: {node: '>= 14'}
+
+  socks@2.8.9:
+    resolution: {integrity: sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==}
+    engines: {node: '>= 10.0.0', npm: '>= 3.0.0'}
 
   sort-keys@6.0.0:
     resolution: {integrity: sha512-ueSlHJMwpIw42CJ4B11Uxzh/S0p0AlOyiNktlv2KOu5e1JpUE6DlC4AAUjXqesHdBRv/g0wC9Q4vwq0NP2pA9w==}
@@ -3855,9 +3986,9 @@ packages:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
 
-  toad-cache@3.7.0:
-    resolution: {integrity: sha512-/m8M+2BJUpoJdgAHoG+baCwBT+tf2VraSfkBgl0Y00qIWt41DJ8R5B8nsEw0I58YwF5IZH6z24/2TobDKnqSWw==}
-    engines: {node: '>=12'}
+  toad-cache@3.7.1:
+    resolution: {integrity: sha512-5DXWzE4Vz7xNHsv+xQ+MGfJYyC78Aok3tEr0MNwHoRf7vZnga1mQXZ4/Nsodld4VR6Wd+VhfmqnNrsRJyYPfrQ==}
+    engines: {node: '>=20'}
 
   toidentifier@1.0.1:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
@@ -4035,20 +4166,20 @@ packages:
       '@vitest/coverage-v8':
         optional: true
 
-  vitest@4.1.6:
-    resolution: {integrity: sha512-6lvjbS3p9b4CrdCmguzbh2/4uoXhGE2q71R4OX5sqF9R1bo9Xd6fGrMAfvp5wnCzlBnFVdCOp6onuTQVbo8iUQ==}
+  vitest@4.1.7:
+    resolution: {integrity: sha512-flYyaFd2CgoCoU+0UKt3pxksgC+S02iTDN0n3LtqaMeXsI9SBcdNujc2k0DeFLzUn/0k538yNjOSdwgCqcrwJA==}
     engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
       '@opentelemetry/api': ^1.9.0
       '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
-      '@vitest/browser-playwright': 4.1.6
-      '@vitest/browser-preview': 4.1.6
-      '@vitest/browser-webdriverio': 4.1.6
-      '@vitest/coverage-istanbul': 4.1.6
-      '@vitest/coverage-v8': 4.1.6
-      '@vitest/ui': 4.1.6
+      '@vitest/browser-playwright': 4.1.7
+      '@vitest/browser-preview': 4.1.7
+      '@vitest/browser-webdriverio': 4.1.7
+      '@vitest/coverage-istanbul': 4.1.7
+      '@vitest/coverage-v8': 4.1.7
+      '@vitest/ui': 4.1.7
       happy-dom: '*'
       jsdom: '*'
       vite: ^6.0.0 || ^7.0.0 || ^8.0.0
@@ -4181,6 +4312,9 @@ packages:
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
     engines: {node: '>=10'}
+
+  yallist@4.0.0:
+    resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
 
   yaml-effect@0.2.3:
     resolution: {integrity: sha512-378iw8DWn+6cLzHfOZFLEPu/UXcymHtixKe+CM9OFk9G/uFeQfRU/WNnKRVjIkTCj9M8EwJdiOgH3rOrUwyFyQ==}
@@ -4447,7 +4581,7 @@ snapshots:
     dependencies:
       '@changesets/types': 6.1.0
 
-  '@changesets/cli@2.31.0(@types/node@25.8.0)':
+  '@changesets/cli@2.31.0(@types/node@25.9.1)':
     dependencies:
       '@changesets/apply-release-plan': 7.1.1
       '@changesets/assemble-release-plan': 6.0.10
@@ -4463,7 +4597,7 @@ snapshots:
       '@changesets/should-skip-package': 0.1.2
       '@changesets/types': 6.1.0
       '@changesets/write': 0.4.0
-      '@inquirer/external-editor': 1.0.3(@types/node@25.8.0)
+      '@inquirer/external-editor': 1.0.3(@types/node@25.9.1)
       '@manypkg/get-packages': 1.1.3
       ansi-colors: 4.1.3
       enquirer: 2.4.1
@@ -4568,11 +4702,11 @@ snapshots:
       human-id: 4.1.3
       prettier: 2.8.8
 
-  '@commitlint/cli@20.5.3(@types/node@25.8.0)(conventional-commits-parser@6.4.0)(typescript@5.9.3)':
+  '@commitlint/cli@20.5.3(@types/node@25.9.1)(conventional-commits-parser@6.4.0)(typescript@5.9.3)':
     dependencies:
       '@commitlint/format': 20.5.0
       '@commitlint/lint': 20.5.3
-      '@commitlint/load': 20.5.3(@types/node@25.8.0)(typescript@5.9.3)
+      '@commitlint/load': 20.5.3(@types/node@25.9.1)(typescript@5.9.3)
       '@commitlint/read': 20.5.0(conventional-commits-parser@6.4.0)
       '@commitlint/types': 20.5.0
       tinyexec: 1.1.2
@@ -4626,14 +4760,14 @@ snapshots:
       '@commitlint/rules': 20.5.3
       '@commitlint/types': 20.5.0
 
-  '@commitlint/load@20.5.3(@types/node@25.8.0)(typescript@5.9.3)':
+  '@commitlint/load@20.5.3(@types/node@25.9.1)(typescript@5.9.3)':
     dependencies:
       '@commitlint/config-validator': 20.5.0
       '@commitlint/execute-rule': 20.0.0
       '@commitlint/resolve-extends': 20.5.3
       '@commitlint/types': 20.5.0
       cosmiconfig: 9.0.1(typescript@5.9.3)
-      cosmiconfig-typescript-loader: 6.3.0(@types/node@25.8.0)(cosmiconfig@9.0.1(typescript@5.9.3))(typescript@5.9.3)
+      cosmiconfig-typescript-loader: 6.3.0(@types/node@25.9.1)(cosmiconfig@9.0.1(typescript@5.9.3))(typescript@5.9.3)
       es-toolkit: 1.46.1
       is-plain-obj: 4.1.0
       picocolors: 1.1.1
@@ -4641,14 +4775,14 @@ snapshots:
       - '@types/node'
       - typescript
 
-  '@commitlint/load@21.0.1(@types/node@25.8.0)(typescript@5.9.3)':
+  '@commitlint/load@21.0.1(@types/node@25.9.1)(typescript@5.9.3)':
     dependencies:
       '@commitlint/config-validator': 21.0.1
       '@commitlint/execute-rule': 21.0.1
       '@commitlint/resolve-extends': 21.0.1
       '@commitlint/types': 21.0.1
       cosmiconfig: 9.0.1(typescript@5.9.3)
-      cosmiconfig-typescript-loader: 6.3.0(@types/node@25.8.0)(cosmiconfig@9.0.1(typescript@5.9.3))(typescript@5.9.3)
+      cosmiconfig-typescript-loader: 6.3.0(@types/node@25.9.1)(cosmiconfig@9.0.1(typescript@5.9.3))(typescript@5.9.3)
       es-toolkit: 1.46.1
       is-plain-obj: 4.1.0
       picocolors: 1.1.1
@@ -4725,6 +4859,11 @@ snapshots:
       semver: 7.8.0
     optionalDependencies:
       conventional-commits-parser: 6.4.0
+
+  '@cyclonedx/cyclonedx-library@10.0.0(ajv-formats@3.0.1(ajv@8.18.0))(ajv@8.18.0)':
+    optionalDependencies:
+      ajv: 8.18.0
+      ajv-formats: 3.0.1(ajv@8.18.0)
 
   '@effect/cli@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(@effect/printer-ansi@0.49.0(@effect/typeclass@0.40.0(effect@3.21.2))(effect@3.21.2))(@effect/printer@0.49.0(@effect/typeclass@0.40.0(effect@3.21.2))(effect@3.21.2))(effect@3.21.2)':
     dependencies:
@@ -4876,11 +5015,13 @@ snapshots:
       '@eslint/core': 1.2.1
       levn: 0.4.1
 
+  '@gar/promise-retry@1.0.3': {}
+
   '@gwhitney/detect-indent@7.0.1': {}
 
-  '@hono/node-server@1.19.14(hono@4.12.18)':
+  '@hono/node-server@1.19.14(hono@4.12.21)':
     dependencies:
-      hono: 4.12.18
+      hono: 4.12.21
 
   '@humanfs/core@0.19.2':
     dependencies:
@@ -4898,12 +5039,12 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.3': {}
 
-  '@inquirer/external-editor@1.0.3(@types/node@25.8.0)':
+  '@inquirer/external-editor@1.0.3(@types/node@25.9.1)':
     dependencies:
       chardet: 2.1.1
       iconv-lite: 0.7.2
     optionalDependencies:
-      '@types/node': 25.8.0
+      '@types/node': 25.9.1
 
   '@jridgewell/resolve-uri@3.1.2': {}
 
@@ -4930,23 +5071,23 @@ snapshots:
       globby: 11.1.0
       read-yaml-file: 1.1.0
 
-  '@microsoft/api-extractor-model@7.33.8(@types/node@25.8.0)':
+  '@microsoft/api-extractor-model@7.33.8(@types/node@25.9.1)':
     dependencies:
       '@microsoft/tsdoc': 0.16.0
       '@microsoft/tsdoc-config': 0.18.1
-      '@rushstack/node-core-library': 5.23.1(@types/node@25.8.0)
+      '@rushstack/node-core-library': 5.23.1(@types/node@25.9.1)
     transitivePeerDependencies:
       - '@types/node'
 
-  '@microsoft/api-extractor@7.58.7(@types/node@25.8.0)':
+  '@microsoft/api-extractor@7.58.7(@types/node@25.9.1)':
     dependencies:
-      '@microsoft/api-extractor-model': 7.33.8(@types/node@25.8.0)
+      '@microsoft/api-extractor-model': 7.33.8(@types/node@25.9.1)
       '@microsoft/tsdoc': 0.16.0
       '@microsoft/tsdoc-config': 0.18.1
-      '@rushstack/node-core-library': 5.23.1(@types/node@25.8.0)
+      '@rushstack/node-core-library': 5.23.1(@types/node@25.9.1)
       '@rushstack/rig-package': 0.7.3
-      '@rushstack/terminal': 0.24.0(@types/node@25.8.0)
-      '@rushstack/ts-command-line': 5.3.9(@types/node@25.8.0)
+      '@rushstack/terminal': 0.24.0(@types/node@25.9.1)
+      '@rushstack/ts-command-line': 5.3.9(@types/node@25.9.1)
       diff: 8.0.4
       minimatch: 10.2.5
       resolve: 1.22.12
@@ -4967,7 +5108,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.29.0(zod@4.4.3)':
     dependencies:
-      '@hono/node-server': 1.19.14(hono@4.12.18)
+      '@hono/node-server': 1.19.14(hono@4.12.21)
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
       content-type: 1.0.5
@@ -4977,7 +5118,7 @@ snapshots:
       eventsource-parser: 3.0.8
       express: 5.2.1
       express-rate-limit: 8.5.2(express@5.2.1)
-      hono: 4.12.18
+      hono: 4.12.21
       jose: 6.2.3
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
@@ -5026,6 +5167,22 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
 
+  '@npmcli/agent@4.0.0':
+    dependencies:
+      agent-base: 7.1.4
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      lru-cache: 11.5.0
+      socks-proxy-agent: 8.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  '@npmcli/fs@5.0.0':
+    dependencies:
+      semver: 7.8.0
+
+  '@npmcli/redact@4.0.0': {}
+
   '@octokit/auth-app@8.2.0':
     dependencies:
       '@octokit/auth-oauth-app': 9.0.3
@@ -5033,7 +5190,7 @@ snapshots:
       '@octokit/request': 10.0.9
       '@octokit/request-error': 7.1.0
       '@octokit/types': 16.0.0
-      toad-cache: 3.7.0
+      toad-cache: 3.7.1
       universal-github-app-jwt: 2.2.2
       universal-user-agent: 7.0.3
 
@@ -5222,10 +5379,10 @@ snapshots:
       '@pnpm/fs.graceful-fs': 1100.1.0
       ssri: 13.0.1
 
-  '@pnpm/deps.path@1100.0.3':
+  '@pnpm/deps.path@1100.0.4':
     dependencies:
       '@pnpm/crypto.hash': 1100.0.1
-      '@pnpm/types': 1101.1.0
+      '@pnpm/types': 1101.1.1
       semver: 7.8.0
 
   '@pnpm/error@1000.1.0':
@@ -5248,10 +5405,10 @@ snapshots:
     transitivePeerDependencies:
       - '@pnpm/logger'
 
-  '@pnpm/fetching.fetcher-base@1100.1.3':
+  '@pnpm/fetching.fetcher-base@1100.1.5':
     dependencies:
-      '@pnpm/resolving.resolver-base': 1100.1.3
-      '@pnpm/types': 1101.1.0
+      '@pnpm/resolving.resolver-base': 1100.3.0
+      '@pnpm/types': 1101.1.1
       '@types/ssri': 7.1.5
 
   '@pnpm/fs.graceful-fs@1100.1.0':
@@ -5262,26 +5419,26 @@ snapshots:
     dependencies:
       graceful-fs: 4.2.11
 
-  '@pnpm/hooks.types@1100.0.6':
+  '@pnpm/hooks.types@1100.0.8':
     dependencies:
-      '@pnpm/fetching.fetcher-base': 1100.1.3
-      '@pnpm/lockfile.types': 1100.0.5
-      '@pnpm/resolving.resolver-base': 1100.1.3
+      '@pnpm/fetching.fetcher-base': 1100.1.5
+      '@pnpm/lockfile.types': 1100.0.7
+      '@pnpm/resolving.resolver-base': 1100.3.0
       '@pnpm/store.cafs-types': 1100.0.1
-      '@pnpm/types': 1101.1.0
+      '@pnpm/types': 1101.1.1
 
-  '@pnpm/lockfile.fs@1100.0.8(@pnpm/logger@1001.0.1)':
+  '@pnpm/lockfile.fs@1100.1.1(@pnpm/logger@1001.0.1)':
     dependencies:
       '@pnpm/constants': 1100.0.0
-      '@pnpm/deps.path': 1100.0.3
+      '@pnpm/deps.path': 1100.0.4
       '@pnpm/error': 1100.0.0
-      '@pnpm/lockfile.merger': 1100.0.5
-      '@pnpm/lockfile.types': 1100.0.5
-      '@pnpm/lockfile.utils': 1100.0.7
+      '@pnpm/lockfile.merger': 1100.0.7
+      '@pnpm/lockfile.types': 1100.0.7
+      '@pnpm/lockfile.utils': 1100.0.9
       '@pnpm/logger': 1001.0.1
       '@pnpm/network.git-utils': 1100.0.1
       '@pnpm/object.key-sorting': 1100.0.0
-      '@pnpm/types': 1101.1.0
+      '@pnpm/types': 1101.1.1
       '@zkochan/rimraf': 4.0.0
       comver-to-semver: 2.0.0
       js-yaml: '@zkochan/js-yaml@0.0.11'
@@ -5291,28 +5448,28 @@ snapshots:
       strip-bom: 5.0.0
       write-file-atomic: 7.0.1
 
-  '@pnpm/lockfile.merger@1100.0.5':
+  '@pnpm/lockfile.merger@1100.0.7':
     dependencies:
-      '@pnpm/lockfile.types': 1100.0.5
-      '@pnpm/types': 1101.1.0
+      '@pnpm/lockfile.types': 1100.0.7
+      '@pnpm/types': 1101.1.1
       comver-to-semver: 2.0.0
       ramda: '@pnpm/ramda@0.28.1'
       semver: 7.8.0
 
-  '@pnpm/lockfile.types@1100.0.5':
+  '@pnpm/lockfile.types@1100.0.7':
     dependencies:
       '@pnpm/patching.types': 1100.0.0
-      '@pnpm/resolving.resolver-base': 1100.1.3
-      '@pnpm/types': 1101.1.0
+      '@pnpm/resolving.resolver-base': 1100.3.0
+      '@pnpm/types': 1101.1.1
 
-  '@pnpm/lockfile.utils@1100.0.7':
+  '@pnpm/lockfile.utils@1100.0.9':
     dependencies:
-      '@pnpm/deps.path': 1100.0.3
+      '@pnpm/deps.path': 1100.0.4
       '@pnpm/error': 1100.0.0
-      '@pnpm/hooks.types': 1100.0.6
-      '@pnpm/lockfile.types': 1100.0.5
-      '@pnpm/resolving.resolver-base': 1100.1.3
-      '@pnpm/types': 1101.1.0
+      '@pnpm/hooks.types': 1100.0.8
+      '@pnpm/lockfile.types': 1100.0.7
+      '@pnpm/resolving.resolver-base': 1100.3.0
+      '@pnpm/types': 1101.1.1
       get-npm-tarball-url: 2.1.0
       ramda: '@pnpm/ramda@0.28.1'
 
@@ -5364,9 +5521,9 @@ snapshots:
     dependencies:
       '@pnpm/error': 1000.1.0
 
-  '@pnpm/resolving.resolver-base@1100.1.3':
+  '@pnpm/resolving.resolver-base@1100.3.0':
     dependencies:
-      '@pnpm/types': 1101.1.0
+      '@pnpm/types': 1101.1.1
 
   '@pnpm/semver.peer-range@1000.0.0':
     dependencies:
@@ -5380,7 +5537,7 @@ snapshots:
 
   '@pnpm/types@1001.3.0': {}
 
-  '@pnpm/types@1101.1.0': {}
+  '@pnpm/types@1101.1.1': {}
 
   '@pnpm/util.lex-comparator@3.0.2': {}
 
@@ -5452,77 +5609,77 @@ snapshots:
 
   '@rsbuild/core@2.0.6':
     dependencies:
-      '@rspack/core': 2.0.3(@swc/helpers@0.5.21)
+      '@rspack/core': 2.0.4(@swc/helpers@0.5.21)
       '@swc/helpers': 0.5.21
     transitivePeerDependencies:
       - '@module-federation/runtime-tools'
 
-  '@rslib/core@0.21.5(@microsoft/api-extractor@7.58.7(@types/node@25.8.0))(@typescript/native-preview@7.0.0-dev.20260515.1)(typescript@5.9.3)':
+  '@rslib/core@0.21.5(@microsoft/api-extractor@7.58.7(@types/node@25.9.1))(@typescript/native-preview@7.0.0-dev.20260519.1)(typescript@5.9.3)':
     dependencies:
       '@rsbuild/core': 2.0.6
-      rsbuild-plugin-dts: 0.21.5(@microsoft/api-extractor@7.58.7(@types/node@25.8.0))(@rsbuild/core@2.0.6)(@typescript/native-preview@7.0.0-dev.20260515.1)(typescript@5.9.3)
+      rsbuild-plugin-dts: 0.21.5(@microsoft/api-extractor@7.58.7(@types/node@25.9.1))(@rsbuild/core@2.0.6)(@typescript/native-preview@7.0.0-dev.20260519.1)(typescript@5.9.3)
     optionalDependencies:
-      '@microsoft/api-extractor': 7.58.7(@types/node@25.8.0)
+      '@microsoft/api-extractor': 7.58.7(@types/node@25.9.1)
       typescript: 5.9.3
     transitivePeerDependencies:
       - '@module-federation/runtime-tools'
       - '@typescript/native-preview'
       - core-js
 
-  '@rspack/binding-darwin-arm64@2.0.3':
+  '@rspack/binding-darwin-arm64@2.0.4':
     optional: true
 
-  '@rspack/binding-darwin-x64@2.0.3':
+  '@rspack/binding-darwin-x64@2.0.4':
     optional: true
 
-  '@rspack/binding-linux-arm64-gnu@2.0.3':
+  '@rspack/binding-linux-arm64-gnu@2.0.4':
     optional: true
 
-  '@rspack/binding-linux-arm64-musl@2.0.3':
+  '@rspack/binding-linux-arm64-musl@2.0.4':
     optional: true
 
-  '@rspack/binding-linux-x64-gnu@2.0.3':
+  '@rspack/binding-linux-x64-gnu@2.0.4':
     optional: true
 
-  '@rspack/binding-linux-x64-musl@2.0.3':
+  '@rspack/binding-linux-x64-musl@2.0.4':
     optional: true
 
-  '@rspack/binding-wasm32-wasi@2.0.3':
+  '@rspack/binding-wasm32-wasi@2.0.4':
     dependencies:
       '@emnapi/core': 1.10.0
       '@emnapi/runtime': 1.10.0
       '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     optional: true
 
-  '@rspack/binding-win32-arm64-msvc@2.0.3':
+  '@rspack/binding-win32-arm64-msvc@2.0.4':
     optional: true
 
-  '@rspack/binding-win32-ia32-msvc@2.0.3':
+  '@rspack/binding-win32-ia32-msvc@2.0.4':
     optional: true
 
-  '@rspack/binding-win32-x64-msvc@2.0.3':
+  '@rspack/binding-win32-x64-msvc@2.0.4':
     optional: true
 
-  '@rspack/binding@2.0.3':
+  '@rspack/binding@2.0.4':
     optionalDependencies:
-      '@rspack/binding-darwin-arm64': 2.0.3
-      '@rspack/binding-darwin-x64': 2.0.3
-      '@rspack/binding-linux-arm64-gnu': 2.0.3
-      '@rspack/binding-linux-arm64-musl': 2.0.3
-      '@rspack/binding-linux-x64-gnu': 2.0.3
-      '@rspack/binding-linux-x64-musl': 2.0.3
-      '@rspack/binding-wasm32-wasi': 2.0.3
-      '@rspack/binding-win32-arm64-msvc': 2.0.3
-      '@rspack/binding-win32-ia32-msvc': 2.0.3
-      '@rspack/binding-win32-x64-msvc': 2.0.3
+      '@rspack/binding-darwin-arm64': 2.0.4
+      '@rspack/binding-darwin-x64': 2.0.4
+      '@rspack/binding-linux-arm64-gnu': 2.0.4
+      '@rspack/binding-linux-arm64-musl': 2.0.4
+      '@rspack/binding-linux-x64-gnu': 2.0.4
+      '@rspack/binding-linux-x64-musl': 2.0.4
+      '@rspack/binding-wasm32-wasi': 2.0.4
+      '@rspack/binding-win32-arm64-msvc': 2.0.4
+      '@rspack/binding-win32-ia32-msvc': 2.0.4
+      '@rspack/binding-win32-x64-msvc': 2.0.4
 
-  '@rspack/core@2.0.3(@swc/helpers@0.5.21)':
+  '@rspack/core@2.0.4(@swc/helpers@0.5.21)':
     dependencies:
-      '@rspack/binding': 2.0.3
+      '@rspack/binding': 2.0.4
     optionalDependencies:
       '@swc/helpers': 0.5.21
 
-  '@rushstack/node-core-library@5.23.1(@types/node@25.8.0)':
+  '@rushstack/node-core-library@5.23.1(@types/node@25.9.1)':
     dependencies:
       ajv: 8.18.0
       ajv-draft-04: 1.0.0(ajv@8.18.0)
@@ -5533,37 +5690,37 @@ snapshots:
       resolve: 1.22.12
       semver: 7.7.4
     optionalDependencies:
-      '@types/node': 25.8.0
+      '@types/node': 25.9.1
 
-  '@rushstack/problem-matcher@0.2.1(@types/node@25.8.0)':
+  '@rushstack/problem-matcher@0.2.1(@types/node@25.9.1)':
     optionalDependencies:
-      '@types/node': 25.8.0
+      '@types/node': 25.9.1
 
   '@rushstack/rig-package@0.7.3':
     dependencies:
       jju: 1.4.0
       resolve: 1.22.12
 
-  '@rushstack/terminal@0.24.0(@types/node@25.8.0)':
+  '@rushstack/terminal@0.24.0(@types/node@25.9.1)':
     dependencies:
-      '@rushstack/node-core-library': 5.23.1(@types/node@25.8.0)
-      '@rushstack/problem-matcher': 0.2.1(@types/node@25.8.0)
+      '@rushstack/node-core-library': 5.23.1(@types/node@25.9.1)
+      '@rushstack/problem-matcher': 0.2.1(@types/node@25.9.1)
       supports-color: 8.1.1
     optionalDependencies:
-      '@types/node': 25.8.0
+      '@types/node': 25.9.1
 
-  '@rushstack/ts-command-line@5.3.9(@types/node@25.8.0)':
+  '@rushstack/ts-command-line@5.3.9(@types/node@25.9.1)':
     dependencies:
-      '@rushstack/terminal': 0.24.0(@types/node@25.8.0)
+      '@rushstack/terminal': 0.24.0(@types/node@25.9.1)
       '@types/argparse': 1.0.38
       argparse: 1.0.10
       string-argv: 0.3.2
     transitivePeerDependencies:
       - '@types/node'
 
-  ? '@savvy-web/changesets@0.10.0(@changesets/cli@2.31.0(@types/node@25.8.0))(@effect/cluster@0.58.2(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/workflow@0.18.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(effect@3.21.2))(effect@3.21.2))(@effect/printer-ansi@0.49.0(@effect/typeclass@0.40.0(effect@3.21.2))(effect@3.21.2))(@effect/printer@0.49.0(@effect/typeclass@0.40.0(effect@3.21.2))(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))'
+  ? '@savvy-web/changesets@0.10.0(@changesets/cli@2.31.0(@types/node@25.9.1))(@effect/cluster@0.58.2(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/workflow@0.18.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(effect@3.21.2))(effect@3.21.2))(@effect/printer-ansi@0.49.0(@effect/typeclass@0.40.0(effect@3.21.2))(effect@3.21.2))(@effect/printer@0.49.0(@effect/typeclass@0.40.0(effect@3.21.2))(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))'
   : dependencies:
-      '@changesets/cli': 2.31.0(@types/node@25.8.0)
+      '@changesets/cli': 2.31.0(@types/node@25.9.1)
       '@changesets/get-github-info': 0.8.0
       '@effect/cli': 0.75.1(@effect/platform@0.96.1(effect@3.21.2))(@effect/printer-ansi@0.49.0(@effect/typeclass@0.40.0(effect@3.21.2))(effect@3.21.2))(@effect/printer@0.49.0(@effect/typeclass@0.40.0(effect@3.21.2))(effect@3.21.2))(effect@3.21.2)
       '@effect/platform': 0.96.1(effect@3.21.2)
@@ -5592,9 +5749,9 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@savvy-web/commitlint@0.9.0(@commitlint/cli@20.5.3(@types/node@25.8.0)(conventional-commits-parser@6.4.0)(typescript@5.9.3))(@commitlint/config-conventional@20.5.3)(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/typeclass@0.40.0(effect@3.21.2))(@effect/workflow@0.18.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(effect@3.21.2))(commitizen@4.3.1(@types/node@25.8.0)(typescript@5.9.3))(husky@9.1.7)':
+  '@savvy-web/commitlint@0.9.0(@commitlint/cli@20.5.3(@types/node@25.9.1)(conventional-commits-parser@6.4.0)(typescript@5.9.3))(@commitlint/config-conventional@20.5.3)(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/typeclass@0.40.0(effect@3.21.2))(@effect/workflow@0.18.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(effect@3.21.2))(commitizen@4.3.1(@types/node@25.9.1)(typescript@5.9.3))(husky@9.1.7)':
     dependencies:
-      '@commitlint/cli': 20.5.3(@types/node@25.8.0)(conventional-commits-parser@6.4.0)(typescript@5.9.3)
+      '@commitlint/cli': 20.5.3(@types/node@25.9.1)(conventional-commits-parser@6.4.0)(typescript@5.9.3)
       '@commitlint/config-conventional': 20.5.3
       '@effect/cli': 0.75.1(@effect/platform@0.96.1(effect@3.21.2))(@effect/printer-ansi@0.49.0(@effect/typeclass@0.40.0(effect@3.21.2))(effect@3.21.2))(@effect/printer@0.49.0(@effect/typeclass@0.40.0(effect@3.21.2))(effect@3.21.2))(effect@3.21.2)
       '@effect/cluster': 0.58.2(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/workflow@0.18.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(effect@3.21.2))(effect@3.21.2)
@@ -5605,7 +5762,7 @@ snapshots:
       '@effect/rpc': 0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2)
       '@effect/sql': 0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2)
       '@savvy-web/silk-effects': 0.3.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2)
-      commitizen: 4.3.1(@types/node@25.8.0)(typescript@5.9.3)
+      commitizen: 4.3.1(@types/node@25.9.1)(typescript@5.9.3)
       effect: 3.21.2
       husky: 9.1.7
       shell-quote: 1.8.3
@@ -5618,14 +5775,14 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@savvy-web/lint-staged@1.0.1(b3913e0c25b2ca92183434221f153154)':
+  '@savvy-web/lint-staged@1.0.1(f2a8555238dbf5cde762ee23c09148a2)':
     dependencies:
       '@effect/cli': 0.75.1(@effect/platform@0.96.1(effect@3.21.2))(@effect/printer-ansi@0.49.0(@effect/typeclass@0.40.0(effect@3.21.2))(effect@3.21.2))(@effect/printer@0.49.0(@effect/typeclass@0.40.0(effect@3.21.2))(effect@3.21.2))(effect@3.21.2)
       '@effect/platform': 0.96.1(effect@3.21.2)
       '@effect/platform-node': 0.106.0(@effect/cluster@0.58.2(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/workflow@0.18.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(effect@3.21.2)
       '@savvy-web/silk-effects': 0.3.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2)
-      '@types/node': 25.8.0
-      '@typescript/native-preview': 7.0.0-dev.20260515.1
+      '@types/node': 25.9.1
+      '@typescript/native-preview': 7.0.0-dev.20260519.1
       effect: 3.21.2
       husky: 9.1.7
       jsonc-effect: 0.2.1(effect@3.21.2)
@@ -5648,21 +5805,21 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@savvy-web/rslib-builder@0.20.3(@pnpm/logger@1001.0.1)(@rslib/core@0.21.5(@microsoft/api-extractor@7.58.7(@types/node@25.8.0))(@typescript/native-preview@7.0.0-dev.20260515.1)(typescript@5.9.3))(@types/node@25.8.0)(@typescript/native-preview@7.0.0-dev.20260515.1)(jiti@2.6.1)(typescript@5.9.3)':
+  '@savvy-web/rslib-builder@0.20.4(@pnpm/logger@1001.0.1)(@rslib/core@0.21.5(@microsoft/api-extractor@7.58.7(@types/node@25.9.1))(@typescript/native-preview@7.0.0-dev.20260519.1)(typescript@5.9.3))(@types/node@25.9.1)(@typescript/native-preview@7.0.0-dev.20260519.1)(jiti@2.6.1)(typescript@5.9.3)':
     dependencies:
-      '@microsoft/api-extractor': 7.58.7(@types/node@25.8.0)
+      '@microsoft/api-extractor': 7.58.7(@types/node@25.9.1)
       '@microsoft/tsdoc': 0.16.0
       '@microsoft/tsdoc-config': 0.18.1
       '@pnpm/catalogs.config': 1100.0.0
       '@pnpm/catalogs.protocol-parser': 1100.0.0
       '@pnpm/exportable-manifest': 1000.4.2(@pnpm/logger@1001.0.1)
-      '@pnpm/lockfile.fs': 1100.0.8(@pnpm/logger@1001.0.1)
+      '@pnpm/lockfile.fs': 1100.1.1(@pnpm/logger@1001.0.1)
       '@pnpm/workspace.read-manifest': 1000.3.1
       '@rsbuild/core': 2.0.6
-      '@rslib/core': 0.21.5(@microsoft/api-extractor@7.58.7(@types/node@25.8.0))(@typescript/native-preview@7.0.0-dev.20260515.1)(typescript@5.9.3)
-      '@types/node': 25.8.0
-      '@typescript-eslint/parser': 8.59.3(eslint@10.4.0(jiti@2.6.1))(typescript@5.9.3)
-      '@typescript/native-preview': 7.0.0-dev.20260515.1
+      '@rslib/core': 0.21.5(@microsoft/api-extractor@7.58.7(@types/node@25.9.1))(@typescript/native-preview@7.0.0-dev.20260519.1)(typescript@5.9.3)
+      '@types/node': 25.9.1
+      '@typescript-eslint/parser': 8.59.4(eslint@10.4.0(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript/native-preview': 7.0.0-dev.20260519.1
       deep-equal: 2.2.3
       eslint: 10.4.0(jiti@2.6.1)
       eslint-plugin-tsdoc: 0.5.2(eslint@10.4.0(jiti@2.6.1))(typescript@5.9.3)
@@ -5688,17 +5845,36 @@ snapshots:
       workspaces-effect: 0.4.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2)
       yaml-effect: 0.2.3(effect@3.21.2)
 
-  '@savvy-web/vitest@1.3.2(003ae254b51b79a5e2095f7fac8ef1b5)':
+  '@savvy-web/vitest@1.3.2(89d6e39c26f70fd9d0b890d721f9ebe5)':
     dependencies:
-      '@types/node': 25.8.0
-      '@typescript/native-preview': 7.0.0-dev.20260515.1
-      '@vitest/coverage-v8': 4.1.6(vitest@4.1.6)
+      '@types/node': 25.9.1
+      '@typescript/native-preview': 7.0.0-dev.20260519.1
+      '@vitest/coverage-v8': 4.1.7(vitest@4.1.7)
       typescript: 5.9.3
-      vitest: 4.1.6(@types/node@25.8.0)(@vitest/coverage-v8@4.1.6)(vite@8.0.13(@types/node@25.8.0)(jiti@2.6.1)(yaml@2.9.0))
-      vitest-agent-reporter: 1.3.1(@effect/cluster@0.58.2(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/workflow@0.18.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(effect@3.21.2))(effect@3.21.2))(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/printer-ansi@0.49.0(@effect/typeclass@0.40.0(effect@3.21.2))(effect@3.21.2))(@effect/printer@0.49.0(@effect/typeclass@0.40.0(effect@3.21.2))(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@vitest/coverage-v8@4.1.6)(typescript@5.9.3)(vitest@4.1.6)
+      vitest: 4.1.7(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7)(vite@8.0.13(@types/node@25.9.1)(jiti@2.6.1)(yaml@2.9.0))
+      vitest-agent-reporter: 1.3.1(@effect/cluster@0.58.2(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/workflow@0.18.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(effect@3.21.2))(effect@3.21.2))(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/printer-ansi@0.49.0(@effect/typeclass@0.40.0(effect@3.21.2))(effect@3.21.2))(@effect/printer@0.49.0(@effect/typeclass@0.40.0(effect@3.21.2))(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@vitest/coverage-v8@4.1.7)(typescript@5.9.3)(vitest@4.1.7)
       workspace-tools: 0.41.4
 
   '@sec-ant/readable-stream@0.4.1': {}
+
+  '@sigstore/bundle@4.0.0':
+    dependencies:
+      '@sigstore/protobuf-specs': 0.5.1
+
+  '@sigstore/core@3.2.0': {}
+
+  '@sigstore/protobuf-specs@0.5.1': {}
+
+  '@sigstore/sign@4.1.1':
+    dependencies:
+      '@gar/promise-retry': 1.0.3
+      '@sigstore/bundle': 4.0.0
+      '@sigstore/core': 3.2.0
+      '@sigstore/protobuf-specs': 0.5.1
+      make-fetch-happen: 15.0.5
+      proc-log: 6.1.0
+    transitivePeerDependencies:
+      - supports-color
 
   '@simple-libs/child-process-utils@1.0.2':
     dependencies:
@@ -5770,7 +5946,7 @@ snapshots:
 
   '@types/node@12.20.55': {}
 
-  '@types/node@25.8.0':
+  '@types/node@25.9.1':
     dependencies:
       undici-types: 7.24.6
 
@@ -5780,18 +5956,18 @@ snapshots:
 
   '@types/ssri@7.1.5':
     dependencies:
-      '@types/node': 25.8.0
+      '@types/node': 25.9.1
 
   '@types/unist@2.0.11': {}
 
   '@types/unist@3.0.3': {}
 
-  '@typescript-eslint/parser@8.59.3(eslint@10.4.0(jiti@2.6.1))(typescript@5.9.3)':
+  '@typescript-eslint/parser@8.59.4(eslint@10.4.0(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/scope-manager': 8.59.3
-      '@typescript-eslint/types': 8.59.3
-      '@typescript-eslint/typescript-estree': 8.59.3(typescript@5.9.3)
-      '@typescript-eslint/visitor-keys': 8.59.3
+      '@typescript-eslint/scope-manager': 8.59.4
+      '@typescript-eslint/types': 8.59.4
+      '@typescript-eslint/typescript-estree': 8.59.4(typescript@5.9.3)
+      '@typescript-eslint/visitor-keys': 8.59.4
       debug: 4.4.3
       eslint: 10.4.0(jiti@2.6.1)
       typescript: 5.9.3
@@ -5807,10 +5983,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/project-service@8.59.3(typescript@5.9.3)':
+  '@typescript-eslint/project-service@8.59.4(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.59.3(typescript@5.9.3)
-      '@typescript-eslint/types': 8.59.3
+      '@typescript-eslint/tsconfig-utils': 8.59.4(typescript@5.9.3)
+      '@typescript-eslint/types': 8.59.4
       debug: 4.4.3
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -5821,22 +5997,22 @@ snapshots:
       '@typescript-eslint/types': 8.56.1
       '@typescript-eslint/visitor-keys': 8.56.1
 
-  '@typescript-eslint/scope-manager@8.59.3':
+  '@typescript-eslint/scope-manager@8.59.4':
     dependencies:
-      '@typescript-eslint/types': 8.59.3
-      '@typescript-eslint/visitor-keys': 8.59.3
+      '@typescript-eslint/types': 8.59.4
+      '@typescript-eslint/visitor-keys': 8.59.4
 
   '@typescript-eslint/tsconfig-utils@8.56.1(typescript@5.9.3)':
     dependencies:
       typescript: 5.9.3
 
-  '@typescript-eslint/tsconfig-utils@8.59.3(typescript@5.9.3)':
+  '@typescript-eslint/tsconfig-utils@8.59.4(typescript@5.9.3)':
     dependencies:
       typescript: 5.9.3
 
   '@typescript-eslint/types@8.56.1': {}
 
-  '@typescript-eslint/types@8.59.3': {}
+  '@typescript-eslint/types@8.59.4': {}
 
   '@typescript-eslint/typescript-estree@8.56.1(typescript@5.9.3)':
     dependencies:
@@ -5853,12 +6029,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/typescript-estree@8.59.3(typescript@5.9.3)':
+  '@typescript-eslint/typescript-estree@8.59.4(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/project-service': 8.59.3(typescript@5.9.3)
-      '@typescript-eslint/tsconfig-utils': 8.59.3(typescript@5.9.3)
-      '@typescript-eslint/types': 8.59.3
-      '@typescript-eslint/visitor-keys': 8.59.3
+      '@typescript-eslint/project-service': 8.59.4(typescript@5.9.3)
+      '@typescript-eslint/tsconfig-utils': 8.59.4(typescript@5.9.3)
+      '@typescript-eslint/types': 8.59.4
+      '@typescript-eslint/visitor-keys': 8.59.4
       debug: 4.4.3
       minimatch: 10.2.5
       semver: 7.8.0
@@ -5884,41 +6060,41 @@ snapshots:
       '@typescript-eslint/types': 8.56.1
       eslint-visitor-keys: 5.0.1
 
-  '@typescript-eslint/visitor-keys@8.59.3':
+  '@typescript-eslint/visitor-keys@8.59.4':
     dependencies:
-      '@typescript-eslint/types': 8.59.3
+      '@typescript-eslint/types': 8.59.4
       eslint-visitor-keys: 5.0.1
 
-  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260515.1':
+  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260519.1':
     optional: true
 
-  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260515.1':
+  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260519.1':
     optional: true
 
-  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260515.1':
+  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260519.1':
     optional: true
 
-  '@typescript/native-preview-linux-arm@7.0.0-dev.20260515.1':
+  '@typescript/native-preview-linux-arm@7.0.0-dev.20260519.1':
     optional: true
 
-  '@typescript/native-preview-linux-x64@7.0.0-dev.20260515.1':
+  '@typescript/native-preview-linux-x64@7.0.0-dev.20260519.1':
     optional: true
 
-  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260515.1':
+  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260519.1':
     optional: true
 
-  '@typescript/native-preview-win32-x64@7.0.0-dev.20260515.1':
+  '@typescript/native-preview-win32-x64@7.0.0-dev.20260519.1':
     optional: true
 
-  '@typescript/native-preview@7.0.0-dev.20260515.1':
+  '@typescript/native-preview@7.0.0-dev.20260519.1':
     optionalDependencies:
-      '@typescript/native-preview-darwin-arm64': 7.0.0-dev.20260515.1
-      '@typescript/native-preview-darwin-x64': 7.0.0-dev.20260515.1
-      '@typescript/native-preview-linux-arm': 7.0.0-dev.20260515.1
-      '@typescript/native-preview-linux-arm64': 7.0.0-dev.20260515.1
-      '@typescript/native-preview-linux-x64': 7.0.0-dev.20260515.1
-      '@typescript/native-preview-win32-arm64': 7.0.0-dev.20260515.1
-      '@typescript/native-preview-win32-x64': 7.0.0-dev.20260515.1
+      '@typescript/native-preview-darwin-arm64': 7.0.0-dev.20260519.1
+      '@typescript/native-preview-darwin-x64': 7.0.0-dev.20260519.1
+      '@typescript/native-preview-linux-arm': 7.0.0-dev.20260519.1
+      '@typescript/native-preview-linux-arm64': 7.0.0-dev.20260519.1
+      '@typescript/native-preview-linux-x64': 7.0.0-dev.20260519.1
+      '@typescript/native-preview-win32-arm64': 7.0.0-dev.20260519.1
+      '@typescript/native-preview-win32-x64': 7.0.0-dev.20260519.1
 
   '@typespec/ts-http-runtime@0.3.5':
     dependencies:
@@ -5928,10 +6104,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/coverage-v8@4.1.6(vitest@4.1.6)':
+  '@vitest/coverage-v8@4.1.7(vitest@4.1.7)':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
-      '@vitest/utils': 4.1.6
+      '@vitest/utils': 4.1.7
       ast-v8-to-istanbul: 1.0.0
       istanbul-lib-coverage: 3.2.2
       istanbul-lib-report: 3.0.1
@@ -5940,46 +6116,46 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.6(@types/node@25.8.0)(@vitest/coverage-v8@4.1.6)(vite@8.0.13(@types/node@25.8.0)(jiti@2.6.1)(yaml@2.9.0))
+      vitest: 4.1.7(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7)(vite@8.0.13(@types/node@25.9.1)(jiti@2.6.1)(yaml@2.9.0))
 
-  '@vitest/expect@4.1.6':
+  '@vitest/expect@4.1.7':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@types/chai': 5.2.3
-      '@vitest/spy': 4.1.6
-      '@vitest/utils': 4.1.6
+      '@vitest/spy': 4.1.7
+      '@vitest/utils': 4.1.7
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.6(vite@8.0.13(@types/node@25.8.0)(jiti@2.6.1)(yaml@2.9.0))':
+  '@vitest/mocker@4.1.7(vite@8.0.13(@types/node@25.9.1)(jiti@2.6.1)(yaml@2.9.0))':
     dependencies:
-      '@vitest/spy': 4.1.6
+      '@vitest/spy': 4.1.7
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.0.13(@types/node@25.8.0)(jiti@2.6.1)(yaml@2.9.0)
+      vite: 8.0.13(@types/node@25.9.1)(jiti@2.6.1)(yaml@2.9.0)
 
-  '@vitest/pretty-format@4.1.6':
+  '@vitest/pretty-format@4.1.7':
     dependencies:
       tinyrainbow: 3.1.0
 
-  '@vitest/runner@4.1.6':
+  '@vitest/runner@4.1.7':
     dependencies:
-      '@vitest/utils': 4.1.6
+      '@vitest/utils': 4.1.7
       pathe: 2.0.3
 
-  '@vitest/snapshot@4.1.6':
+  '@vitest/snapshot@4.1.7':
     dependencies:
-      '@vitest/pretty-format': 4.1.6
-      '@vitest/utils': 4.1.6
+      '@vitest/pretty-format': 4.1.7
+      '@vitest/utils': 4.1.7
       magic-string: 0.30.21
       pathe: 2.0.3
 
-  '@vitest/spy@4.1.6': {}
+  '@vitest/spy@4.1.7': {}
 
-  '@vitest/utils@4.1.6':
+  '@vitest/utils@4.1.7':
     dependencies:
-      '@vitest/pretty-format': 4.1.6
+      '@vitest/pretty-format': 4.1.7
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
@@ -6131,7 +6307,7 @@ snapshots:
       http-errors: 2.0.1
       iconv-lite: 0.7.2
       on-finished: 2.4.1
-      qs: 6.15.1
+      qs: 6.15.2
       raw-body: 3.0.2
       type-is: 2.1.0
     transitivePeerDependencies:
@@ -6156,6 +6332,19 @@ snapshots:
       ieee754: 1.2.1
 
   bytes@3.1.2: {}
+
+  cacache@20.0.4:
+    dependencies:
+      '@npmcli/fs': 5.0.0
+      fs-minipass: 3.0.3
+      glob: 13.0.6
+      lru-cache: 11.5.0
+      minipass: 7.1.3
+      minipass-collect: 2.0.1
+      minipass-flush: 1.0.7
+      minipass-pipeline: 1.2.4
+      p-map: 7.0.4
+      ssri: 13.0.1
 
   cachedir@2.3.0: {}
 
@@ -6254,10 +6443,10 @@ snapshots:
 
   commander@8.3.0: {}
 
-  commitizen@4.3.1(@types/node@25.8.0)(typescript@5.9.3):
+  commitizen@4.3.1(@types/node@25.9.1)(typescript@5.9.3):
     dependencies:
       cachedir: 2.3.0
-      cz-conventional-changelog: 3.3.0(@types/node@25.8.0)(typescript@5.9.3)
+      cz-conventional-changelog: 3.3.0(@types/node@25.9.1)(typescript@5.9.3)
       dedent: 0.7.0
       detect-indent: 6.1.0
       find-node-modules: 2.1.3
@@ -6315,9 +6504,9 @@ snapshots:
       object-assign: 4.1.1
       vary: 1.1.2
 
-  cosmiconfig-typescript-loader@6.3.0(@types/node@25.8.0)(cosmiconfig@9.0.1(typescript@5.9.3))(typescript@5.9.3):
+  cosmiconfig-typescript-loader@6.3.0(@types/node@25.9.1)(cosmiconfig@9.0.1(typescript@5.9.3))(typescript@5.9.3):
     dependencies:
-      '@types/node': 25.8.0
+      '@types/node': 25.9.1
       cosmiconfig: 9.0.1(typescript@5.9.3)
       jiti: 2.6.1
       typescript: 5.9.3
@@ -6337,16 +6526,16 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
-  cz-conventional-changelog@3.3.0(@types/node@25.8.0)(typescript@5.9.3):
+  cz-conventional-changelog@3.3.0(@types/node@25.9.1)(typescript@5.9.3):
     dependencies:
       chalk: 2.4.2
-      commitizen: 4.3.1(@types/node@25.8.0)(typescript@5.9.3)
+      commitizen: 4.3.1(@types/node@25.9.1)(typescript@5.9.3)
       conventional-commit-types: 3.0.0
       lodash.map: 4.6.0
       longest: 2.0.1
       word-wrap: 1.2.5
     optionalDependencies:
-      '@commitlint/load': 21.0.1(@types/node@25.8.0)(typescript@5.9.3)
+      '@commitlint/load': 21.0.1(@types/node@25.9.1)(typescript@5.9.3)
     transitivePeerDependencies:
       - '@types/node'
       - typescript
@@ -6652,7 +6841,7 @@ snapshots:
       once: 1.4.0
       parseurl: 1.3.3
       proxy-addr: 2.0.7
-      qs: 6.15.1
+      qs: 6.15.2
       range-parser: 1.2.1
       router: 2.2.0
       send: 1.2.1
@@ -6815,6 +7004,10 @@ snapshots:
       jsonfile: 6.2.1
       universalify: 2.0.1
 
+  fs-minipass@3.0.3:
+    dependencies:
+      minipass: 7.1.3
+
   fs.realpath@1.0.0: {}
 
   fsevents@2.3.3:
@@ -6961,9 +7154,11 @@ snapshots:
     dependencies:
       parse-passwd: 1.0.0
 
-  hono@4.12.18: {}
+  hono@4.12.21: {}
 
   html-escaper@2.0.2: {}
+
+  http-cache-semantics@4.2.0: {}
 
   http-errors@2.0.1:
     dependencies:
@@ -7257,7 +7452,7 @@ snapshots:
 
   jsonpointer@5.0.1: {}
 
-  katex@0.16.46:
+  katex@0.16.47:
     dependencies:
       commander: 8.3.0
 
@@ -7376,7 +7571,7 @@ snapshots:
 
   longest@2.0.1: {}
 
-  lru-cache@11.3.6: {}
+  lru-cache@11.5.0: {}
 
   magic-string@0.30.21:
     dependencies:
@@ -7391,6 +7586,23 @@ snapshots:
   make-dir@4.0.0:
     dependencies:
       semver: 7.8.0
+
+  make-fetch-happen@15.0.5:
+    dependencies:
+      '@gar/promise-retry': 1.0.3
+      '@npmcli/agent': 4.0.0
+      '@npmcli/redact': 4.0.0
+      cacache: 20.0.4
+      http-cache-semantics: 4.2.0
+      minipass: 7.1.3
+      minipass-fetch: 5.0.2
+      minipass-flush: 1.0.7
+      minipass-pipeline: 1.2.4
+      negotiator: 1.0.0
+      proc-log: 6.1.0
+      ssri: 13.0.1
+    transitivePeerDependencies:
+      - supports-color
 
   markdown-it@14.1.1:
     dependencies:
@@ -7653,7 +7865,7 @@ snapshots:
     dependencies:
       '@types/katex': 0.16.8
       devlop: 1.1.0
-      katex: 0.16.46
+      katex: 0.16.47
       micromark-factory-space: 2.0.1
       micromark-util-character: 2.1.1
       micromark-util-symbol: 2.0.1
@@ -7800,7 +8012,39 @@ snapshots:
 
   minimist@1.2.8: {}
 
+  minipass-collect@2.0.1:
+    dependencies:
+      minipass: 7.1.3
+
+  minipass-fetch@5.0.2:
+    dependencies:
+      minipass: 7.1.3
+      minipass-sized: 2.0.0
+      minizlib: 3.1.0
+    optionalDependencies:
+      iconv-lite: 0.7.2
+
+  minipass-flush@1.0.7:
+    dependencies:
+      minipass: 3.3.6
+
+  minipass-pipeline@1.2.4:
+    dependencies:
+      minipass: 3.3.6
+
+  minipass-sized@2.0.0:
+    dependencies:
+      minipass: 7.1.3
+
+  minipass@3.3.6:
+    dependencies:
+      yallist: 4.0.0
+
   minipass@7.1.3: {}
+
+  minizlib@3.1.0:
+    dependencies:
+      minipass: 7.1.3
 
   mkdirp-classic@0.5.3: {}
 
@@ -7950,6 +8194,8 @@ snapshots:
 
   p-map@2.1.0: {}
 
+  p-map@7.0.4: {}
+
   p-try@2.2.0: {}
 
   package-manager-detector@0.2.11:
@@ -8008,7 +8254,7 @@ snapshots:
 
   path-scurry@2.0.2:
     dependencies:
-      lru-cache: 11.3.6
+      lru-cache: 11.5.0
       minipass: 7.1.3
 
   path-to-regexp@8.4.2: {}
@@ -8029,7 +8275,7 @@ snapshots:
 
   possible-typed-array-names@1.1.0: {}
 
-  postcss@8.5.14:
+  postcss@8.5.15:
     dependencies:
       nanoid: 3.3.12
       picocolors: 1.1.1
@@ -8060,6 +8306,8 @@ snapshots:
     dependencies:
       parse-ms: 4.0.0
 
+  proc-log@6.1.0: {}
+
   protocols@2.0.2: {}
 
   proxy-addr@2.0.7:
@@ -8078,7 +8326,7 @@ snapshots:
 
   pure-rand@6.1.0: {}
 
-  qs@6.15.1:
+  qs@6.15.2:
     dependencies:
       side-channel: 1.1.0
 
@@ -8220,13 +8468,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  rsbuild-plugin-dts@0.21.5(@microsoft/api-extractor@7.58.7(@types/node@25.8.0))(@rsbuild/core@2.0.6)(@typescript/native-preview@7.0.0-dev.20260515.1)(typescript@5.9.3):
+  rsbuild-plugin-dts@0.21.5(@microsoft/api-extractor@7.58.7(@types/node@25.9.1))(@rsbuild/core@2.0.6)(@typescript/native-preview@7.0.0-dev.20260519.1)(typescript@5.9.3):
     dependencies:
       '@ast-grep/napi': 0.37.0
       '@rsbuild/core': 2.0.6
     optionalDependencies:
-      '@microsoft/api-extractor': 7.58.7(@types/node@25.8.0)
-      '@typescript/native-preview': 7.0.0-dev.20260515.1
+      '@microsoft/api-extractor': 7.58.7(@types/node@25.9.1)
+      '@typescript/native-preview': 7.0.0-dev.20260519.1
       typescript: 5.9.3
 
   run-async@2.4.1: {}
@@ -8372,7 +8620,22 @@ snapshots:
       ansi-styles: 6.2.3
       is-fullwidth-code-point: 5.1.0
 
+  smart-buffer@4.2.0: {}
+
   smol-toml@1.6.1: {}
+
+  socks-proxy-agent@8.0.5:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+      socks: 2.8.9
+    transitivePeerDependencies:
+      - supports-color
+
+  socks@2.8.9:
+    dependencies:
+      ip-address: 10.2.0
+      smart-buffer: 4.2.0
 
   sort-keys@6.0.0:
     dependencies:
@@ -8520,7 +8783,7 @@ snapshots:
     dependencies:
       is-number: 7.0.0
 
-  toad-cache@3.7.0: {}
+  toad-cache@3.7.1: {}
 
   toidentifier@1.0.1: {}
 
@@ -8639,20 +8902,20 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite@8.0.13(@types/node@25.8.0)(jiti@2.6.1)(yaml@2.9.0):
+  vite@8.0.13(@types/node@25.9.1)(jiti@2.6.1)(yaml@2.9.0):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
-      postcss: 8.5.14
+      postcss: 8.5.15
       rolldown: 1.0.1
       tinyglobby: 0.2.16
     optionalDependencies:
-      '@types/node': 25.8.0
+      '@types/node': 25.9.1
       fsevents: 2.3.3
       jiti: 2.6.1
       yaml: 2.9.0
 
-  vitest-agent-reporter@1.3.1(@effect/cluster@0.58.2(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/workflow@0.18.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(effect@3.21.2))(effect@3.21.2))(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/printer-ansi@0.49.0(@effect/typeclass@0.40.0(effect@3.21.2))(effect@3.21.2))(@effect/printer@0.49.0(@effect/typeclass@0.40.0(effect@3.21.2))(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@vitest/coverage-v8@4.1.6)(typescript@5.9.3)(vitest@4.1.6):
+  vitest-agent-reporter@1.3.1(@effect/cluster@0.58.2(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/workflow@0.18.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(effect@3.21.2))(effect@3.21.2))(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/printer-ansi@0.49.0(@effect/typeclass@0.40.0(effect@3.21.2))(effect@3.21.2))(@effect/printer@0.49.0(@effect/typeclass@0.40.0(effect@3.21.2))(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@vitest/coverage-v8@4.1.7)(typescript@5.9.3)(vitest@4.1.7):
     dependencies:
       '@effect/cli': 0.75.1(@effect/platform@0.96.1(effect@3.21.2))(@effect/printer-ansi@0.49.0(@effect/typeclass@0.40.0(effect@3.21.2))(effect@3.21.2))(@effect/printer@0.49.0(@effect/typeclass@0.40.0(effect@3.21.2))(effect@3.21.2))(effect@3.21.2)
       '@effect/platform': 0.96.1(effect@3.21.2)
@@ -8663,10 +8926,10 @@ snapshots:
       '@trpc/server': 11.17.0(typescript@5.9.3)
       effect: 3.21.2
       std-env: 4.1.0
-      vitest: 4.1.6(@types/node@25.8.0)(@vitest/coverage-v8@4.1.6)(vite@8.0.13(@types/node@25.8.0)(jiti@2.6.1)(yaml@2.9.0))
+      vitest: 4.1.7(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7)(vite@8.0.13(@types/node@25.9.1)(jiti@2.6.1)(yaml@2.9.0))
       zod: 4.4.3
     optionalDependencies:
-      '@vitest/coverage-v8': 4.1.6(vitest@4.1.6)
+      '@vitest/coverage-v8': 4.1.7(vitest@4.1.7)
     transitivePeerDependencies:
       - '@cfworker/json-schema'
       - '@effect/cluster'
@@ -8679,15 +8942,15 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  vitest@4.1.6(@types/node@25.8.0)(@vitest/coverage-v8@4.1.6)(vite@8.0.13(@types/node@25.8.0)(jiti@2.6.1)(yaml@2.9.0)):
+  vitest@4.1.7(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7)(vite@8.0.13(@types/node@25.9.1)(jiti@2.6.1)(yaml@2.9.0)):
     dependencies:
-      '@vitest/expect': 4.1.6
-      '@vitest/mocker': 4.1.6(vite@8.0.13(@types/node@25.8.0)(jiti@2.6.1)(yaml@2.9.0))
-      '@vitest/pretty-format': 4.1.6
-      '@vitest/runner': 4.1.6
-      '@vitest/snapshot': 4.1.6
-      '@vitest/spy': 4.1.6
-      '@vitest/utils': 4.1.6
+      '@vitest/expect': 4.1.7
+      '@vitest/mocker': 4.1.7(vite@8.0.13(@types/node@25.9.1)(jiti@2.6.1)(yaml@2.9.0))
+      '@vitest/pretty-format': 4.1.7
+      '@vitest/runner': 4.1.7
+      '@vitest/snapshot': 4.1.7
+      '@vitest/spy': 4.1.7
+      '@vitest/utils': 4.1.7
       es-module-lexer: 2.1.0
       expect-type: 1.3.0
       magic-string: 0.30.21
@@ -8699,11 +8962,11 @@ snapshots:
       tinyexec: 1.1.2
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
-      vite: 8.0.13(@types/node@25.8.0)(jiti@2.6.1)(yaml@2.9.0)
+      vite: 8.0.13(@types/node@25.9.1)(jiti@2.6.1)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      '@types/node': 25.8.0
-      '@vitest/coverage-v8': 4.1.6(vitest@4.1.6)
+      '@types/node': 25.9.1
+      '@vitest/coverage-v8': 4.1.7(vitest@4.1.7)
     transitivePeerDependencies:
       - msw
 
@@ -8836,6 +9099,8 @@ snapshots:
   xml-naming@0.1.0: {}
 
   y18n@5.0.8: {}
+
+  yallist@4.0.0: {}
 
   yaml-effect@0.2.3(effect@3.21.2):
     dependencies:

--- a/src/Action.ts
+++ b/src/Action.ts
@@ -56,8 +56,15 @@ export const Action = {
 	 * to avoid timing issues.
 	 */
 	run: ((program: Effect.Effect<void, unknown, CoreServices>, options?: ActionRunOptions): Promise<void> => {
+		// `ActionsRuntime.Default` and any user-supplied `options.layer` may
+		// each surface their own remaining context requirements (e.g.
+		// `FileSystem` from `@effect/platform`); `Layer.mergeAll` widens the
+		// requires-channel to the union of both sides. The annotation accepts
+		// `any` in every slot — this is a deliberate type-erasure seam at the
+		// run boundary so callers do not have to construct a single concrete
+		// Layer<…> annotation that names every transitively-required service.
 		// biome-ignore lint/suspicious/noExplicitAny: Layer type erasure at the run boundary
-		const fullLayer: Layer.Layer<any, never, never> = options?.layer
+		const fullLayer: Layer.Layer<any, never, any> = options?.layer
 			? Layer.mergeAll(ActionsRuntime.Default, options.layer)
 			: ActionsRuntime.Default;
 
@@ -103,7 +110,12 @@ export const Action = {
 			}),
 		);
 
-		return Effect.runPromise(runnable).catch(() => {
+		// `runnable` has `R: any` because `fullLayer` was annotated `Layer<…, …, any>` —
+		// see the comment above where `fullLayer` is declared. Cast back to
+		// `R: never` at the run boundary; the layer has fully resolved the
+		// program by this point so no requirements actually remain.
+		// biome-ignore lint/suspicious/noExplicitAny: matches the type-erasure seam at fullLayer
+		return Effect.runPromise(runnable as Effect.Effect<void, never, never>).catch(() => {
 			// Last resort — if even the error handler fails, the process should still exit
 			process.exitCode = 1;
 		});

--- a/src/errors/AttestError.ts
+++ b/src/errors/AttestError.ts
@@ -1,0 +1,22 @@
+import { Data } from "effect";
+
+/**
+ * Errors raised by Attest operations.
+ *
+ * @remarks
+ * The `reason` discriminator lets callers pattern-match on the failing
+ * stage without coupling to the implementation graph:
+ *
+ * - `"build"`  — failure constructing the in-toto statement
+ * - `"save"`   — failure writing a statement or bundle to disk
+ * - `"oidc"`   — failure obtaining the GitHub Actions OIDC token
+ * - `"sign"`   — failure signing the DSSE envelope via Sigstore
+ * - `"upload"` — failure POSTing the bundle to GitHub's attestations API
+ *
+ * @public
+ */
+export class AttestError extends Data.TaggedError("AttestError")<{
+	readonly reason: "build" | "save" | "oidc" | "sign" | "upload";
+	readonly message: string;
+	readonly cause?: unknown;
+}> {}

--- a/src/errors/CheckRunError.ts
+++ b/src/errors/CheckRunError.ts
@@ -8,7 +8,7 @@ export class CheckRunError extends Data.TaggedError("CheckRunError")<{
 	readonly name: string;
 
 	/** The operation that failed. */
-	readonly operation: "create" | "update" | "complete";
+	readonly operation: "create" | "update" | "complete" | "get";
 
 	/** Human-readable description. */
 	readonly reason: string;

--- a/src/errors/CommandRunnerError.test.ts
+++ b/src/errors/CommandRunnerError.test.ts
@@ -58,8 +58,14 @@ describe("CommandRunnerError", () => {
 		expect(error.message).not.toContain("node  ");
 	});
 
-	it("truncates long stderr to 500 characters", () => {
-		const longStderr = "x".repeat(1000);
+	it("shows the tail of long stderr (where errors live) with a head-truncated marker", () => {
+		// `npm` writes warnings and notices first and the actual `npm error`
+		// lines last; the formatter shows the trailing 2000 chars to surface
+		// the cause, with a `...[N chars truncated from head]...` marker
+		// before the tail.
+		const head = "h".repeat(1000);
+		const tail = "t".repeat(2000);
+		const longStderr = `${head}\n${tail}`;
 		const error = new CommandRunnerError({
 			command: "git",
 			args: ["push"],
@@ -67,8 +73,41 @@ describe("CommandRunnerError", () => {
 			stderr: longStderr,
 			reason: "Command exited with code 1",
 		});
-		// The stderr portion should be at most 500 chars
-		expect(error.message).toContain("x".repeat(500));
-		expect(error.message).not.toContain("x".repeat(501));
+
+		// The tail (the actual error) is preserved …
+		expect(error.message).toContain(tail);
+		// … the head is not …
+		expect(error.message).not.toContain(head);
+		// … and a truncation marker appears.
+		expect(error.message).toMatch(/\.\.\.\[\d+ chars truncated from head\]\.\.\./);
+	});
+
+	it("includes the full stderr when shorter than the cap", () => {
+		const stderr = "npm error 403 Forbidden";
+		const error = new CommandRunnerError({
+			command: "npm",
+			args: ["publish"],
+			exitCode: 1,
+			stderr,
+			reason: "Command exited with code 1",
+		});
+
+		expect(error.message).toContain(stderr);
+		expect(error.message).not.toContain("truncated from head");
+	});
+
+	it("falls back to stdout when stderr is empty", () => {
+		// Some CLIs route error context to stdout. Carry it on the error too
+		// so the formatter can surface it as a last resort.
+		const error = new CommandRunnerError({
+			command: "npm",
+			args: ["publish"],
+			exitCode: 1,
+			stderr: "",
+			stdout: "npm error E403 Forbidden",
+			reason: "Command exited with code 1",
+		});
+
+		expect(error.message).toContain("npm error E403 Forbidden");
 	});
 });

--- a/src/errors/CommandRunnerError.ts
+++ b/src/errors/CommandRunnerError.ts
@@ -1,6 +1,32 @@
 import { Data } from "effect";
 
 /**
+ * Maximum stderr/stdout length surfaced in the formatted `message`. Tail-bound
+ * because tools like `npm` write warnings and notices first and errors last;
+ * surfacing the head would hide the real cause.
+ *
+ * @internal
+ */
+const MAX_OUTPUT_CHARS = 2000;
+
+/**
+ * Format a captured output stream for inclusion in the error message.
+ *
+ * @remarks
+ * Returns the trimmed output when short; when longer than
+ * {@link MAX_OUTPUT_CHARS}, returns a `...[N chars truncated]...\n<tail>`
+ * shape so the actually-useful tail of stderr (where errors live) reaches
+ * the reader.
+ *
+ * @internal
+ */
+const formatOutputTail = (output: string): string => {
+	const trimmed = output.trim();
+	if (trimmed.length <= MAX_OUTPUT_CHARS) return trimmed;
+	return `...[${trimmed.length - MAX_OUTPUT_CHARS} chars truncated from head]...\n${trimmed.slice(-MAX_OUTPUT_CHARS)}`;
+};
+
+/**
  * Error when a shell command fails or produces unexpected output.
  */
 export class CommandRunnerError extends Data.TaggedError("CommandRunnerError")<{
@@ -16,6 +42,13 @@ export class CommandRunnerError extends Data.TaggedError("CommandRunnerError")<{
 	/** Captured stderr output, if available. */
 	readonly stderr: string | undefined;
 
+	/**
+	 * Captured stdout output, if available. Carried alongside stderr because
+	 * some CLIs (notably `npm`) emit progress, notices, and even error
+	 * details on stdout; downstream errors can consult both.
+	 */
+	readonly stdout?: string | undefined;
+
 	/** Human-readable description of what went wrong. */
 	readonly reason: string;
 }> {
@@ -23,7 +56,13 @@ export class CommandRunnerError extends Data.TaggedError("CommandRunnerError")<{
 		const cmd = this.args.length > 0 ? `${this.command} ${this.args.join(" ")}` : this.command;
 		const parts = [`Command "${cmd}" failed`];
 		if (this.exitCode !== undefined) parts.push(`(exit ${this.exitCode})`);
-		if (this.stderr) parts.push(`: ${this.stderr.slice(0, 500)}`);
+		// Prefer stderr (where errors live); fall back to stdout for tools that
+		// route errors there. Show the tail when long — `npm` writes warnings
+		// and notices first and the actual `npm error` lines at the end.
+		const stream = this.stderr?.trim() ? this.stderr : this.stdout?.trim() ? this.stdout : undefined;
+		if (stream !== undefined && stream.trim() !== "") {
+			parts.push(`:\n${formatOutputTail(stream)}`);
+		}
 		return parts.join(" ");
 	}
 }

--- a/src/errors/GitHubArtifactMetadataError.ts
+++ b/src/errors/GitHubArtifactMetadataError.ts
@@ -1,0 +1,15 @@
+import { Data } from "effect";
+
+/**
+ * Error from GitHub Packages artifact-metadata operations.
+ */
+export class GitHubArtifactMetadataError extends Data.TaggedError("GitHubArtifactMetadataError")<{
+	/** The operation that failed. */
+	readonly operation: "createStorageRecord";
+
+	/** Human-readable description of what went wrong. */
+	readonly reason: string;
+
+	/** Whether this error is retryable (e.g., rate limit, 5xx). */
+	readonly retryable: boolean;
+}> {}

--- a/src/errors/GitHubCommitError.ts
+++ b/src/errors/GitHubCommitError.ts
@@ -1,0 +1,15 @@
+import { Data } from "effect";
+
+/**
+ * Error from GitHub commit operations.
+ */
+export class GitHubCommitError extends Data.TaggedError("GitHubCommitError")<{
+	/** The operation that failed. */
+	readonly operation: "get" | "list" | "compare";
+
+	/** The ref involved, when known. */
+	readonly ref?: string;
+
+	/** Human-readable description. */
+	readonly reason: string;
+}> {}

--- a/src/errors/GitHubContentError.ts
+++ b/src/errors/GitHubContentError.ts
@@ -1,0 +1,15 @@
+import { Data } from "effect";
+
+/**
+ * Error from GitHub repository-content operations.
+ */
+export class GitHubContentError extends Data.TaggedError("GitHubContentError")<{
+	/** The operation that failed. */
+	readonly operation: "getFile";
+
+	/** The path requested, when known. */
+	readonly path?: string;
+
+	/** Human-readable description. */
+	readonly reason: string;
+}> {}

--- a/src/errors/GitHubIssueError.ts
+++ b/src/errors/GitHubIssueError.ts
@@ -5,7 +5,7 @@ import { Data } from "effect";
  */
 export class GitHubIssueError extends Data.TaggedError("GitHubIssueError")<{
 	/** The operation that failed. */
-	readonly operation: "list" | "close" | "comment" | "getLinkedIssues";
+	readonly operation: "list" | "close" | "comment" | "getLinkedIssues" | "get";
 
 	/** The issue number, if applicable. */
 	readonly issueNumber?: number;

--- a/src/errors/GitHubReleaseError.ts
+++ b/src/errors/GitHubReleaseError.ts
@@ -5,7 +5,7 @@ import { Data } from "effect";
  */
 export class GitHubReleaseError extends Data.TaggedError("GitHubReleaseError")<{
 	/** The operation that failed. */
-	readonly operation: "create" | "uploadAsset" | "getByTag" | "list";
+	readonly operation: "create" | "uploadAsset" | "getByTag" | "list" | "updateRelease" | "listReleaseAssets";
 
 	/** The release tag, if applicable. */
 	readonly tag?: string;

--- a/src/errors/NpmRegistryError.ts
+++ b/src/errors/NpmRegistryError.ts
@@ -7,4 +7,18 @@ export class NpmRegistryError extends Data.TaggedError("NpmRegistryError")<{
 	readonly pkg: string;
 	readonly operation: "view" | "search" | "versions";
 	readonly reason: string;
-}> {}
+}> {
+	/**
+	 * Human-readable summary: `[<operation>] <pkg>: <reason>`.
+	 *
+	 * @remarks
+	 * `Data.TaggedError` does not synthesise a `message` getter — callers that
+	 * read `error.message` would see an empty string otherwise. The publish
+	 * orchestrator catches this error class into a generic `{ error: string }`
+	 * shape via `e.message`; the explicit getter ensures that catch produces a
+	 * useful message instead of swallowing the cause.
+	 */
+	get message(): string {
+		return `[${this.operation}] ${this.pkg}: ${this.reason}`;
+	}
+}

--- a/src/errors/OidcTokenError.ts
+++ b/src/errors/OidcTokenError.ts
@@ -1,0 +1,17 @@
+import { Data } from "effect";
+
+/**
+ * Errors raised by OidcTokenIssuer.
+ *
+ * - `"env"`    — required `ACTIONS_ID_TOKEN_REQUEST_*` env var missing
+ * - `"http"`   — non-2xx response or transport error from the token service
+ * - `"decode"` — token service returned a payload without a `value` field
+ * - `"save"`   — failure writing the redacted token to disk
+ *
+ * @public
+ */
+export class OidcTokenError extends Data.TaggedError("OidcTokenError")<{
+	readonly reason: "env" | "http" | "decode" | "save";
+	readonly message: string;
+	readonly cause?: unknown;
+}> {}

--- a/src/errors/PackagePublishError.test.ts
+++ b/src/errors/PackagePublishError.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import { PackagePublishError } from "./PackagePublishError.js";
+
+describe("PackagePublishError", () => {
+	it("preserves _tag as PackagePublishError", () => {
+		const err = new PackagePublishError({ operation: "publish", reason: "boom" });
+		expect(err._tag).toBe("PackagePublishError");
+	});
+
+	it("message composes [operation] reason", () => {
+		const err = new PackagePublishError({ operation: "publish", reason: "boom" });
+		expect(err.message).toBe("[publish] boom");
+	});
+
+	it("message appends the cause's stderr when present", () => {
+		// The appended stderr starts on its own line so multi-line npm/git
+		// output reads naturally in CI logs and check-run pages.
+		const err = new PackagePublishError({
+			operation: "publish",
+			reason: "Command exited with code 1",
+			cause: { stderr: "npm error 403 Forbidden" },
+		});
+		expect(err.message).toBe("[publish] Command exited with code 1:\nnpm error 403 Forbidden");
+	});
+
+	it("message omits cause when stderr is absent", () => {
+		const err = new PackagePublishError({
+			operation: "dryRun",
+			reason: "Something went wrong",
+			cause: new Error("inner"),
+		});
+		expect(err.message).toBe("[dryRun] Something went wrong");
+	});
+
+	it("message omits cause when stderr is empty", () => {
+		const err = new PackagePublishError({
+			operation: "pack",
+			reason: "Pack failed",
+			cause: { stderr: "   " },
+		});
+		expect(err.message).toBe("[pack] Pack failed");
+	});
+
+	it("shows the tail of long stderr (where errors live), not the head", () => {
+		// `npm` writes warnings + notices first and `npm error` lines last;
+		// truncating from the head surfaces the cause. The cap is 2000 chars.
+		const head = "h".repeat(500);
+		const tail = "t".repeat(2000);
+		const err = new PackagePublishError({
+			operation: "publish",
+			reason: "failed",
+			cause: { stderr: `${head}\n${tail}` },
+		});
+
+		expect(err.message).toContain(tail);
+		expect(err.message).not.toContain(head);
+		expect(err.message).toMatch(/\.\.\.\[\d+ chars truncated from head\]\.\.\./);
+	});
+
+	it("falls back to stdout when the cause's stderr is empty", () => {
+		const err = new PackagePublishError({
+			operation: "publish",
+			reason: "failed",
+			cause: { stderr: "", stdout: "npm error E403 Forbidden" },
+		});
+		expect(err.message).toContain("npm error E403 Forbidden");
+	});
+});

--- a/src/errors/PackagePublishError.ts
+++ b/src/errors/PackagePublishError.ts
@@ -5,7 +5,15 @@ import { Data } from "effect";
  */
 export class PackagePublishError extends Data.TaggedError("PackagePublishError")<{
 	/** The operation that failed. */
-	readonly operation: "setupAuth" | "pack" | "publish" | "verifyIntegrity" | "publishToRegistries";
+	readonly operation:
+		| "setupAuth"
+		| "pack"
+		| "publish"
+		| "publishTarball"
+		| "verifyIntegrity"
+		| "publishToRegistries"
+		| "publishIdempotent"
+		| "dryRun";
 
 	/** The package name, if applicable. */
 	readonly pkg?: string;
@@ -15,4 +23,44 @@ export class PackagePublishError extends Data.TaggedError("PackagePublishError")
 
 	/** Human-readable description of what went wrong. */
 	readonly reason: string;
-}> {}
+
+	/**
+	 * The underlying error that caused this failure, when one exists — e.g. the
+	 * `CommandRunnerError` from a failed `npm` invocation, which carries the
+	 * command's `stderr`, `exitCode`, and `args`. Absent for errors constructed
+	 * without a source error.
+	 */
+	readonly cause?: unknown;
+}> {
+	/**
+	 * Human-readable summary: `[<operation>] <reason>`, with the underlying
+	 * command's stderr (or stdout, as a fallback) appended when `cause`
+	 * carries one. Output longer than 2000 chars is truncated from the
+	 * **head** — `npm` writes warnings and notices first and the actual
+	 * `npm error` lines at the end, so a head-truncation hides the cause
+	 * while a tail-show surfaces it. A `...[N chars truncated from head]...`
+	 * marker leads the truncated payload.
+	 */
+	get message(): string {
+		let line = `[${this.operation}] ${this.reason}`;
+		const cause = this.cause;
+		if (typeof cause === "object" && cause !== null) {
+			const c = cause as { stderr?: unknown; stdout?: unknown };
+			const stderrStr = typeof c.stderr === "string" ? c.stderr.trim() : "";
+			const stdoutStr = typeof c.stdout === "string" ? c.stdout.trim() : "";
+			// Prefer stderr; fall back to stdout for tools that route errors
+			// there. Combining both can produce noise — npm writes long notice
+			// blocks to stdout that drown a short stderr error — so prefer one.
+			const stream = stderrStr !== "" ? stderrStr : stdoutStr;
+			if (stream !== "") {
+				const MAX = 2000;
+				const display =
+					stream.length <= MAX
+						? stream
+						: `...[${stream.length - MAX} chars truncated from head]...\n${stream.slice(-MAX)}`;
+				line += `:\n${display}`;
+			}
+		}
+		return line;
+	}
+}

--- a/src/errors/PullRequestError.ts
+++ b/src/errors/PullRequestError.ts
@@ -8,6 +8,8 @@ export class PullRequestError extends Data.TaggedError("PullRequestError")<{
 	readonly operation:
 		| "get"
 		| "list"
+		| "listFiles"
+		| "listAssociatedWithCommit"
 		| "create"
 		| "update"
 		| "getOrCreate"

--- a/src/errors/SbomError.ts
+++ b/src/errors/SbomError.ts
@@ -1,0 +1,16 @@
+import { Data } from "effect";
+
+/**
+ * Errors raised by Sbom operations.
+ *
+ * - `"build"`     — failed to construct the Bom model (bad input)
+ * - `"serialize"` — failed to serialize to JSON
+ * - `"save"`      — failed to write the BOM file to disk
+ *
+ * @public
+ */
+export class SbomError extends Data.TaggedError("SbomError")<{
+	readonly reason: "build" | "serialize" | "save";
+	readonly message: string;
+	readonly cause?: unknown;
+}> {}

--- a/src/errors/SigstoreSignerError.ts
+++ b/src/errors/SigstoreSignerError.ts
@@ -1,0 +1,16 @@
+import { Data } from "effect";
+
+/**
+ * Errors raised by SigstoreSigner.
+ *
+ * - `"sign"`    — Fulcio / FulcioSigner failed to produce a signature
+ * - `"witness"` — Rekor failed to issue a transparency-log entry
+ * - `"bundle"`  — bundle JSON could not be produced from the protobuf
+ *
+ * @public
+ */
+export class SigstoreSignerError extends Data.TaggedError("SigstoreSignerError")<{
+	readonly reason: "sign" | "witness" | "bundle";
+	readonly message: string;
+	readonly cause?: unknown;
+}> {}

--- a/src/errors/SlsaError.ts
+++ b/src/errors/SlsaError.ts
@@ -1,0 +1,16 @@
+import { Data } from "effect";
+
+/**
+ * Error raised by SLSA helpers.
+ *
+ * - `"decode"` — JWT payload could not be decoded
+ * - `"claims"` — decoded JWT is missing required claims
+ * - `"env"`    — predicate could not be assembled from the runner environment
+ *
+ * @public
+ */
+export class SlsaError extends Data.TaggedError("SlsaError")<{
+	readonly reason: "decode" | "claims" | "env";
+	readonly message: string;
+	readonly cause?: unknown;
+}> {}

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ export { ActionEnvironmentError } from "./errors/ActionEnvironmentError.js";
 export { ActionInputError } from "./errors/ActionInputError.js";
 export { ActionOutputError } from "./errors/ActionOutputError.js";
 export { ActionStateError } from "./errors/ActionStateError.js";
+export { AttestError } from "./errors/AttestError.js";
 export { ChangesetError } from "./errors/ChangesetError.js";
 export { CheckRunError } from "./errors/CheckRunError.js";
 export { CommandRunnerError } from "./errors/CommandRunnerError.js";
@@ -23,19 +24,26 @@ export { ConfigLoaderError } from "./errors/ConfigLoaderError.js";
 export { GitBranchError } from "./errors/GitBranchError.js";
 export { GitCommitError } from "./errors/GitCommitError.js";
 export { GitHubAppError } from "./errors/GitHubAppError.js";
+export { GitHubArtifactMetadataError } from "./errors/GitHubArtifactMetadataError.js";
 export { GitHubClientError } from "./errors/GitHubClientError.js";
+export { GitHubCommitError } from "./errors/GitHubCommitError.js";
+export { GitHubContentError } from "./errors/GitHubContentError.js";
 export { GitHubGraphQLError } from "./errors/GitHubGraphQLError.js";
 export { GitHubIssueError } from "./errors/GitHubIssueError.js";
 export { GitHubReleaseError } from "./errors/GitHubReleaseError.js";
 export { GitTagError } from "./errors/GitTagError.js";
 export { NpmRegistryError } from "./errors/NpmRegistryError.js";
+export { OidcTokenError } from "./errors/OidcTokenError.js";
 export { PackageManagerError } from "./errors/PackageManagerError.js";
 export { PackagePublishError } from "./errors/PackagePublishError.js";
 export { PullRequestCommentError } from "./errors/PullRequestCommentError.js";
 export { PullRequestError } from "./errors/PullRequestError.js";
 export { RateLimitError } from "./errors/RateLimitError.js";
 export { RuntimeEnvironmentError } from "./errors/RuntimeEnvironmentError.js";
+export { SbomError } from "./errors/SbomError.js";
 export { SemverResolverError } from "./errors/SemverResolverError.js";
+export { SigstoreSignerError } from "./errors/SigstoreSignerError.js";
+export { SlsaError } from "./errors/SlsaError.js";
 export { TokenPermissionError } from "./errors/TokenPermissionError.js";
 export { ToolInstallerError } from "./errors/ToolInstallerError.js";
 export { WorkflowDispatchError } from "./errors/WorkflowDispatchError.js";
@@ -57,6 +65,9 @@ export { ActionOutputsTest } from "./layers/ActionOutputsTest.js";
 export { ActionStateLive } from "./layers/ActionStateLive.js";
 export type { ActionStateTestState } from "./layers/ActionStateTest.js";
 export { ActionStateTest } from "./layers/ActionStateTest.js";
+export { AttestLive } from "./layers/AttestLive.js";
+export type { AttestTestState } from "./layers/AttestTest.js";
+export { AttestTest, AttestTestFullLayer, makeAttestTestState } from "./layers/AttestTest.js";
 export { ChangesetAnalyzerLive } from "./layers/ChangesetAnalyzerLive.js";
 export type { ChangesetAnalyzerTestState } from "./layers/ChangesetAnalyzerTest.js";
 export { ChangesetAnalyzerTest } from "./layers/ChangesetAnalyzerTest.js";
@@ -81,9 +92,18 @@ export { GitCommitTest } from "./layers/GitCommitTest.js";
 export { GitHubAppLive } from "./layers/GitHubAppLive.js";
 export type { GitHubAppTestState } from "./layers/GitHubAppTest.js";
 export { GitHubAppTest } from "./layers/GitHubAppTest.js";
+export { GitHubArtifactMetadataLive } from "./layers/GitHubArtifactMetadataLive.js";
+export type { GitHubArtifactMetadataTestState } from "./layers/GitHubArtifactMetadataTest.js";
+export { GitHubArtifactMetadataTest } from "./layers/GitHubArtifactMetadataTest.js";
 export { GitHubClientLive } from "./layers/GitHubClientLive.js";
 export type { GitHubClientTestState, RestResponse } from "./layers/GitHubClientTest.js";
 export { GitHubClientTest } from "./layers/GitHubClientTest.js";
+export { GitHubCommitLive } from "./layers/GitHubCommitLive.js";
+export type { GitHubCommitTestState } from "./layers/GitHubCommitTest.js";
+export { GitHubCommitTest } from "./layers/GitHubCommitTest.js";
+export { GitHubContentLive } from "./layers/GitHubContentLive.js";
+export type { GitHubContentTestState } from "./layers/GitHubContentTest.js";
+export { GitHubContentTest } from "./layers/GitHubContentTest.js";
 export { GitHubGraphQLLive } from "./layers/GitHubGraphQLLive.js";
 export type { GitHubGraphQLTestState } from "./layers/GitHubGraphQLTest.js";
 export { GitHubGraphQLTest } from "./layers/GitHubGraphQLTest.js";
@@ -100,6 +120,8 @@ export { NpmRegistryLive } from "./layers/NpmRegistryLive.js";
 export type { NpmRegistryTestState } from "./layers/NpmRegistryTest.js";
 export { NpmRegistryTest } from "./layers/NpmRegistryTest.js";
 export { OctokitAuthAppLive } from "./layers/OctokitAuthAppLive.js";
+export { OidcTokenIssuerLive, saveToken } from "./layers/OidcTokenIssuerLive.js";
+export { OidcTokenIssuerTest } from "./layers/OidcTokenIssuerTest.js";
 export { PackageManagerAdapterLive } from "./layers/PackageManagerAdapterLive.js";
 export type { PackageManagerAdapterTestState } from "./layers/PackageManagerAdapterTest.js";
 export { PackageManagerAdapterTest } from "./layers/PackageManagerAdapterTest.js";
@@ -115,6 +137,11 @@ export { PullRequestTest } from "./layers/PullRequestTest.js";
 export { RateLimiterLive } from "./layers/RateLimiterLive.js";
 export type { RateLimiterTestState } from "./layers/RateLimiterTest.js";
 export { RateLimiterTest } from "./layers/RateLimiterTest.js";
+export { SbomLive } from "./layers/SbomLive.js";
+export type { SbomTestState } from "./layers/SbomTest.js";
+export { SbomTest, makeSbomTestState } from "./layers/SbomTest.js";
+export { SigstoreSignerLive, makeSigstoreSignerLive } from "./layers/SigstoreSignerLive.js";
+export { SigstoreSignerTest } from "./layers/SigstoreSignerTest.js";
 export { TokenPermissionCheckerLive } from "./layers/TokenPermissionCheckerLive.js";
 export type { TokenPermissionCheckerTestState } from "./layers/TokenPermissionCheckerTest.js";
 export { TokenPermissionCheckerTest } from "./layers/TokenPermissionCheckerTest.js";
@@ -131,6 +158,18 @@ export { WorkspaceDetectorTest } from "./layers/WorkspaceDetectorTest.js";
 export { ActionsConfigProvider } from "./runtime/ActionsConfigProvider.js";
 export { ActionsLogger } from "./runtime/ActionsLogger.js";
 export { ActionsRuntime } from "./runtime/ActionsRuntime.js";
+export * as Step from "./runtime/Step.js";
+export type { AttestInput, AttestationRecord } from "./schemas/Attestation.js";
+export {
+	CYCLONEDX_BOM,
+	IN_TOTO_STATEMENT_V1,
+	InTotoStatement,
+	InTotoSubject,
+	SIGSTORE_BUNDLE_V0_3_MEDIA_TYPE,
+	SLSA_PROVENANCE_V1,
+	SPDX_V2_3,
+	SigstoreBundle,
+} from "./schemas/Attestation.js";
 // -- Schemas --
 export type {
 	BumpType as BumpTypeType,
@@ -179,8 +218,16 @@ export { ActionEnvironment } from "./services/ActionEnvironment.js";
 export { ActionLogger } from "./services/ActionLogger.js";
 export { ActionOutputs } from "./services/ActionOutputs.js";
 export { ActionState } from "./services/ActionState.js";
+export type { AttestationListEntry, ProvenanceAttestationInput, SbomAttestationInput } from "./services/Attest.js";
+export { Attest } from "./services/Attest.js";
 export { ChangesetAnalyzer } from "./services/ChangesetAnalyzer.js";
-export type { AnnotationLevel, CheckRunAnnotation, CheckRunConclusion, CheckRunOutput } from "./services/CheckRun.js";
+export type {
+	AnnotationLevel,
+	CheckRunAnnotation,
+	CheckRunConclusion,
+	CheckRunData,
+	CheckRunOutput,
+} from "./services/CheckRun.js";
 export { CheckRun } from "./services/CheckRun.js";
 export type { ExecOptions, ExecOutput } from "./services/CommandRunner.js";
 export { CommandRunner } from "./services/CommandRunner.js";
@@ -190,7 +237,12 @@ export { GitBranch } from "./services/GitBranch.js";
 export { GitCommit } from "./services/GitCommit.js";
 export type { BotIdentity, InstallationToken as InstallationTokenType } from "./services/GitHubApp.js";
 export { GitHubApp, InstallationToken } from "./services/GitHubApp.js";
+export type { StorageRecordInput } from "./services/GitHubArtifactMetadata.js";
+export { GitHubArtifactMetadata } from "./services/GitHubArtifactMetadata.js";
 export { GitHubClient } from "./services/GitHubClient.js";
+export type { CommitComparison, CommitDetail, CommitFile, CommitSummary } from "./services/GitHubCommit.js";
+export { GitHubCommit } from "./services/GitHubCommit.js";
+export { GitHubContent } from "./services/GitHubContent.js";
 export { GitHubGraphQL } from "./services/GitHubGraphQL.js";
 export type { IssueData } from "./services/GitHubIssue.js";
 export { GitHubIssue } from "./services/GitHubIssue.js";
@@ -201,15 +253,26 @@ export { GitTag } from "./services/GitTag.js";
 export { NpmRegistry } from "./services/NpmRegistry.js";
 export type { AppAuth } from "./services/OctokitAuthApp.js";
 export { OctokitAuthApp } from "./services/OctokitAuthApp.js";
+export { OidcTokenIssuer } from "./services/OidcTokenIssuer.js";
 export type { InstallOptions } from "./services/PackageManagerAdapter.js";
 export { PackageManagerAdapter } from "./services/PackageManagerAdapter.js";
-export type { PackResult, RegistryTarget } from "./services/PackagePublish.js";
+export type {
+	DryRunResult,
+	IdempotentPublishInput,
+	IdempotentPublishResult,
+	PackResult,
+	RegistryTarget,
+} from "./services/PackagePublish.js";
 export { PackagePublish } from "./services/PackagePublish.js";
-export type { PullRequestInfo, PullRequestListOptions } from "./services/PullRequest.js";
+export type { PullRequestFile, PullRequestInfo, PullRequestListOptions } from "./services/PullRequest.js";
 export { PullRequest } from "./services/PullRequest.js";
 export type { CommentRecord } from "./services/PullRequestComment.js";
 export { PullRequestComment } from "./services/PullRequestComment.js";
 export { RateLimiter } from "./services/RateLimiter.js";
+export type { CycloneDXBom, InFlightPackage, ResolvedDependency, SbomInput } from "./services/Sbom.js";
+export { Sbom } from "./services/Sbom.js";
+export type { SigstoreSignerConfig } from "./services/SigstoreSigner.js";
+export { IN_TOTO_PAYLOAD_TYPE, SIGSTORE_OIDC_AUDIENCE, SigstoreSigner } from "./services/SigstoreSigner.js";
 export { TokenPermissionChecker } from "./services/TokenPermissionChecker.js";
 export { ToolInstaller } from "./services/ToolInstaller.js";
 export type { PollOptions, WorkflowRunStatus } from "./services/WorkflowDispatch.js";
@@ -219,6 +282,19 @@ export { AutoMerge } from "./utils/AutoMerge.js";
 export type { AccumulateResult } from "./utils/ErrorAccumulator.js";
 export { ErrorAccumulator } from "./utils/ErrorAccumulator.js";
 export { GithubMarkdown } from "./utils/GithubMarkdown.js";
+export { buildStatement, npmPurl, serializeStatement, subject } from "./utils/intoto.js";
+export type { RegistryType } from "./utils/RegistryClassifier.js";
+export {
+	generatePackageViewUrl,
+	getRegistryDisplayName,
+	getRegistryType,
+	isCustomRegistry,
+	isGitHubPackagesRegistry,
+	isJsrRegistry,
+	isNpmRegistry,
+} from "./utils/RegistryClassifier.js";
 export type { Report } from "./utils/ReportBuilder.js";
 export { ReportBuilder } from "./utils/ReportBuilder.js";
 export { SemverResolver } from "./utils/SemverResolver.js";
+export type { OidcClaims } from "./utils/slsa.js";
+export { GITHUB_BUILD_TYPE, buildSLSAProvenancePredicate, decodeJwtClaims } from "./utils/slsa.js";

--- a/src/layers/ActionOutputsLive.test.ts
+++ b/src/layers/ActionOutputsLive.test.ts
@@ -1,4 +1,5 @@
 import { FileSystem } from "@effect/platform";
+import type { Exit } from "effect";
 import { Cause, Chunk, Effect, Layer, Schema } from "effect";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ActionOutputs } from "../services/ActionOutputs.js";
@@ -72,15 +73,30 @@ const makeTestLayer = (state: MockFsState) => Layer.succeed(FileSystem.FileSyste
 
 const makeFaultyTestLayer = (state: MockFsState) => Layer.succeed(FileSystem.FileSystem, makeFaultyMockFs(state));
 
+// `ActionOutputsLive` is `Layer<ActionOutputs, never, FileSystem.FileSystem>`;
+// providing the test FS layer fully resolves it. `tsgo` does not always narrow
+// `Effect.provide`'s requires-channel to `never` through the layer composition,
+// so an explicit `as Effect<..., never>` at each runner site keeps the test
+// helpers callable without leaking type variance noise into every invocation.
 const run = <A, E>(state: MockFsState, effect: Effect.Effect<A, E, ActionOutputs>) =>
-	Effect.runPromise(Effect.provide(effect, ActionOutputsLive.pipe(Layer.provide(makeTestLayer(state)))));
+	Effect.runPromise(
+		Effect.provide(effect, ActionOutputsLive.pipe(Layer.provide(makeTestLayer(state)))) as Effect.Effect<A, E, never>,
+	);
 
 const runExit = <A, E>(state: MockFsState, effect: Effect.Effect<A, E, ActionOutputs>) =>
-	Effect.runPromise(Effect.exit(Effect.provide(effect, ActionOutputsLive.pipe(Layer.provide(makeTestLayer(state))))));
+	Effect.runPromise(
+		Effect.exit(Effect.provide(effect, ActionOutputsLive.pipe(Layer.provide(makeTestLayer(state))))) as Effect.Effect<
+			Exit.Exit<A, E>,
+			never,
+			never
+		>,
+	);
 
 const runExitFaulty = <A, E>(state: MockFsState, effect: Effect.Effect<A, E, ActionOutputs>) =>
 	Effect.runPromise(
-		Effect.exit(Effect.provide(effect, ActionOutputsLive.pipe(Layer.provide(makeFaultyTestLayer(state))))),
+		Effect.exit(
+			Effect.provide(effect, ActionOutputsLive.pipe(Layer.provide(makeFaultyTestLayer(state)))),
+		) as Effect.Effect<Exit.Exit<A, E>, never, never>,
 	);
 
 // -- Tests --

--- a/src/layers/AttestLive.ts
+++ b/src/layers/AttestLive.ts
@@ -1,0 +1,421 @@
+/**
+ * Live implementation of the {@link Attest} service.
+ *
+ * @remarks
+ * Composes the pure in-toto builder ({@link buildStatement}), the
+ * {@link SigstoreSigner} (Fulcio + Rekor), and the upstream
+ * `GitHubClient` to provide a single `attest()` entry point for signed
+ * provenance + SBOM attestations.
+ */
+
+import { FileSystem } from "@effect/platform";
+import { Effect, Layer } from "effect";
+import { AttestError } from "../errors/AttestError.js";
+import type { AttestationRecord, SigstoreBundle } from "../schemas/Attestation.js";
+import { CYCLONEDX_BOM, InTotoStatement, SLSA_PROVENANCE_V1 } from "../schemas/Attestation.js";
+import type { AttestationListEntry } from "../services/Attest.js";
+import { Attest } from "../services/Attest.js";
+import { GitHubClient } from "../services/GitHubClient.js";
+import { Sbom } from "../services/Sbom.js";
+import { SigstoreSigner } from "../services/SigstoreSigner.js";
+import { buildStatement, subject as makeSubject, npmPurl, serializeStatement } from "../utils/intoto.js";
+
+const CREATE_ATTESTATION_REQUEST = "POST /repos/{owner}/{repo}/attestations" as const;
+const LIST_ATTESTATIONS_REQUEST = "GET /repos/{owner}/{repo}/attestations/{subject_digest}" as const;
+
+interface OctokitLike {
+	readonly request: (route: string, params: Record<string, unknown>) => Promise<{ data: unknown }>;
+}
+
+const isOctokitLike = (value: unknown): value is OctokitLike =>
+	typeof value === "object" &&
+	value !== null &&
+	"request" in value &&
+	typeof (value as OctokitLike).request === "function";
+
+const attestationIdFromResponse = (raw: unknown): number => {
+	const data = typeof raw === "string" ? JSON.parse(raw) : raw;
+	if (data && typeof data === "object" && "id" in data && typeof (data as { id: unknown }).id === "number") {
+		return (data as { id: number }).id;
+	}
+	throw new Error(
+		`GitHub attestations API response did not include a numeric id: ${JSON.stringify(data).slice(0, 200)}`,
+	);
+};
+
+/**
+ * Shape of one `attestations[]` entry on `GET /repos/.../attestations/{subject_digest}`.
+ *
+ * @remarks
+ * Mirrors the Octokit OpenAPI surface: `bundle.dsseEnvelope.payload`
+ * is a base64-encoded in-toto statement, `repository_id` /
+ * `bundle_url` / `initiator` are advisory metadata. The real GitHub
+ * API also includes an `id` field on each entry that the OpenAPI
+ * types omit — we read it defensively when present so the result's
+ * `attestationUrl` can point at the GitHub UI.
+ *
+ * @internal
+ */
+interface RawListedAttestation {
+	readonly id?: number;
+	readonly bundle?: {
+		readonly dsseEnvelope?: {
+			readonly payload?: string;
+		};
+	};
+	readonly bundle_url?: string;
+}
+
+/**
+ * Decode a base64-encoded DSSE payload and extract the in-toto
+ * statement's `predicateType`.
+ *
+ * @remarks
+ * The DSSE payload is a base64-encoded JSON in-toto statement; the
+ * statement carries `predicateType` as a top-level string. Returns
+ * `null` when the payload is missing, undecodable, or non-JSON —
+ * callers treat that as "unknown predicate type" and filter the
+ * entry out of any predicate-type-filtered result.
+ *
+ * @internal
+ */
+const predicateTypeFromBundle = (entry: RawListedAttestation): string | null => {
+	const payload = entry.bundle?.dsseEnvelope?.payload;
+	if (typeof payload !== "string" || payload.length === 0) return null;
+	try {
+		const decoded = Buffer.from(payload, "base64").toString("utf-8");
+		const statement = JSON.parse(decoded) as { predicateType?: unknown };
+		return typeof statement.predicateType === "string" ? statement.predicateType : null;
+	} catch {
+		return null;
+	}
+};
+
+/**
+ * Parse the raw `GET /repos/.../attestations/{subject_digest}` body
+ * into a list of {@link AttestationListEntry} rows.
+ *
+ * @remarks
+ * Owner/repo are needed to construct the GitHub UI URL when the
+ * response carries a numeric `id`. When `id` is missing, we fall
+ * back to `bundle_url` (the raw-bundle endpoint) so callers always
+ * receive a non-empty URL to surface.
+ *
+ * @internal
+ */
+const parseListedAttestations = (raw: unknown, owner: string, repo: string): ReadonlyArray<AttestationListEntry> => {
+	const data = typeof raw === "string" ? (JSON.parse(raw) as unknown) : raw;
+	const attestations =
+		data && typeof data === "object" && "attestations" in data
+			? (data as { attestations: ReadonlyArray<RawListedAttestation> | undefined }).attestations
+			: undefined;
+	if (!Array.isArray(attestations)) return [];
+
+	const entries: AttestationListEntry[] = [];
+	for (const entry of attestations) {
+		const predicateType = predicateTypeFromBundle(entry);
+		if (predicateType === null) continue;
+		const attestationUrl =
+			typeof entry.id === "number"
+				? `https://github.com/${owner}/${repo}/attestations/${entry.id}`
+				: typeof entry.bundle_url === "string" && entry.bundle_url.length > 0
+					? entry.bundle_url
+					: `https://github.com/${owner}/${repo}/attestations`;
+		entries.push({ attestationUrl, predicateType });
+	}
+	return entries;
+};
+
+/**
+ * `true` when an Octokit-style HTTP error reports the subject digest
+ * has no attestations.
+ *
+ * @remarks
+ * GitHub returns 404 when no attestations exist for a subject.
+ * Some deployments also serve 422 for invalid digest formats; we
+ * treat both as "empty list" so the orchestrator skips writing only
+ * when something is actually present, never because a probe failed.
+ *
+ * @internal
+ */
+const isEmptyListError = (cause: unknown): boolean => {
+	if (cause === null || typeof cause !== "object") return false;
+	const status = (cause as { status?: unknown }).status;
+	return status === 404 || status === 422;
+};
+
+/**
+ * Core attest-from-input flow shared by `attest`, `sbom`, and
+ * `provenance` — build the statement, sign it, POST to GitHub.
+ *
+ * @internal
+ */
+const attestFromInput = (
+	input: import("../schemas/Attestation.js").AttestInput,
+): Effect.Effect<
+	AttestationRecord,
+	AttestError,
+	SigstoreSigner | import("../services/OidcTokenIssuer.js").OidcTokenIssuer | GitHubClient
+> =>
+	Effect.gen(function* () {
+		const statement = yield* Effect.try({
+			try: () => buildStatement(input),
+			catch: (cause) =>
+				new AttestError({
+					reason: "build",
+					message: `Failed to build in-toto statement: ${cause instanceof Error ? cause.message : String(cause)}`,
+					cause,
+				}),
+		});
+
+		const signer = yield* SigstoreSigner;
+		const bundle = yield* signer.signStatement(statement).pipe(
+			Effect.mapError(
+				(cause) =>
+					new AttestError({
+						reason: "sign",
+						message: cause.message,
+						cause,
+					}),
+			),
+		);
+
+		const client = yield* GitHubClient;
+		const { owner, repo } = yield* client.repo.pipe(
+			Effect.mapError(
+				(cause) =>
+					new AttestError({
+						reason: "upload",
+						message: `Failed to resolve repo context: ${cause.reason}`,
+						cause,
+					}),
+			),
+		);
+
+		// Flatten the bundle to a pure JSON value for the request body: the
+		// round-trip drops any class prototypes and non-JSON fields from the
+		// in-memory `@sigstore/bundle` object so only wire-safe data is POSTed.
+		const bundlePayload = JSON.parse(JSON.stringify(bundle)) as Record<string, unknown>;
+		const attestationId = yield* client
+			.rest("repos.createAttestation", async (octokit) => {
+				if (!isOctokitLike(octokit)) {
+					throw new Error("GitHubClient did not provide an Octokit-compatible client");
+				}
+				const response = await octokit.request(CREATE_ATTESTATION_REQUEST, {
+					owner,
+					repo,
+					bundle: bundlePayload,
+				});
+				return { data: attestationIdFromResponse(response.data) };
+			})
+			.pipe(
+				Effect.mapError(
+					(cause) =>
+						new AttestError({
+							reason: "upload",
+							message: `Failed to persist attestation: ${cause.reason}`,
+							cause,
+						}),
+				),
+			);
+
+		const record: AttestationRecord = {
+			statement,
+			bundle,
+			attestationId,
+			attestationUrl: `https://github.com/${owner}/${repo}/attestations/${attestationId}`,
+		};
+		return record;
+	});
+
+/**
+ * Live {@link Attest} layer.
+ *
+ * @public
+ */
+export const AttestLive = Layer.succeed(Attest, {
+	buildStatement: (input) =>
+		Effect.try({
+			try: () => buildStatement(input),
+			catch: (cause) =>
+				new AttestError({
+					reason: "build",
+					message: `Failed to build in-toto statement: ${cause instanceof Error ? cause.message : String(cause)}`,
+					cause,
+				}),
+		}),
+
+	save: (data: InTotoStatement | SigstoreBundle, path: string) =>
+		Effect.gen(function* () {
+			const fs = yield* FileSystem.FileSystem;
+			const serialized = data instanceof InTotoStatement ? serializeStatement(data) : JSON.stringify(data, null, 2);
+			yield* fs.writeFileString(path, serialized).pipe(
+				Effect.mapError(
+					(error) =>
+						new AttestError({
+							reason: "save",
+							message: `Failed to write ${path}: ${error.message}`,
+							cause: error,
+						}),
+				),
+			);
+		}),
+
+	buildBundle: (input) =>
+		Effect.gen(function* () {
+			const statement = yield* Effect.try({
+				try: () => buildStatement(input),
+				catch: (cause) =>
+					new AttestError({
+						reason: "build",
+						message: `Failed to build in-toto statement: ${cause instanceof Error ? cause.message : String(cause)}`,
+						cause,
+					}),
+			});
+			const signer = yield* SigstoreSigner;
+			return yield* signer.signStatement(statement).pipe(
+				Effect.mapError(
+					(cause) =>
+						new AttestError({
+							reason: "sign",
+							message: cause.message,
+							cause,
+						}),
+				),
+			);
+		}),
+
+	attest: (input) => attestFromInput(input),
+
+	sbom: (input) =>
+		Effect.gen(function* () {
+			// Caller may supply EITHER `bomDocument` (attest the pre-built BOM
+			// verbatim) OR `dependencies` (build a fresh BOM via the Sbom service
+			// and attest that). When both are absent we fall back to the original
+			// empty-deps behaviour with a debug warning — keeps existing callers
+			// working mid-migration without quietly producing an empty SBOM.
+			let predicate: unknown;
+			if (input.bomDocument !== undefined) {
+				predicate = input.bomDocument;
+			} else {
+				if (input.dependencies === undefined) {
+					yield* Effect.logDebug(
+						"[Attest.sbom] neither `bomDocument` nor `dependencies` supplied; building an empty-deps BOM. New callers should provide one of the two.",
+					);
+				}
+				const sbomService = yield* Sbom;
+				// Build the SbomInput by spreading only the defined optional
+				// fields so `exactOptionalPropertyTypes` accepts the call.
+				const sbomInput = {
+					rootName: input.rootName,
+					rootVersion: input.rootVersion,
+					...(input.rootLicense !== undefined ? { rootLicense: input.rootLicense } : {}),
+					...(input.rootDescription !== undefined ? { rootDescription: input.rootDescription } : {}),
+					...(input.rootAuthor !== undefined ? { rootAuthor: input.rootAuthor } : {}),
+					...(input.supplier !== undefined ? { supplier: input.supplier } : {}),
+					...(input.authors !== undefined ? { authors: input.authors } : {}),
+					dependencies: input.dependencies ?? [],
+					...(input.inFlightPackages !== undefined ? { inFlightPackages: input.inFlightPackages } : {}),
+				};
+				const bom = yield* sbomService.generate(sbomInput).pipe(
+					Effect.mapError(
+						(cause) =>
+							new AttestError({
+								reason: "build",
+								message: `Failed to generate SBOM: ${cause.message}`,
+								cause,
+							}),
+					),
+				);
+				const bomJson = yield* sbomService.serializeJson(bom).pipe(
+					Effect.mapError(
+						(cause) =>
+							new AttestError({
+								reason: "build",
+								message: `Failed to serialize SBOM: ${cause.message}`,
+								cause,
+							}),
+					),
+				);
+				predicate = JSON.parse(bomJson) as unknown;
+			}
+
+			return yield* attestFromInput({
+				subjects: [makeSubject(npmPurl(input.rootName, input.rootVersion), input.subjectSha256)],
+				predicateType: CYCLONEDX_BOM,
+				predicate,
+			});
+		}),
+
+	provenance: (input) =>
+		attestFromInput({
+			subjects: [makeSubject(input.subjectName, input.subjectSha256)],
+			predicateType: SLSA_PROVENANCE_V1,
+			predicate: input.predicate,
+		}),
+
+	listForSubject: (subjectSha256, options) =>
+		Effect.gen(function* () {
+			const client = yield* GitHubClient;
+			const { owner, repo } = yield* client.repo.pipe(
+				Effect.mapError(
+					(cause) =>
+						new AttestError({
+							reason: "upload",
+							message: `Failed to resolve repo context: ${cause.reason}`,
+							cause,
+						}),
+				),
+			);
+
+			// GitHub's filter accepts the short aliases `provenance` / `sbom`
+			// or a freeform predicate-type URI. The orchestrator passes the
+			// full URI; we forward it unchanged so future filter tokens
+			// pass through transparently.
+			const predicateTypeFilter = options?.predicateType;
+			const entries = yield* client
+				.rest("repos.listAttestations", async (octokit) => {
+					if (!isOctokitLike(octokit)) {
+						throw new Error("GitHubClient did not provide an Octokit-compatible client");
+					}
+					try {
+						// `predicate_type` query parameter is deprecated as of
+						// 2026-03-10 and scheduled for removal 2028-03-10. We
+						// already filter client-side below (the canonical match
+						// because some predicates carry the freeform URI rather
+						// than the short alias the server accepts), so we omit
+						// the query entirely — the endpoint returns every
+						// attestation for the subject digest and the loop
+						// downstream selects the matching one.
+						const response = await octokit.request(LIST_ATTESTATIONS_REQUEST, {
+							owner,
+							repo,
+							subject_digest: `sha256:${subjectSha256}`,
+						});
+						return { data: parseListedAttestations(response.data, owner, repo) };
+					} catch (cause) {
+						if (isEmptyListError(cause)) {
+							return { data: [] as ReadonlyArray<AttestationListEntry> };
+						}
+						throw cause;
+					}
+				})
+				.pipe(
+					Effect.mapError(
+						(cause) =>
+							new AttestError({
+								reason: "upload",
+								message: `Failed to list attestations: ${cause.reason}`,
+								cause,
+							}),
+					),
+				);
+
+			// Server-side `predicate_type` is advisory — some attestations
+			// carry the freeform URI variant that the short-alias filter
+			// does not catch. Re-filter client-side on the parsed in-toto
+			// predicateType for an authoritative match.
+			if (predicateTypeFilter === undefined) return entries;
+			return entries.filter((e) => e.predicateType === predicateTypeFilter);
+		}),
+});

--- a/src/layers/AttestLive.ts
+++ b/src/layers/AttestLive.ts
@@ -11,7 +11,7 @@
 import { FileSystem } from "@effect/platform";
 import { Effect, Layer } from "effect";
 import { AttestError } from "../errors/AttestError.js";
-import type { AttestationRecord, SigstoreBundle } from "../schemas/Attestation.js";
+import type { AttestInput, AttestationRecord, SigstoreBundle } from "../schemas/Attestation.js";
 import { CYCLONEDX_BOM, InTotoStatement, SLSA_PROVENANCE_V1 } from "../schemas/Attestation.js";
 import type { AttestationListEntry } from "../services/Attest.js";
 import { Attest } from "../services/Attest.js";
@@ -145,28 +145,39 @@ const isEmptyListError = (cause: unknown): boolean => {
 };
 
 /**
+ * Build an in-toto statement from input, mapping any failure to a typed
+ * `AttestError` with `reason: "build"`. Shared by the `buildStatement` and
+ * `buildBundle` methods and the `attestFromInput` flow so the try/catch
+ * error-mapping lives in exactly one place.
+ *
+ * @internal
+ */
+const buildStatementEffect = (input: AttestInput): Effect.Effect<InTotoStatement, AttestError> =>
+	Effect.try({
+		try: () => buildStatement(input),
+		catch: (cause) =>
+			new AttestError({
+				reason: "build",
+				message: `Failed to build in-toto statement: ${cause instanceof Error ? cause.message : String(cause)}`,
+				cause,
+			}),
+	});
+
+/**
  * Core attest-from-input flow shared by `attest`, `sbom`, and
  * `provenance` — build the statement, sign it, POST to GitHub.
  *
  * @internal
  */
 const attestFromInput = (
-	input: import("../schemas/Attestation.js").AttestInput,
+	input: AttestInput,
 ): Effect.Effect<
 	AttestationRecord,
 	AttestError,
 	SigstoreSigner | import("../services/OidcTokenIssuer.js").OidcTokenIssuer | GitHubClient
 > =>
 	Effect.gen(function* () {
-		const statement = yield* Effect.try({
-			try: () => buildStatement(input),
-			catch: (cause) =>
-				new AttestError({
-					reason: "build",
-					message: `Failed to build in-toto statement: ${cause instanceof Error ? cause.message : String(cause)}`,
-					cause,
-				}),
-		});
+		const statement = yield* buildStatementEffect(input);
 
 		const signer = yield* SigstoreSigner;
 		const bundle = yield* signer.signStatement(statement).pipe(
@@ -234,16 +245,7 @@ const attestFromInput = (
  * @public
  */
 export const AttestLive = Layer.succeed(Attest, {
-	buildStatement: (input) =>
-		Effect.try({
-			try: () => buildStatement(input),
-			catch: (cause) =>
-				new AttestError({
-					reason: "build",
-					message: `Failed to build in-toto statement: ${cause instanceof Error ? cause.message : String(cause)}`,
-					cause,
-				}),
-		}),
+	buildStatement: (input) => buildStatementEffect(input),
 
 	save: (data: InTotoStatement | SigstoreBundle, path: string) =>
 		Effect.gen(function* () {
@@ -263,15 +265,7 @@ export const AttestLive = Layer.succeed(Attest, {
 
 	buildBundle: (input) =>
 		Effect.gen(function* () {
-			const statement = yield* Effect.try({
-				try: () => buildStatement(input),
-				catch: (cause) =>
-					new AttestError({
-						reason: "build",
-						message: `Failed to build in-toto statement: ${cause instanceof Error ? cause.message : String(cause)}`,
-						cause,
-					}),
-			});
+			const statement = yield* buildStatementEffect(input);
 			const signer = yield* SigstoreSigner;
 			return yield* signer.signStatement(statement).pipe(
 				Effect.mapError(

--- a/src/layers/AttestTest.test.ts
+++ b/src/layers/AttestTest.test.ts
@@ -1,0 +1,210 @@
+/**
+ * Step-7 tests for the Attest service: AttestTest + SbomTest layers.
+ *
+ * @remarks
+ * Exercises the test-layer factories themselves. Downstream packages
+ * will use these to wire `Attest` and `Sbom` into their own tests
+ * without spinning up Sigstore or GitHub.
+ */
+
+import { NodeFileSystem } from "@effect/platform-node";
+import { Cause, Effect, Exit, Layer } from "effect";
+import { describe, expect, it } from "vitest";
+import {
+	Attest,
+	AttestError,
+	AttestTestFullLayer,
+	CYCLONEDX_BOM,
+	IN_TOTO_STATEMENT_V1,
+	SLSA_PROVENANCE_V1,
+	Sbom,
+	SbomTest,
+	makeAttestTestState,
+	makeSbomTestState,
+	npmPurl,
+	subject,
+} from "../testing.js";
+
+describe("AttestTest — step 7", () => {
+	it(".empty() returns a working layer with default attestation id and repo", async () => {
+		const record = await Effect.runPromise(
+			Effect.gen(function* () {
+				const attest = yield* Attest;
+				return yield* attest.attest({
+					subjects: [subject("pkg:npm/x@1.0.0", "a".repeat(64))],
+					predicateType: SLSA_PROVENANCE_V1,
+					predicate: {},
+				});
+			}).pipe(Effect.provide(AttestTestFullLayer())),
+		);
+
+		expect(record.attestationId).toBe(1);
+		expect(record.attestationUrl).toBe("https://github.com/test-owner/test-repo/attestations/1");
+		expect(record.statement._type).toBe(IN_TOTO_STATEMENT_V1);
+	});
+
+	it(".layer(state) records every method call into state", async () => {
+		const state = makeAttestTestState({ attestationId: 99, repo: "acme/widgets" });
+
+		await Effect.runPromise(
+			Effect.gen(function* () {
+				const attest = yield* Attest;
+				yield* attest.buildStatement({
+					subjects: [subject("pkg:npm/a@1.0.0", "1".repeat(64))],
+					predicateType: SLSA_PROVENANCE_V1,
+					predicate: {},
+				});
+				yield* attest.attest({
+					subjects: [subject("pkg:npm/b@1.0.0", "2".repeat(64))],
+					predicateType: SLSA_PROVENANCE_V1,
+					predicate: {},
+				});
+				yield* attest.sbom({
+					rootName: "@savvy-web/example",
+					rootVersion: "1.0.0",
+					subjectSha256: "3".repeat(64),
+					dependencies: [{ name: "lodash", version: "4.17.21" }],
+				});
+				yield* attest.provenance({
+					subjectName: "pkg:npm/c@1.0.0",
+					subjectSha256: "4".repeat(64),
+					predicate: { buildDefinition: {}, runDetails: {} },
+				});
+			}).pipe(Effect.provide(AttestTestFullLayer(state))),
+		);
+
+		expect(state.buildStatementCalls).toHaveLength(1);
+		expect(state.attestCalls).toHaveLength(1);
+		expect(state.sbomCalls).toHaveLength(1);
+		expect(state.provenanceCalls).toHaveLength(1);
+
+		expect(state.buildStatementCalls[0].subjects[0].name).toBe("pkg:npm/a@1.0.0");
+		expect(state.sbomCalls[0].rootName).toBe("@savvy-web/example");
+		expect(state.provenanceCalls[0].subjectName).toBe("pkg:npm/c@1.0.0");
+	});
+
+	it("returned records use the configured attestation id and repo", async () => {
+		const state = makeAttestTestState({ attestationId: 42, repo: "acme/widgets" });
+
+		const record = await Effect.runPromise(
+			Effect.gen(function* () {
+				const attest = yield* Attest;
+				return yield* attest.sbom({
+					rootName: "root",
+					rootVersion: "1.0.0",
+					subjectSha256: "a".repeat(64),
+					dependencies: [],
+				});
+			}).pipe(Effect.provide(AttestTestFullLayer(state))),
+		);
+
+		expect(record.attestationId).toBe(42);
+		expect(record.attestationUrl).toBe("https://github.com/acme/widgets/attestations/42");
+		expect(record.statement.predicateType).toBe(CYCLONEDX_BOM);
+	});
+
+	it("save() records the path and data without touching disk", async () => {
+		const state = makeAttestTestState();
+
+		await Effect.runPromise(
+			Effect.gen(function* () {
+				const attest = yield* Attest;
+				const statement = yield* attest.buildStatement({
+					subjects: [subject(npmPurl("@savvy-web/example", "1.0.0"), "a".repeat(64))],
+					predicateType: SLSA_PROVENANCE_V1,
+					predicate: {},
+				});
+				yield* attest.save(statement, "/tmp/should-never-be-written.json");
+			}).pipe(Effect.provide(Layer.merge(AttestTestFullLayer(state), NodeFileSystem.layer))),
+		);
+
+		expect(state.saves.size).toBe(1);
+		expect(state.saves.has("/tmp/should-never-be-written.json")).toBe(true);
+	});
+
+	it("failWith causes every method to fail with the configured error", async () => {
+		const failure = new AttestError({ reason: "upload", message: "simulated 503" });
+		const state = makeAttestTestState({ failWith: failure });
+
+		const exit = await Effect.runPromise(
+			Effect.gen(function* () {
+				const attest = yield* Attest;
+				return yield* attest.attest({
+					subjects: [subject("pkg:npm/x@1.0.0", "a".repeat(64))],
+					predicateType: SLSA_PROVENANCE_V1,
+					predicate: {},
+				});
+			}).pipe(Effect.provide(AttestTestFullLayer(state)), Effect.exit),
+		);
+
+		expect(Exit.isFailure(exit)).toBe(true);
+		if (Exit.isFailure(exit)) {
+			const f = Cause.failureOption(exit.cause);
+			expect(f._tag).toBe("Some");
+			if (f._tag === "Some") {
+				expect(f.value._tag).toBe("AttestError");
+				expect(f.value.reason).toBe("upload");
+				expect(f.value.message).toBe("simulated 503");
+			}
+		}
+		// Calls still get recorded even when failWith is set — that's
+		// useful for asserting the SUT tried to do the right thing
+		// before the error surfaced.
+		expect(state.attestCalls).toHaveLength(1);
+	});
+});
+
+describe("SbomTest — step 7", () => {
+	it(".empty() returns a minimal CycloneDX 1.5 BOM", async () => {
+		const json = await Effect.runPromise(
+			Effect.gen(function* () {
+				const sbom = yield* Sbom;
+				const bom = yield* sbom.generate({
+					rootName: "root",
+					rootVersion: "1.0.0",
+					dependencies: [],
+				});
+				return yield* sbom.serializeJson(bom);
+			}).pipe(Effect.provide(SbomTest.empty())),
+		);
+
+		const parsed = JSON.parse(json) as { bomFormat: string; specVersion: string };
+		expect(parsed.bomFormat).toBe("CycloneDX");
+		expect(parsed.specVersion).toBe("1.5");
+	});
+
+	it(".layer(state) records generate calls and save paths", async () => {
+		const state = makeSbomTestState();
+
+		await Effect.runPromise(
+			Effect.gen(function* () {
+				const sbom = yield* Sbom;
+				const bom = yield* sbom.generate({
+					rootName: "@savvy-web/example",
+					rootVersion: "1.0.0",
+					dependencies: [{ name: "lodash", version: "4.17.21" }],
+				});
+				yield* sbom.save(bom, "/tmp/bom.json");
+			}).pipe(Effect.provide(Layer.merge(SbomTest.layer(state), NodeFileSystem.layer))),
+		);
+
+		expect(state.generateCalls).toHaveLength(1);
+		expect(state.generateCalls[0].rootName).toBe("@savvy-web/example");
+		expect(state.saves.size).toBe(1);
+		expect(state.saves.has("/tmp/bom.json")).toBe(true);
+	});
+
+	it("jsonResponse override is returned from serializeJson", async () => {
+		const state = makeSbomTestState({ jsonResponse: '{"custom":"bom"}' });
+
+		const json = await Effect.runPromise(
+			Effect.gen(function* () {
+				const sbom = yield* Sbom;
+				const bom = yield* sbom.generate({ rootName: "r", rootVersion: "0", dependencies: [] });
+				return yield* sbom.serializeJson(bom);
+			}).pipe(Effect.provide(SbomTest.layer(state))),
+		);
+
+		expect(json).toBe('{"custom":"bom"}');
+	});
+});

--- a/src/layers/AttestTest.ts
+++ b/src/layers/AttestTest.ts
@@ -1,0 +1,215 @@
+import { FileSystem } from "@effect/platform";
+import { Effect, Layer } from "effect";
+import type { AttestError } from "../errors/AttestError.js";
+import type { AttestInput, AttestationRecord, InTotoStatement } from "../schemas/Attestation.js";
+import { SIGSTORE_BUNDLE_V0_3_MEDIA_TYPE, SigstoreBundle } from "../schemas/Attestation.js";
+import type { AttestationListEntry, ProvenanceAttestationInput, SbomAttestationInput } from "../services/Attest.js";
+import { Attest } from "../services/Attest.js";
+import { buildStatement, subject as makeSubject } from "../utils/intoto.js";
+import { GitHubClientTest } from "./GitHubClientTest.js";
+import { OidcTokenIssuerTest } from "./OidcTokenIssuerTest.js";
+import { SbomTest } from "./SbomTest.js";
+import { SigstoreSignerTest } from "./SigstoreSignerTest.js";
+
+// ─── AttestTest ──────────────────────────────────────────────────────
+
+/**
+ * Mutable state recorded by {@link AttestTest.layer}.
+ *
+ * @public
+ */
+export interface AttestTestState {
+	/** Inputs passed to every {@link Attest.buildStatement} call. */
+	readonly buildStatementCalls: AttestInput[];
+	/** Inputs passed to every {@link Attest.buildBundle} call. */
+	readonly buildBundleCalls: AttestInput[];
+	/** Inputs passed to every {@link Attest.attest} call. */
+	readonly attestCalls: AttestInput[];
+	/** Inputs passed to every {@link Attest.sbom} call. */
+	readonly sbomCalls: SbomAttestationInput[];
+	/** Inputs passed to every {@link Attest.provenance} call. */
+	readonly provenanceCalls: ProvenanceAttestationInput[];
+	/** Inputs passed to every {@link Attest.listForSubject} call. */
+	readonly listForSubjectCalls: Array<{
+		readonly subjectSha256: string;
+		readonly predicateType: string | undefined;
+	}>;
+	/** Path → data captured by {@link Attest.save}. */
+	readonly saves: Map<string, InTotoStatement | SigstoreBundle>;
+	/**
+	 * Pre-seeded attestation entries indexed by tarball sha256-hex. The
+	 * {@link Attest.listForSubject} test implementation returns the
+	 * matching entry list (filtered by `predicateType` when requested);
+	 * an unseeded subject returns the empty array.
+	 */
+	readonly seedAttestations: Map<string, ReadonlyArray<AttestationListEntry>>;
+	/**
+	 * Override the synthetic attestation id used in returned records.
+	 * Defaults to `1`.
+	 */
+	readonly attestationId?: number;
+	/**
+	 * Override the synthetic GitHub repo path baked into the
+	 * attestation URL. Defaults to `"test-owner/test-repo"`.
+	 */
+	readonly repo?: string;
+	/**
+	 * If set, every Attest operation that would normally succeed fails
+	 * with this error instead. Useful for testing error-handling paths.
+	 */
+	readonly failWith?: AttestError;
+}
+
+/**
+ * Build a fresh, empty {@link AttestTestState}.
+ *
+ * @public
+ */
+export const makeAttestTestState = (overrides: Partial<AttestTestState> = {}): AttestTestState => ({
+	buildStatementCalls: [],
+	buildBundleCalls: [],
+	attestCalls: [],
+	sbomCalls: [],
+	provenanceCalls: [],
+	listForSubjectCalls: [],
+	saves: new Map(),
+	seedAttestations: new Map(),
+	...overrides,
+});
+
+const stubBundle = (): SigstoreBundle =>
+	new SigstoreBundle({
+		mediaType: SIGSTORE_BUNDLE_V0_3_MEDIA_TYPE,
+		verificationMaterial: { tlogEntries: [] },
+		dsseEnvelope: {
+			payload: "",
+			payloadType: "application/vnd.in-toto+json",
+			signatures: [{ sig: "test-signature", keyid: "" }],
+		},
+	});
+
+const stubRecord = (state: AttestTestState, statement: InTotoStatement): AttestationRecord => {
+	const id = state.attestationId ?? 1;
+	const repo = state.repo ?? "test-owner/test-repo";
+	return {
+		statement,
+		bundle: stubBundle(),
+		attestationId: id,
+		attestationUrl: `https://github.com/${repo}/attestations/${id}`,
+	};
+};
+
+const failOrSucceed = <A>(state: AttestTestState, value: A): Effect.Effect<A, AttestError> =>
+	state.failWith ? Effect.fail(state.failWith) : Effect.succeed(value);
+
+/**
+ * Test layer factories for {@link Attest}.
+ *
+ * @public
+ */
+export const AttestTest = {
+	/**
+	 * Test layer that records every call into `state` and returns
+	 * synthetic responses. Pass the same `state` object to your test's
+	 * assertions to inspect what was called.
+	 */
+	layer: (state: AttestTestState): Layer.Layer<Attest> =>
+		Layer.succeed(Attest, {
+			buildStatement: (input) =>
+				Effect.sync(() => {
+					state.buildStatementCalls.push(input);
+					return buildStatement(input);
+				}).pipe(Effect.flatMap((s) => failOrSucceed(state, s))),
+
+			save: (data, path) =>
+				Effect.gen(function* () {
+					if (state.failWith) return yield* Effect.fail(state.failWith);
+					state.saves.set(path, data);
+					// Touch FileSystem so the resource declaration in the
+					// service signature stays honest under the test layer.
+					yield* FileSystem.FileSystem;
+				}),
+
+			buildBundle: (input) =>
+				Effect.sync(() => {
+					state.buildBundleCalls.push(input);
+					return stubBundle();
+				}).pipe(Effect.flatMap((b) => failOrSucceed(state, b))),
+
+			attest: (input) =>
+				Effect.sync(() => {
+					state.attestCalls.push(input);
+					return stubRecord(state, buildStatement(input));
+				}).pipe(Effect.flatMap((r) => failOrSucceed(state, r))),
+
+			sbom: (input) =>
+				Effect.sync(() => {
+					state.sbomCalls.push(input);
+					// When the caller passed `bomDocument` (the explicit-BOM
+					// path) use it verbatim as the predicate; otherwise fall
+					// back to a minimal empty-deps CycloneDX stub. Mirrors the
+					// branch the live implementation takes so tests assert on
+					// the right shape.
+					const predicate: unknown =
+						input.bomDocument !== undefined
+							? input.bomDocument
+							: { bomFormat: "CycloneDX", specVersion: "1.5", components: [] };
+					return stubRecord(
+						state,
+						buildStatement({
+							subjects: [makeSubject(`pkg:npm/${input.rootName}@${input.rootVersion}`, input.subjectSha256)],
+							predicateType: "https://cyclonedx.org/bom",
+							predicate,
+						}),
+					);
+				}).pipe(Effect.flatMap((r) => failOrSucceed(state, r))),
+
+			provenance: (input) =>
+				Effect.sync(() => {
+					state.provenanceCalls.push(input);
+					return stubRecord(
+						state,
+						buildStatement({
+							subjects: [makeSubject(input.subjectName, input.subjectSha256)],
+							predicateType: "https://slsa.dev/provenance/v1",
+							predicate: input.predicate,
+						}),
+					);
+				}).pipe(Effect.flatMap((r) => failOrSucceed(state, r))),
+
+			listForSubject: (subjectSha256, options) =>
+				Effect.sync(() => {
+					state.listForSubjectCalls.push({
+						subjectSha256,
+						predicateType: options?.predicateType,
+					});
+					const seeded = state.seedAttestations.get(subjectSha256) ?? [];
+					return options?.predicateType !== undefined
+						? seeded.filter((e) => e.predicateType === options.predicateType)
+						: seeded;
+				}).pipe(Effect.flatMap((r) => failOrSucceed(state, r))),
+		}),
+
+	/**
+	 * Test layer with default state — useful when the test doesn't care
+	 * what calls were made, only that the service is available.
+	 */
+	empty: (): Layer.Layer<Attest> => AttestTest.layer(makeAttestTestState()),
+};
+
+/**
+ * Composed layer that provides `Attest` plus every dependency it
+ * declares (`SigstoreSigner`, `OidcTokenIssuer`, `Sbom`, and
+ * `GitHubClient`). Use this when you just want to call into `Attest`
+ * from a test without wiring four layers by hand.
+ *
+ * @public
+ */
+export const AttestTestFullLayer = (state: AttestTestState = makeAttestTestState()) =>
+	Layer.mergeAll(
+		AttestTest.layer(state),
+		SigstoreSignerTest,
+		OidcTokenIssuerTest,
+		SbomTest.empty(),
+		GitHubClientTest.empty(),
+	);

--- a/src/layers/CheckRunLive.test.ts
+++ b/src/layers/CheckRunLive.test.ts
@@ -7,6 +7,7 @@ import { CheckRunLive } from "./CheckRunLive.js";
 
 const mockCreate = vi.fn();
 const mockUpdate = vi.fn();
+const mockGet = vi.fn();
 
 const mockClient: typeof GitHubClient.Service = {
 	rest: <T>(_operation: string, fn: (octokit: unknown) => Promise<{ data: T }>) =>
@@ -14,7 +15,7 @@ const mockClient: typeof GitHubClient.Service = {
 			try: () =>
 				fn({
 					rest: {
-						checks: { create: mockCreate, update: mockUpdate },
+						checks: { create: mockCreate, update: mockUpdate, get: mockGet },
 					},
 				}),
 			catch: (e) =>
@@ -44,9 +45,11 @@ beforeEach(() => {
 describe("CheckRunLive", () => {
 	describe("create", () => {
 		it("calls checks.create and returns id", async () => {
-			mockCreate.mockResolvedValue({ data: { id: 123 } });
+			mockCreate.mockResolvedValue({
+				data: { id: 123, name: "my-check", status: "in_progress", conclusion: null, html_url: "https://gh/checks/123" },
+			});
 			const result = await run(Effect.flatMap(CheckRun, (svc) => svc.create("my-check", "abc123")));
-			expect(result).toBe(123);
+			expect(result.id).toBe(123);
 			expect(mockCreate).toHaveBeenCalledWith(
 				expect.objectContaining({
 					owner: "test-owner",
@@ -58,9 +61,36 @@ describe("CheckRunLive", () => {
 			);
 		});
 
+		it("create returns CheckRunData with the html_url", async () => {
+			mockCreate.mockResolvedValue({
+				data: { id: 7, name: "build", status: "in_progress", conclusion: null, html_url: "https://gh/checks/7" },
+			});
+			const result = await run(Effect.flatMap(CheckRun, (svc) => svc.create("build", "sha123")));
+			expect(result.id).toBe(7);
+			expect(result.htmlUrl).toBe("https://gh/checks/7");
+		});
+
 		it("fails on API error", async () => {
 			mockCreate.mockRejectedValue(new Error("api error"));
 			const exit = await runExit(Effect.flatMap(CheckRun, (svc) => svc.create("check", "sha")));
+			expect(exit._tag).toBe("Failure");
+		});
+	});
+
+	describe("get", () => {
+		it("get returns the check run's data", async () => {
+			mockGet.mockResolvedValue({
+				data: { id: 9, name: "build", status: "completed", conclusion: "success", html_url: "https://gh/checks/9" },
+			});
+			const result = await run(Effect.flatMap(CheckRun, (svc) => svc.get(9)));
+			expect(result.id).toBe(9);
+			expect(result.status).toBe("completed");
+			expect(result.conclusion).toBe("success");
+		});
+
+		it("fails on API error", async () => {
+			mockGet.mockRejectedValue(new Error("not found"));
+			const exit = await runExit(Effect.flatMap(CheckRun, (svc) => svc.get(99)));
 			expect(exit._tag).toBe("Failure");
 		});
 	});
@@ -127,7 +157,15 @@ describe("CheckRunLive", () => {
 
 	describe("withCheckRun", () => {
 		it("creates, runs effect, and completes with success", async () => {
-			mockCreate.mockResolvedValue({ data: { id: 10 } });
+			mockCreate.mockResolvedValue({
+				data: {
+					id: 10,
+					name: "bracket-check",
+					status: "in_progress",
+					conclusion: null,
+					html_url: "https://gh/checks/10",
+				},
+			});
 			mockUpdate.mockResolvedValue({ data: {} });
 			const result = await run(
 				Effect.flatMap(CheckRun, (svc) => svc.withCheckRun("bracket-check", "sha123", (_id) => Effect.succeed("done"))),
@@ -138,7 +176,9 @@ describe("CheckRunLive", () => {
 		});
 
 		it("completes with failure when effect fails", async () => {
-			mockCreate.mockResolvedValue({ data: { id: 11 } });
+			mockCreate.mockResolvedValue({
+				data: { id: 11, name: "fail-check", status: "in_progress", conclusion: null, html_url: "https://gh/checks/11" },
+			});
 			mockUpdate.mockResolvedValue({ data: {} });
 			const exit = await runExit(
 				Effect.flatMap(CheckRun, (svc) =>

--- a/src/layers/CheckRunLive.ts
+++ b/src/layers/CheckRunLive.ts
@@ -1,26 +1,43 @@
 import { Effect, Layer } from "effect";
 import { CheckRunError } from "../errors/CheckRunError.js";
 import type { GitHubClientError } from "../errors/GitHubClientError.js";
-import type { CheckRunConclusion, CheckRunOutput } from "../services/CheckRun.js";
+import type { CheckRunConclusion, CheckRunData, CheckRunOutput } from "../services/CheckRun.js";
 import { CheckRun } from "../services/CheckRun.js";
 import { GitHubClient } from "../services/GitHubClient.js";
 
 const mapError =
-	(name: string, operation: "create" | "update" | "complete") =>
+	(name: string, operation: "create" | "update" | "complete" | "get") =>
 	(error: GitHubClientError): CheckRunError =>
 		new CheckRunError({ name, operation, reason: error.reason });
+
+interface RawCheckRun {
+	readonly id: number;
+	readonly name: string;
+	readonly status: string;
+	readonly conclusion: string | null;
+	readonly html_url: string;
+}
 
 /** Minimal Octokit shape for checks API calls. */
 interface OctokitChecks {
 	readonly rest: {
 		readonly checks: {
-			readonly create: (args: Record<string, unknown>) => Promise<{ data: { id: number } }>;
+			readonly create: (args: Record<string, unknown>) => Promise<{ data: RawCheckRun }>;
 			readonly update: (args: Record<string, unknown>) => Promise<{ data: unknown }>;
+			readonly get: (args: Record<string, unknown>) => Promise<{ data: RawCheckRun }>;
 		};
 	};
 }
 
 const asChecks = (octokit: unknown): OctokitChecks => octokit as OctokitChecks;
+
+const toCheckRunData = (raw: RawCheckRun): CheckRunData => ({
+	id: raw.id,
+	name: raw.name,
+	status: raw.status as CheckRunData["status"],
+	conclusion: (raw.conclusion as CheckRunConclusion | null) ?? null,
+	htmlUrl: raw.html_url,
+});
 
 const formatOutput = (output: CheckRunOutput) => ({
 	title: output.title,
@@ -34,7 +51,7 @@ const formatOutput = (output: CheckRunOutput) => ({
 export const CheckRunLive: Layer.Layer<CheckRun, never, GitHubClient> = Layer.effect(
 	CheckRun,
 	Effect.map(GitHubClient, (client) => {
-		const createCheckRun = (name: string, headSha: string): Effect.Effect<number, CheckRunError> =>
+		const createCheckRun = (name: string, headSha: string): Effect.Effect<CheckRunData, CheckRunError> =>
 			Effect.flatMap(client.repo, ({ owner, repo }) =>
 				client.rest("checks.create", (octokit) =>
 					asChecks(octokit).rest.checks.create({
@@ -47,7 +64,7 @@ export const CheckRunLive: Layer.Layer<CheckRun, never, GitHubClient> = Layer.ef
 					}),
 				),
 			).pipe(
-				Effect.map((data) => (data as { id: number }).id),
+				Effect.map((data) => toCheckRunData(data as unknown as RawCheckRun)),
 				Effect.mapError(mapError(name, "create")),
 			);
 
@@ -74,6 +91,20 @@ export const CheckRunLive: Layer.Layer<CheckRun, never, GitHubClient> = Layer.ef
 		return {
 			create: createCheckRun,
 
+			get: (checkRunId) =>
+				Effect.flatMap(client.repo, ({ owner, repo }) =>
+					client.rest("checks.get", (octokit) =>
+						asChecks(octokit).rest.checks.get({
+							owner,
+							repo,
+							check_run_id: checkRunId,
+						}),
+					),
+				).pipe(
+					Effect.map((data) => toCheckRunData(data as unknown as RawCheckRun)),
+					Effect.mapError(mapError("", "get")),
+				),
+
 			update: (checkRunId, output) =>
 				Effect.flatMap(client.repo, ({ owner, repo }) =>
 					client.rest("checks.update", (octokit) =>
@@ -89,11 +120,11 @@ export const CheckRunLive: Layer.Layer<CheckRun, never, GitHubClient> = Layer.ef
 			complete: (checkRunId, conclusion, output) => completeCheckRun("", checkRunId, conclusion, output),
 
 			withCheckRun: (name, headSha, effect) =>
-				Effect.flatMap(createCheckRun(name, headSha), (checkRunId) =>
-					Effect.matchCauseEffect(effect(checkRunId), {
+				Effect.flatMap(createCheckRun(name, headSha), (checkRun) =>
+					Effect.matchCauseEffect(effect(checkRun.id), {
 						onFailure: (cause) =>
-							completeCheckRun(name, checkRunId, "failure").pipe(Effect.flatMap(() => Effect.failCause(cause))),
-						onSuccess: (result) => completeCheckRun(name, checkRunId, "success").pipe(Effect.map(() => result)),
+							completeCheckRun(name, checkRun.id, "failure").pipe(Effect.flatMap(() => Effect.failCause(cause))),
+						onSuccess: (result) => completeCheckRun(name, checkRun.id, "success").pipe(Effect.map(() => result)),
 					}),
 				),
 		};

--- a/src/layers/CheckRunTest.ts
+++ b/src/layers/CheckRunTest.ts
@@ -1,5 +1,6 @@
 import { Effect, Layer } from "effect";
-import type { CheckRunConclusion, CheckRunOutput } from "../services/CheckRun.js";
+import { CheckRunError } from "../errors/CheckRunError.js";
+import type { CheckRunConclusion, CheckRunData, CheckRunOutput } from "../services/CheckRun.js";
 import { CheckRun } from "../services/CheckRun.js";
 
 /**
@@ -11,6 +12,7 @@ export interface CheckRunRecord {
 	readonly id: number;
 	readonly name: string;
 	readonly headSha: string;
+	readonly htmlUrl: string;
 	status: "in_progress" | "completed";
 	conclusion?: CheckRunConclusion;
 	readonly outputs: Array<CheckRunOutput>;
@@ -26,20 +28,41 @@ export interface CheckRunTestState {
 	nextId: number;
 }
 
+const recordToData = (run: CheckRunRecord): CheckRunData => ({
+	id: run.id,
+	name: run.name,
+	status: run.status,
+	conclusion: run.conclusion ?? null,
+	htmlUrl: run.htmlUrl,
+});
+
 const makeTestCheckRun = (state: CheckRunTestState): typeof CheckRun.Service => {
 	const impl: typeof CheckRun.Service = {
 		create: (name, headSha) =>
 			Effect.sync(() => {
 				const id = state.nextId++;
-				state.runs.push({
+				const run: CheckRunRecord = {
 					id,
 					name,
 					headSha,
+					htmlUrl: `https://github.com/test/checks/${id}`,
 					status: "in_progress",
 					outputs: [],
-				});
-				return id;
+				};
+				state.runs.push(run);
+				return recordToData(run);
 			}),
+
+		get: (checkRunId) =>
+			Effect.sync(() => state.runs.find((r) => r.id === checkRunId)).pipe(
+				Effect.flatMap((run) =>
+					run
+						? Effect.succeed(recordToData(run))
+						: Effect.fail(
+								new CheckRunError({ name: "", operation: "get", reason: `No check run with id ${checkRunId}` }),
+							),
+				),
+			),
 
 		update: (checkRunId, output) =>
 			Effect.sync(() => {
@@ -62,10 +85,10 @@ const makeTestCheckRun = (state: CheckRunTestState): typeof CheckRun.Service => 
 			}),
 
 		withCheckRun: (name, headSha, effect) =>
-			Effect.flatMap(impl.create(name, headSha), (checkRunId) =>
-				Effect.matchCauseEffect(effect(checkRunId), {
-					onFailure: (cause) => Effect.flatMap(impl.complete(checkRunId, "failure"), () => Effect.failCause(cause)),
-					onSuccess: (result) => Effect.map(impl.complete(checkRunId, "success"), () => result),
+			Effect.flatMap(impl.create(name, headSha), (checkRun) =>
+				Effect.matchCauseEffect(effect(checkRun.id), {
+					onFailure: (cause) => Effect.flatMap(impl.complete(checkRun.id, "failure"), () => Effect.failCause(cause)),
+					onSuccess: (result) => Effect.map(impl.complete(checkRun.id, "success"), () => result),
 				}),
 			),
 	};

--- a/src/layers/CommandRunnerLive.ts
+++ b/src/layers/CommandRunnerLive.ts
@@ -90,6 +90,11 @@ const failOnNonZero = (
 					args,
 					exitCode: output.exitCode,
 					stderr: output.stderr,
+					// Surface stdout too — npm emits progress, notices, and
+					// (occasionally) error context on stdout, so a downstream
+					// `CommandRunnerError.message` getter can fall back to it
+					// when stderr is empty.
+					stdout: output.stdout,
 					reason: `Command exited with code ${output.exitCode}`,
 				}),
 			);

--- a/src/layers/GitHubArtifactMetadataLive.test.ts
+++ b/src/layers/GitHubArtifactMetadataLive.test.ts
@@ -1,0 +1,134 @@
+import { Effect, Layer } from "effect";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { GitHubArtifactMetadataError } from "../errors/GitHubArtifactMetadataError.js";
+import { GitHubClientError } from "../errors/GitHubClientError.js";
+import { GitHubArtifactMetadata } from "../services/GitHubArtifactMetadata.js";
+import { GitHubClient } from "../services/GitHubClient.js";
+import { GitHubArtifactMetadataLive } from "./GitHubArtifactMetadataLive.js";
+
+const mockRequest = vi.fn();
+
+const mockClient: typeof GitHubClient.Service = {
+	rest: <T>(_operation: string, fn: (octokit: unknown) => Promise<{ data: T }>) =>
+		Effect.tryPromise({
+			try: () =>
+				fn({
+					request: mockRequest,
+				}),
+			catch: (e) =>
+				new GitHubClientError({
+					operation: _operation,
+					status: undefined,
+					reason: e instanceof Error ? e.message : String(e),
+					retryable: false,
+				}),
+		}).pipe(Effect.map((r) => r.data)),
+	graphql: () => Effect.die("not used"),
+	paginate: <T>(
+		_operation: string,
+		fn: (octokit: unknown, page: number, perPage: number) => Promise<{ data: T[] }>,
+		_options?: { perPage?: number; maxPages?: number },
+	) =>
+		Effect.tryPromise({
+			try: () =>
+				fn(
+					{
+						request: mockRequest,
+					},
+					1,
+					30,
+				),
+			catch: (e) =>
+				new GitHubClientError({
+					operation: _operation,
+					status: undefined,
+					reason: e instanceof Error ? e.message : String(e),
+					retryable: false,
+				}),
+		}).pipe(Effect.map((r) => r.data)),
+	repo: Effect.succeed({ owner: "test-owner", repo: "test-repo" }),
+};
+
+const testLayer = Layer.provide(GitHubArtifactMetadataLive, Layer.succeed(GitHubClient, mockClient));
+
+const run = <A, E>(effect: Effect.Effect<A, E, GitHubArtifactMetadata>) =>
+	Effect.runPromise(Effect.provide(effect, testLayer));
+
+const runExit = <A, E>(effect: Effect.Effect<A, E, GitHubArtifactMetadata>) =>
+	Effect.runPromise(Effect.exit(Effect.provide(effect, testLayer)));
+
+beforeEach(() => {
+	vi.clearAllMocks();
+});
+
+describe("GitHubArtifactMetadataLive", () => {
+	describe("createStorageRecord", () => {
+		it("posts the record and returns the created ids", async () => {
+			mockRequest.mockResolvedValue({
+				data: {
+					storage_records: [{ id: 11 }, { id: 12 }],
+				},
+			});
+
+			const result = await run(
+				Effect.flatMap(GitHubArtifactMetadata, (svc) =>
+					svc.createStorageRecord({
+						name: "pkg:npm/@scope/pkg@1.2.3",
+						digest: "sha256:abc123",
+						version: "1.2.3",
+						registryUrl: "https://npm.pkg.github.com/",
+						artifactUrl: "https://github.com/packages/npm/@scope/pkg/123",
+						repo: "pkg",
+					}),
+				),
+			);
+
+			expect(result).toEqual([11, 12]);
+			expect(mockRequest).toHaveBeenCalledWith(
+				"POST /orgs/{owner}/artifacts/metadata/storage-record",
+				expect.objectContaining({
+					owner: "test-owner",
+					registry_url: "https://npm.pkg.github.com/",
+					artifact_url: "https://github.com/packages/npm/@scope/pkg/123",
+				}),
+			);
+			// Ensure camelCase inputs are NOT passed as-is (snake_case keys required)
+			expect(mockRequest).not.toHaveBeenCalledWith(
+				expect.anything(),
+				expect.objectContaining({ registryUrl: expect.anything() }),
+			);
+			expect(mockRequest).not.toHaveBeenCalledWith(
+				expect.anything(),
+				expect.objectContaining({ artifactUrl: expect.anything() }),
+			);
+		});
+
+		it("fails with GitHubArtifactMetadataError when the request fails", async () => {
+			mockRequest.mockRejectedValue(new Error("network failure"));
+
+			const exit = await runExit(
+				Effect.flatMap(GitHubArtifactMetadata, (svc) =>
+					svc.createStorageRecord({
+						name: "pkg:npm/@scope/pkg@1.2.3",
+						digest: "sha256:abc123",
+						version: "1.2.3",
+						registryUrl: "https://npm.pkg.github.com/",
+						artifactUrl: "https://github.com/packages/npm/@scope/pkg/123",
+						repo: "pkg",
+					}),
+				),
+			);
+
+			expect(exit._tag).toBe("Failure");
+			if (exit._tag === "Failure") {
+				const cause = exit.cause;
+				expect(cause._tag).toBe("Fail");
+				if (cause._tag === "Fail") {
+					const error = cause.error;
+					expect(error).toBeInstanceOf(GitHubArtifactMetadataError);
+					expect((error as GitHubArtifactMetadataError).operation).toBe("createStorageRecord");
+				}
+			}
+		});
+	});
+});

--- a/src/layers/GitHubArtifactMetadataLive.ts
+++ b/src/layers/GitHubArtifactMetadataLive.ts
@@ -1,0 +1,53 @@
+import { Effect, Layer } from "effect";
+import { GitHubArtifactMetadataError } from "../errors/GitHubArtifactMetadataError.js";
+import type { GitHubClientError } from "../errors/GitHubClientError.js";
+import { GitHubArtifactMetadata } from "../services/GitHubArtifactMetadata.js";
+import { GitHubClient } from "../services/GitHubClient.js";
+
+/** Minimal Octokit shape for the low-level `request` method. */
+interface OctokitRequest {
+	readonly request: (route: string, params: Record<string, unknown>) => Promise<{ data: unknown }>;
+}
+
+/** The storage-record endpoint's response shape. */
+interface RawStorageResponse {
+	readonly storage_records?: ReadonlyArray<{ readonly id: number }>;
+}
+
+/**
+ * Live `GitHubArtifactMetadata` layer.
+ *
+ * @public
+ */
+export const GitHubArtifactMetadataLive: Layer.Layer<GitHubArtifactMetadata, never, GitHubClient> = Layer.effect(
+	GitHubArtifactMetadata,
+	Effect.map(GitHubClient, (client) => ({
+		createStorageRecord: (input) =>
+			Effect.flatMap(client.repo, ({ owner }) =>
+				client.rest<ReadonlyArray<number>>("orgs.createArtifactStorageRecord", async (octokit) => {
+					const ok = octokit as OctokitRequest;
+					const response = await ok.request("POST /orgs/{owner}/artifacts/metadata/storage-record", {
+						owner,
+						name: input.name,
+						digest: input.digest,
+						version: input.version,
+						registry_url: input.registryUrl,
+						artifact_url: input.artifactUrl,
+						repo: input.repo,
+					});
+					const data = typeof response.data === "string" ? (JSON.parse(response.data) as unknown) : response.data;
+					const ids = (data as RawStorageResponse | null)?.storage_records?.map((r) => r.id) ?? [];
+					return { data: ids };
+				}),
+			).pipe(
+				Effect.mapError(
+					(error: GitHubClientError) =>
+						new GitHubArtifactMetadataError({
+							operation: "createStorageRecord",
+							reason: error.reason,
+							retryable: error.retryable,
+						}),
+				),
+			),
+	})),
+);

--- a/src/layers/GitHubArtifactMetadataTest.ts
+++ b/src/layers/GitHubArtifactMetadataTest.ts
@@ -1,0 +1,39 @@
+import { Effect, Layer } from "effect";
+import type { GitHubArtifactMetadata, StorageRecordInput } from "../services/GitHubArtifactMetadata.js";
+import { GitHubArtifactMetadata as GitHubArtifactMetadataTag } from "../services/GitHubArtifactMetadata.js";
+
+/**
+ * Test state for `GitHubArtifactMetadata`.
+ *
+ * @public
+ */
+export interface GitHubArtifactMetadataTestState {
+	/** Recorded `createStorageRecord` calls. */
+	readonly calls: Array<StorageRecordInput>;
+	/** Record IDs `createStorageRecord` returns. */
+	readonly recordIds: ReadonlyArray<number>;
+}
+
+const makeTestClient = (state: GitHubArtifactMetadataTestState): typeof GitHubArtifactMetadata.Service => ({
+	createStorageRecord: (input) => {
+		state.calls.push(input);
+		return Effect.succeed(state.recordIds);
+	},
+});
+
+/**
+ * Test implementation for `GitHubArtifactMetadata`.
+ *
+ * @public
+ */
+export const GitHubArtifactMetadataTest = {
+	/** Create a test layer with pre-configured state. */
+	layer: (state: GitHubArtifactMetadataTestState): Layer.Layer<GitHubArtifactMetadata> =>
+		Layer.succeed(GitHubArtifactMetadataTag, makeTestClient(state)),
+
+	/** Create a test layer with empty state. Returns both state and layer for assertions. */
+	empty: (): { state: GitHubArtifactMetadataTestState; layer: Layer.Layer<GitHubArtifactMetadata> } => {
+		const state: GitHubArtifactMetadataTestState = { calls: [], recordIds: [1] };
+		return { state, layer: Layer.succeed(GitHubArtifactMetadataTag, makeTestClient(state)) };
+	},
+} as const;

--- a/src/layers/GitHubClientLive.ts
+++ b/src/layers/GitHubClientLive.ts
@@ -3,11 +3,47 @@ import type { Redacted } from "effect";
 import { Effect, Layer } from "effect";
 import type { GitHubAppError } from "../errors/GitHubAppError.js";
 import { GitHubClientError } from "../errors/GitHubClientError.js";
+import * as WorkflowCommand from "../runtime/WorkflowCommand.js";
 import { GitHubApp } from "../services/GitHubApp.js";
 import { GitHubClient } from "../services/GitHubClient.js";
 import { unwrapRedacted } from "../utils/unwrapRedacted.js";
 import { GitHubAppLive } from "./GitHubAppLive.js";
 import { OctokitAuthAppLive } from "./OctokitAuthAppLive.js";
+
+/**
+ * Custom `log` sink installed on every Octokit instance to suppress the
+ * `@octokit/plugin-request-log` per-request lines that would otherwise
+ * leak past `Step.withStep`'s buffer.
+ *
+ * The plugin is enabled by default in `@octokit/rest`. Its wrap-hook
+ * calls `octokit.log.info(...)` after every successful request and
+ * `octokit.log.error(...)` on failure — the latter producing lines
+ * like `POST /repos/owner/name/git/refs - 422 with id ... in 412ms`
+ * that we see in the runner UI even after the orchestrator has caught
+ * the error and recovered (idempotent recovery, `getReleaseByTag`
+ * fallback, etc).
+ *
+ * Routing through `WorkflowCommand.issue("debug", …)` emits a
+ * `::debug::` workflow command — visible only when the workflow
+ * exports `ACTIONS_STEP_DEBUG=true`. The full error context the user
+ * needs on a real failure is already carried by the `GitHubClientError`
+ * that `wrapError` constructs and surfaces through Effect's error
+ * channel.
+ */
+const silentOctokitLog = {
+	debug: (message: string): void => {
+		WorkflowCommand.issue("debug", {}, message);
+	},
+	info: (message: string): void => {
+		WorkflowCommand.issue("debug", {}, message);
+	},
+	warn: (message: string): void => {
+		WorkflowCommand.issue("debug", {}, message);
+	},
+	error: (message: string): void => {
+		WorkflowCommand.issue("debug", {}, message);
+	},
+};
 
 const isRetryableStatus = (status: number): boolean => status === 429 || status >= 500;
 
@@ -32,7 +68,7 @@ const wrapError = (operation: string, error: unknown): GitHubClientError => {
 
 /** Build the GitHubClient service object from a concrete token. */
 const makeClient = (token: string): typeof GitHubClient.Service => {
-	const octokit = new Octokit({ auth: token });
+	const octokit = new Octokit({ auth: token, log: silentOctokitLog });
 	return {
 		rest: <T>(operation: string, fn: (octokit: unknown) => Promise<{ data: T }>) =>
 			Effect.tryPromise({

--- a/src/layers/GitHubCommitLive.test.ts
+++ b/src/layers/GitHubCommitLive.test.ts
@@ -1,0 +1,116 @@
+import { Effect } from "effect";
+import { describe, expect, it } from "vitest";
+import { GitHubCommit } from "../services/GitHubCommit.js";
+import type { GitHubClientTestState, RestResponse } from "./GitHubClientTest.js";
+import { GitHubClientTest } from "./GitHubClientTest.js";
+import { GitHubCommitLive } from "./GitHubCommitLive.js";
+
+const clientState = (overrides: {
+	rest?: Array<[string, RestResponse]>;
+	paginate?: Array<[string, Array<unknown[]>]>;
+}): GitHubClientTestState => ({
+	restResponses: new Map(overrides.rest ?? []),
+	paginateResponses: new Map(overrides.paginate ?? []),
+	graphqlResponses: new Map(),
+	repo: { owner: "owner", repo: "repo" },
+});
+
+describe("GitHubCommitLive", () => {
+	it("get maps a commit to CommitDetail with parents", async () => {
+		const result = await Effect.runPromise(
+			Effect.gen(function* () {
+				const svc = yield* GitHubCommit;
+				return yield* svc.get("sha1");
+			}).pipe(
+				Effect.provide(GitHubCommitLive),
+				Effect.provide(
+					GitHubClientTest.layer(
+						clientState({
+							rest: [
+								[
+									"repos.getCommit",
+									{
+										data: {
+											sha: "sha1",
+											commit: { message: "feat: x", author: { name: "Ann" } },
+											parents: [{ sha: "parent-sha" }],
+										},
+									},
+								],
+							],
+						}),
+					),
+				),
+			),
+		);
+		expect(result).toEqual({
+			sha: "sha1",
+			message: "feat: x",
+			author: "Ann",
+			parents: [{ sha: "parent-sha" }],
+		});
+	});
+
+	it("list maps paginated commits to CommitSummary[]", async () => {
+		const result = await Effect.runPromise(
+			Effect.gen(function* () {
+				const svc = yield* GitHubCommit;
+				return yield* svc.list("main");
+			}).pipe(
+				Effect.provide(GitHubCommitLive),
+				Effect.provide(
+					GitHubClientTest.layer(
+						clientState({
+							paginate: [["repos.listCommits", [[{ sha: "c1", commit: { message: "m1", author: { name: "A" } } }]]]],
+						}),
+					),
+				),
+			),
+		);
+		expect(result).toEqual([{ sha: "c1", message: "m1", author: "A" }]);
+	});
+
+	it("compare maps a comparison to commits and files", async () => {
+		const result = await Effect.runPromise(
+			Effect.gen(function* () {
+				const svc = yield* GitHubCommit;
+				return yield* svc.compare("base", "head");
+			}).pipe(
+				Effect.provide(GitHubCommitLive),
+				Effect.provide(
+					GitHubClientTest.layer(
+						clientState({
+							rest: [
+								[
+									"repos.compareCommits",
+									{
+										data: {
+											commits: [{ sha: "c1", commit: { message: "m1" } }],
+											files: [{ filename: "a/package.json", status: "modified" }],
+										},
+									},
+								],
+							],
+						}),
+					),
+				),
+			),
+		);
+		expect(result).toEqual({
+			commits: [{ sha: "c1", message: "m1", author: "Unknown" }],
+			files: [{ filename: "a/package.json", status: "modified" }],
+		});
+	});
+
+	it("compare wraps client errors as GitHubCommitError carrying the base...head ref", async () => {
+		const result = await Effect.runPromise(
+			Effect.gen(function* () {
+				const svc = yield* GitHubCommit;
+				return yield* svc.compare("base", "head");
+			}).pipe(Effect.provide(GitHubCommitLive), Effect.provide(GitHubClientTest.layer(clientState({}))), Effect.flip),
+		);
+		expect(result._tag).toBe("GitHubCommitError");
+		expect(result.operation).toBe("compare");
+		expect(result.ref).toBe("base...head");
+	});
+});

--- a/src/layers/GitHubCommitLive.ts
+++ b/src/layers/GitHubCommitLive.ts
@@ -1,0 +1,103 @@
+import { Effect, Layer } from "effect";
+import type { GitHubClientError } from "../errors/GitHubClientError.js";
+import { GitHubCommitError } from "../errors/GitHubCommitError.js";
+import { GitHubClient } from "../services/GitHubClient.js";
+import type { CommitComparison, CommitDetail, CommitSummary } from "../services/GitHubCommit.js";
+import { GitHubCommit } from "../services/GitHubCommit.js";
+
+interface RawCommitAuthor {
+	readonly name?: string;
+}
+interface RawCommitMeta {
+	readonly message: string;
+	readonly author?: RawCommitAuthor;
+}
+interface RawListedCommit {
+	readonly sha: string;
+	readonly commit: RawCommitMeta;
+}
+interface RawCommit extends RawListedCommit {
+	readonly parents: ReadonlyArray<{ readonly sha: string }>;
+}
+interface RawCommitFile {
+	readonly filename: string;
+	readonly status: string;
+}
+interface RawComparison {
+	readonly commits: ReadonlyArray<RawListedCommit>;
+	readonly files?: ReadonlyArray<RawCommitFile>;
+}
+
+/** Minimal Octokit shape for repo commit API calls. */
+interface OctokitCommits {
+	readonly rest: {
+		readonly repos: {
+			readonly getCommit: (args: Record<string, unknown>) => Promise<{ data: RawCommit }>;
+			readonly listCommits: (args: Record<string, unknown>) => Promise<{ data: RawListedCommit[] }>;
+			readonly compareCommits: (args: Record<string, unknown>) => Promise<{ data: RawComparison }>;
+		};
+	};
+}
+
+const asCommits = (octokit: unknown): OctokitCommits => octokit as OctokitCommits;
+
+const toSummary = (raw: RawListedCommit): CommitSummary => ({
+	sha: raw.sha,
+	message: raw.commit.message,
+	author: raw.commit.author?.name ?? "Unknown",
+});
+
+const toDetail = (raw: RawCommit): CommitDetail => ({
+	...toSummary(raw),
+	parents: raw.parents.map((p) => ({ sha: p.sha })),
+});
+
+const toComparison = (raw: RawComparison): CommitComparison => ({
+	commits: raw.commits.map(toSummary),
+	files: (raw.files ?? []).map((f) => ({ filename: f.filename, status: f.status })),
+});
+
+const mapClientError =
+	(operation: GitHubCommitError["operation"], ref?: string) =>
+	(error: GitHubClientError): GitHubCommitError =>
+		new GitHubCommitError({
+			operation,
+			...(ref !== undefined ? { ref } : {}),
+			reason: error.reason,
+		});
+
+export const GitHubCommitLive: Layer.Layer<GitHubCommit, never, GitHubClient> = Layer.effect(
+	GitHubCommit,
+	Effect.map(GitHubClient, (client) => ({
+		get: (ref: string) =>
+			Effect.flatMap(client.repo, ({ owner, repo }) =>
+				client.rest("repos.getCommit", (octokit) => asCommits(octokit).rest.repos.getCommit({ owner, repo, ref })),
+			).pipe(
+				Effect.map((data) => toDetail(data as unknown as RawCommit)),
+				Effect.mapError(mapClientError("get", ref)),
+			),
+
+		list: (ref: string) =>
+			Effect.flatMap(client.repo, ({ owner, repo }) =>
+				client.paginate(
+					"repos.listCommits",
+					(octokit, page, perPage) =>
+						asCommits(octokit).rest.repos.listCommits({ owner, repo, sha: ref, page, per_page: perPage }),
+					{},
+				),
+			).pipe(
+				Effect.map((items) => (items as unknown as RawListedCommit[]).map(toSummary)),
+				Effect.mapError(mapClientError("list", ref)),
+			),
+
+		compare: (base: string, head: string) =>
+			Effect.flatMap(client.repo, ({ owner, repo }) =>
+				client.rest("repos.compareCommits", (octokit) =>
+					asCommits(octokit).rest.repos.compareCommits({ owner, repo, base, head }),
+				),
+			).pipe(
+				Effect.map((data) => toComparison(data as unknown as RawComparison)),
+				Effect.mapError(mapClientError("compare", `${base}...${head}`)),
+			),
+	})),
+);

--- a/src/layers/GitHubCommitTest.ts
+++ b/src/layers/GitHubCommitTest.ts
@@ -1,0 +1,51 @@
+import { Effect, Layer } from "effect";
+import { GitHubCommitError } from "../errors/GitHubCommitError.js";
+import type { CommitComparison, CommitDetail, CommitSummary } from "../services/GitHubCommit.js";
+import { GitHubCommit } from "../services/GitHubCommit.js";
+
+/**
+ * Test state for GitHubCommit.
+ *
+ * @public
+ */
+export interface GitHubCommitTestState {
+	/** Commits by ref, returned by get. */
+	readonly commits: Map<string, CommitDetail>;
+	/** Commit lists by ref, returned by list. */
+	readonly commitLists: Map<string, ReadonlyArray<CommitSummary>>;
+	/** Comparisons keyed by `${base}...${head}`, returned by compare. */
+	readonly comparisons: Map<string, CommitComparison>;
+}
+
+const makeTestGitHubCommit = (state: GitHubCommitTestState): typeof GitHubCommit.Service => ({
+	get: (ref) =>
+		Effect.sync(() => state.commits.get(ref)).pipe(
+			Effect.flatMap((commit) =>
+				commit
+					? Effect.succeed(commit)
+					: Effect.fail(new GitHubCommitError({ operation: "get", ref, reason: "Commit not found" })),
+			),
+		),
+
+	list: (ref) => Effect.succeed(state.commitLists.get(ref) ?? []),
+
+	compare: (base, head) => Effect.succeed(state.comparisons.get(`${base}...${head}`) ?? { commits: [], files: [] }),
+});
+
+/**
+ * Test implementation for GitHubCommit.
+ *
+ * @public
+ */
+export const GitHubCommitTest = {
+	/** Create test layer that serves seeded commit data. */
+	layer: (state: GitHubCommitTestState): Layer.Layer<GitHubCommit> =>
+		Layer.succeed(GitHubCommit, makeTestGitHubCommit(state)),
+
+	/** Create a fresh test state. */
+	empty: (): GitHubCommitTestState => ({
+		commits: new Map(),
+		commitLists: new Map(),
+		comparisons: new Map(),
+	}),
+} as const;

--- a/src/layers/GitHubContentLive.test.ts
+++ b/src/layers/GitHubContentLive.test.ts
@@ -69,6 +69,27 @@ describe("GitHubContentLive", () => {
 		expect(result.path).toBe("some/submodule");
 	});
 
+	it("getFile fails when the content encoding is not base64", async () => {
+		const result = await Effect.runPromise(
+			Effect.gen(function* () {
+				const svc = yield* GitHubContent;
+				return yield* svc.getFile("big-file.bin", "base-sha");
+			}).pipe(
+				Effect.provide(GitHubContentLive),
+				Effect.provide(
+					GitHubClientTest.layer(
+						clientState([["repos.getContent", { data: { type: "file", encoding: "none", content: "" } }]]),
+					),
+				),
+				Effect.flip,
+			),
+		);
+		expect(result._tag).toBe("GitHubContentError");
+		expect(result.operation).toBe("getFile");
+		expect(result.path).toBe("big-file.bin");
+		expect(result.reason).toContain("none");
+	});
+
 	it("getFile wraps a client error as GitHubContentError", async () => {
 		const result = await Effect.runPromise(
 			Effect.gen(function* () {

--- a/src/layers/GitHubContentLive.test.ts
+++ b/src/layers/GitHubContentLive.test.ts
@@ -1,0 +1,83 @@
+import { Buffer } from "node:buffer";
+import { Effect } from "effect";
+import { describe, expect, it } from "vitest";
+import { GitHubContent } from "../services/GitHubContent.js";
+import type { GitHubClientTestState, RestResponse } from "./GitHubClientTest.js";
+import { GitHubClientTest } from "./GitHubClientTest.js";
+import { GitHubContentLive } from "./GitHubContentLive.js";
+
+const clientState = (rest: Array<[string, RestResponse]>): GitHubClientTestState => ({
+	restResponses: new Map(rest),
+	paginateResponses: new Map(),
+	graphqlResponses: new Map(),
+	repo: { owner: "owner", repo: "repo" },
+});
+
+describe("GitHubContentLive", () => {
+	it("getFile decodes a base64 file to UTF-8 text", async () => {
+		const text = JSON.stringify({ version: "1.2.3" });
+		const result = await Effect.runPromise(
+			Effect.gen(function* () {
+				const svc = yield* GitHubContent;
+				return yield* svc.getFile("pkg/package.json", "base-sha");
+			}).pipe(
+				Effect.provide(GitHubContentLive),
+				Effect.provide(
+					GitHubClientTest.layer(
+						clientState([
+							[
+								"repos.getContent",
+								{ data: { type: "file", encoding: "base64", content: Buffer.from(text).toString("base64") } },
+							],
+						]),
+					),
+				),
+			),
+		);
+		expect(JSON.parse(result)).toEqual({ version: "1.2.3" });
+	});
+
+	it("getFile fails when the path resolves to a directory", async () => {
+		const result = await Effect.runPromise(
+			Effect.gen(function* () {
+				const svc = yield* GitHubContent;
+				return yield* svc.getFile("some/dir", "base-sha");
+			}).pipe(
+				Effect.provide(GitHubContentLive),
+				Effect.provide(GitHubClientTest.layer(clientState([["repos.getContent", { data: [{ type: "file" }] }]]))),
+				Effect.flip,
+			),
+		);
+		expect(result._tag).toBe("GitHubContentError");
+		expect(result.operation).toBe("getFile");
+		expect(result.path).toBe("some/dir");
+	});
+
+	it("getFile fails when the path resolves to a submodule", async () => {
+		const result = await Effect.runPromise(
+			Effect.gen(function* () {
+				const svc = yield* GitHubContent;
+				return yield* svc.getFile("some/submodule", "base-sha");
+			}).pipe(
+				Effect.provide(GitHubContentLive),
+				Effect.provide(GitHubClientTest.layer(clientState([["repos.getContent", { data: { type: "submodule" } }]]))),
+				Effect.flip,
+			),
+		);
+		expect(result._tag).toBe("GitHubContentError");
+		expect(result.operation).toBe("getFile");
+		expect(result.path).toBe("some/submodule");
+	});
+
+	it("getFile wraps a client error as GitHubContentError", async () => {
+		const result = await Effect.runPromise(
+			Effect.gen(function* () {
+				const svc = yield* GitHubContent;
+				return yield* svc.getFile("missing.json", "base-sha");
+			}).pipe(Effect.provide(GitHubContentLive), Effect.provide(GitHubClientTest.layer(clientState([]))), Effect.flip),
+		);
+		expect(result._tag).toBe("GitHubContentError");
+		expect(result.operation).toBe("getFile");
+		expect(result.path).toBe("missing.json");
+	});
+});

--- a/src/layers/GitHubContentLive.ts
+++ b/src/layers/GitHubContentLive.ts
@@ -63,6 +63,20 @@ export const GitHubContentLive: Layer.Layer<GitHubContent, never, GitHubClient> 
 							}),
 						);
 					}
+					// The contents API returns `encoding: "base64"` for files it can
+					// inline. Files over the inline size limit come back with
+					// `encoding: "none"` and empty content (the blob API must be used
+					// instead). Decoding a non-base64 payload as base64 silently yields
+					// garbage, so reject anything we cannot faithfully decode.
+					if (file.encoding !== "base64") {
+						return Effect.fail(
+							new GitHubContentError({
+								operation: "getFile",
+								path,
+								reason: `Path "${path}" returned unsupported content encoding "${file.encoding ?? "undefined"}" (expected "base64")`,
+							}),
+						);
+					}
 					return Effect.succeed(Buffer.from(file.content.replace(/\s/g, ""), "base64").toString("utf-8"));
 				}),
 			),

--- a/src/layers/GitHubContentLive.ts
+++ b/src/layers/GitHubContentLive.ts
@@ -1,0 +1,70 @@
+import { Buffer } from "node:buffer";
+import { Effect, Layer } from "effect";
+import type { GitHubClientError } from "../errors/GitHubClientError.js";
+import { GitHubContentError } from "../errors/GitHubContentError.js";
+import { GitHubClient } from "../services/GitHubClient.js";
+import { GitHubContent } from "../services/GitHubContent.js";
+
+interface RawContentFile {
+	readonly type?: string;
+	readonly encoding?: string;
+	readonly content?: string;
+}
+
+/** Minimal Octokit shape for the repo content API. */
+interface OctokitContent {
+	readonly rest: {
+		readonly repos: {
+			readonly getContent: (args: Record<string, unknown>) => Promise<{ data: RawContentFile | unknown[] }>;
+		};
+	};
+}
+
+const asContent = (octokit: unknown): OctokitContent => octokit as OctokitContent;
+
+const mapClientError =
+	(path: string) =>
+	(error: GitHubClientError): GitHubContentError =>
+		new GitHubContentError({ operation: "getFile", path, reason: error.reason });
+
+export const GitHubContentLive: Layer.Layer<GitHubContent, never, GitHubClient> = Layer.effect(
+	GitHubContent,
+	Effect.map(GitHubClient, (client): typeof GitHubContent.Service => ({
+		getFile: (path: string, ref?: string) =>
+			Effect.flatMap(client.repo, ({ owner, repo }) =>
+				client.rest("repos.getContent", (octokit) =>
+					asContent(octokit).rest.repos.getContent({
+						owner,
+						repo,
+						path,
+						...(ref !== undefined ? { ref } : {}),
+					}),
+				),
+			).pipe(
+				Effect.mapError(mapClientError(path)),
+				Effect.flatMap((data) => {
+					const raw = data as unknown as RawContentFile | unknown[];
+					if (Array.isArray(raw)) {
+						return Effect.fail(
+							new GitHubContentError({
+								operation: "getFile",
+								path,
+								reason: `Path "${path}" is a directory, not a file`,
+							}),
+						);
+					}
+					const file = raw as RawContentFile;
+					if (file.type !== "file" || file.content === undefined) {
+						return Effect.fail(
+							new GitHubContentError({
+								operation: "getFile",
+								path,
+								reason: `Path "${path}" did not resolve to a file`,
+							}),
+						);
+					}
+					return Effect.succeed(Buffer.from(file.content.replace(/\s/g, ""), "base64").toString("utf-8"));
+				}),
+			),
+	})),
+);

--- a/src/layers/GitHubContentTest.ts
+++ b/src/layers/GitHubContentTest.ts
@@ -1,0 +1,42 @@
+import { Effect, Layer } from "effect";
+import { GitHubContentError } from "../errors/GitHubContentError.js";
+import { GitHubContent } from "../services/GitHubContent.js";
+
+/**
+ * Test state for GitHubContent.
+ *
+ * @public
+ */
+export interface GitHubContentTestState {
+	/**
+	 * File contents (already decoded) returned by `getFile`, keyed by
+	 * `${ref ?? ""}:${path}`. Seed with the decoded text, e.g.
+	 * `files.set("base-sha:pkg/package.json", JSON.stringify({ version: "1.0.0" }))`.
+	 */
+	readonly files: Map<string, string>;
+}
+
+const makeTestGitHubContent = (state: GitHubContentTestState): typeof GitHubContent.Service => ({
+	getFile: (path, ref) =>
+		Effect.sync(() => state.files.get(`${ref ?? ""}:${path}`)).pipe(
+			Effect.flatMap((contents) =>
+				contents !== undefined
+					? Effect.succeed(contents)
+					: Effect.fail(new GitHubContentError({ operation: "getFile", path, reason: "File not found" })),
+			),
+		),
+});
+
+/**
+ * Test implementation for GitHubContent.
+ *
+ * @public
+ */
+export const GitHubContentTest = {
+	/** Create test layer that serves seeded file contents. */
+	layer: (state: GitHubContentTestState): Layer.Layer<GitHubContent> =>
+		Layer.succeed(GitHubContent, makeTestGitHubContent(state)),
+
+	/** Create a fresh test state. */
+	empty: (): GitHubContentTestState => ({ files: new Map() }),
+} as const;

--- a/src/layers/GitHubIssueLive.test.ts
+++ b/src/layers/GitHubIssueLive.test.ts
@@ -10,6 +10,7 @@ import { GitHubIssueLive } from "./GitHubIssueLive.js";
 const mockListForRepo = vi.fn();
 const mockUpdate = vi.fn();
 const mockCreateComment = vi.fn();
+const mockGet = vi.fn();
 
 const mockClient: typeof GitHubClient.Service = {
 	rest: <T>(_operation: string, fn: (octokit: unknown) => Promise<{ data: T }>) =>
@@ -21,6 +22,7 @@ const mockClient: typeof GitHubClient.Service = {
 							listForRepo: mockListForRepo,
 							update: mockUpdate,
 							createComment: mockCreateComment,
+							get: mockGet,
 						},
 					},
 				}),
@@ -47,6 +49,7 @@ const mockClient: typeof GitHubClient.Service = {
 								listForRepo: mockListForRepo,
 								update: mockUpdate,
 								createComment: mockCreateComment,
+								get: mockGet,
 							},
 						},
 					},
@@ -208,6 +211,31 @@ describe("GitHubIssueLive", () => {
 					body: "Hello",
 				}),
 			);
+		});
+	});
+
+	describe("get", () => {
+		it("get returns the issue, mapping htmlUrl and nodeId", async () => {
+			mockGet.mockResolvedValue({
+				data: {
+					number: 7,
+					title: "t",
+					state: "open",
+					labels: [],
+					html_url: "https://gh/i/7",
+					node_id: "I_node7",
+				},
+			});
+			const result = await run(Effect.flatMap(GitHubIssue, (svc) => svc.get(7)));
+			expect(result.number).toBe(7);
+			expect(result.htmlUrl).toBe("https://gh/i/7");
+			expect(result.nodeId).toBe("I_node7");
+		});
+
+		it("get fails with a GitHubIssueError when the API call fails", async () => {
+			mockGet.mockRejectedValue(new Error("not found"));
+			const exit = await runExit(Effect.flatMap(GitHubIssue, (svc) => svc.get(999)));
+			expect(exit._tag).toBe("Failure");
 		});
 	});
 

--- a/src/layers/GitHubIssueLive.ts
+++ b/src/layers/GitHubIssueLive.ts
@@ -13,6 +13,7 @@ interface OctokitIssues {
 			readonly listForRepo: (args: Record<string, unknown>) => Promise<{ data: RawIssue[] }>;
 			readonly update: (args: Record<string, unknown>) => Promise<{ data: RawIssue }>;
 			readonly createComment: (args: Record<string, unknown>) => Promise<{ data: { id: number } }>;
+			readonly get: (args: Record<string, unknown>) => Promise<{ data: RawIssue }>;
 		};
 	};
 }
@@ -22,6 +23,8 @@ interface RawIssue {
 	readonly title: string;
 	readonly state: string;
 	readonly labels: Array<{ name?: string } | string>;
+	readonly html_url: string;
+	readonly node_id: string;
 }
 
 interface LinkedIssuesResponse {
@@ -51,10 +54,12 @@ const toIssueData = (raw: RawIssue): IssueData => ({
 	title: raw.title,
 	state: raw.state,
 	labels: raw.labels.map((l) => (typeof l === "string" ? l : (l.name ?? ""))),
+	htmlUrl: raw.html_url,
+	nodeId: raw.node_id,
 });
 
 const mapClientError =
-	(operation: "list" | "close" | "comment", issueNumber?: number) =>
+	(operation: "list" | "close" | "comment" | "get", issueNumber?: number) =>
 	(error: GitHubClientError): GitHubIssueError =>
 		new GitHubIssueError({
 			operation,
@@ -89,6 +94,16 @@ export const GitHubIssueLive: Layer.Layer<GitHubIssue, never, GitHubClient | Git
 				).pipe(
 					Effect.map((items) => items.map((item) => toIssueData(item as unknown as RawIssue))),
 					Effect.mapError(mapClientError("list")),
+				),
+
+			get: (issueNumber) =>
+				Effect.flatMap(client.repo, ({ owner, repo }) =>
+					client.rest("issues.get", (octokit) =>
+						asIssues(octokit).rest.issues.get({ owner, repo, issue_number: issueNumber }),
+					),
+				).pipe(
+					Effect.map((data) => toIssueData(data as unknown as RawIssue)),
+					Effect.mapError(mapClientError("get", issueNumber)),
 				),
 
 			close: (issueNumber, reason) =>

--- a/src/layers/GitHubIssueTest.ts
+++ b/src/layers/GitHubIssueTest.ts
@@ -28,6 +28,20 @@ const makeTestClient = (state: GitHubIssueTestState): typeof GitHubIssue.Service
 		return Effect.succeed(issues);
 	},
 
+	get: (issueNumber) => {
+		const issue = state.issues.get(issueNumber);
+		return issue
+			? Effect.succeed(issue)
+			: Effect.fail(
+					new GitHubIssueError({
+						operation: "get",
+						issueNumber,
+						reason: `Issue #${issueNumber} not found`,
+						retryable: false,
+					}),
+				);
+	},
+
 	close: (issueNumber, reason) => {
 		const issue = state.issues.get(issueNumber);
 		if (!issue) {

--- a/src/layers/GitHubReleaseLive.test.ts
+++ b/src/layers/GitHubReleaseLive.test.ts
@@ -9,6 +9,8 @@ const mockCreateRelease = vi.fn();
 const mockUploadReleaseAsset = vi.fn();
 const mockGetReleaseByTag = vi.fn();
 const mockListReleases = vi.fn();
+const mockUpdateRelease = vi.fn();
+const mockListReleaseAssets = vi.fn();
 
 const mockClient: typeof GitHubClient.Service = {
 	rest: <T>(_operation: string, fn: (octokit: unknown) => Promise<{ data: T }>) =>
@@ -21,6 +23,8 @@ const mockClient: typeof GitHubClient.Service = {
 							uploadReleaseAsset: mockUploadReleaseAsset,
 							getReleaseByTag: mockGetReleaseByTag,
 							listReleases: mockListReleases,
+							updateRelease: mockUpdateRelease,
+							listReleaseAssets: mockListReleaseAssets,
 						},
 					},
 				}),
@@ -48,6 +52,8 @@ const mockClient: typeof GitHubClient.Service = {
 								uploadReleaseAsset: mockUploadReleaseAsset,
 								getReleaseByTag: mockGetReleaseByTag,
 								listReleases: mockListReleases,
+								updateRelease: mockUpdateRelease,
+								listReleaseAssets: mockListReleaseAssets,
 							},
 						},
 					},
@@ -284,6 +290,69 @@ describe("GitHubReleaseLive", () => {
 			expect(result).toHaveLength(2);
 			expect(result[0]?.tag).toBe("v1.0.0");
 			expect(result[1]?.tag).toBe("v2.0.0");
+		});
+	});
+
+	describe("updateRelease", () => {
+		it("updates a release body and returns the updated release", async () => {
+			mockUpdateRelease.mockResolvedValue({
+				data: {
+					id: 42,
+					tag_name: "v1.0.0",
+					name: "Release 1.0.0",
+					body: "new body",
+					draft: false,
+					prerelease: false,
+					upload_url: "https://uploads.github.com/releases/42/assets",
+				},
+			});
+			const result = await run(Effect.flatMap(GitHubRelease, (svc) => svc.updateRelease(42, { body: "new body" })));
+			expect(result.body).toBe("new body");
+			expect(mockUpdateRelease).toHaveBeenCalledWith(
+				expect.objectContaining({
+					owner: "test-owner",
+					repo: "test-repo",
+					release_id: 42,
+					body: "new body",
+				}),
+			);
+		});
+
+		it("fails on API error", async () => {
+			mockUpdateRelease.mockRejectedValue(new Error("api error"));
+			const exit = await runExit(Effect.flatMap(GitHubRelease, (svc) => svc.updateRelease(42, { body: "x" })));
+			expect(exit._tag).toBe("Failure");
+		});
+	});
+
+	describe("listReleaseAssets", () => {
+		it("returns the release's assets", async () => {
+			mockListReleaseAssets.mockResolvedValue({
+				data: [
+					{
+						id: 1,
+						name: "dist.tar.gz",
+						browser_download_url: "https://github.com/releases/download/v1.0.0/dist.tar.gz",
+						size: 2048,
+					},
+					{
+						id: 2,
+						name: "checksums.txt",
+						browser_download_url: "https://github.com/releases/download/v1.0.0/checksums.txt",
+						size: 128,
+					},
+				],
+			});
+			const result = await run(Effect.flatMap(GitHubRelease, (svc) => svc.listReleaseAssets(42)));
+			expect(result).toHaveLength(2);
+			expect(result[0]?.url).toBe("https://github.com/releases/download/v1.0.0/dist.tar.gz");
+			expect(mockListReleaseAssets).toHaveBeenCalledWith(
+				expect.objectContaining({
+					owner: "test-owner",
+					repo: "test-repo",
+					release_id: 42,
+				}),
+			);
 		});
 	});
 });

--- a/src/layers/GitHubReleaseLive.ts
+++ b/src/layers/GitHubReleaseLive.ts
@@ -13,6 +13,8 @@ interface OctokitReleases {
 			readonly uploadReleaseAsset: (args: Record<string, unknown>) => Promise<{ data: RawAsset }>;
 			readonly getReleaseByTag: (args: Record<string, unknown>) => Promise<{ data: RawRelease }>;
 			readonly listReleases: (args: Record<string, unknown>) => Promise<{ data: RawRelease[] }>;
+			readonly updateRelease: (args: Record<string, unknown>) => Promise<{ data: RawRelease }>;
+			readonly listReleaseAssets: (args: Record<string, unknown>) => Promise<{ data: RawAsset[] }>;
 		};
 	};
 }
@@ -54,7 +56,7 @@ const toReleaseAsset = (raw: RawAsset): ReleaseAsset => ({
 });
 
 const mapError =
-	(operation: "create" | "uploadAsset" | "getByTag" | "list", tag?: string) =>
+	(operation: "create" | "uploadAsset" | "getByTag" | "list" | "updateRelease" | "listReleaseAssets", tag?: string) =>
 	(error: GitHubClientError): GitHubReleaseError =>
 		new GitHubReleaseError({
 			operation,
@@ -135,6 +137,40 @@ export const GitHubReleaseLive: Layer.Layer<GitHubRelease, never, GitHubClient> 
 			).pipe(
 				Effect.map((items) => items.map((item) => toReleaseData(item as unknown as RawRelease))),
 				Effect.mapError(mapError("list")),
+			),
+
+		updateRelease: (releaseId, options) =>
+			Effect.flatMap(client.repo, ({ owner, repo }) =>
+				client.rest("repos.updateRelease", (octokit) =>
+					asReleases(octokit).rest.repos.updateRelease({
+						owner,
+						repo,
+						release_id: releaseId,
+						...(options.body !== undefined ? { body: options.body } : {}),
+						...(options.name !== undefined ? { name: options.name } : {}),
+						...(options.draft !== undefined ? { draft: options.draft } : {}),
+						...(options.prerelease !== undefined ? { prerelease: options.prerelease } : {}),
+					}),
+				),
+			).pipe(
+				Effect.map((data) => toReleaseData(data as unknown as RawRelease)),
+				Effect.mapError(mapError("updateRelease")),
+			),
+
+		listReleaseAssets: (releaseId) =>
+			Effect.flatMap(client.repo, ({ owner, repo }) =>
+				client.paginate("repos.listReleaseAssets", (octokit, page, perPage) =>
+					asReleases(octokit).rest.repos.listReleaseAssets({
+						owner,
+						repo,
+						release_id: releaseId,
+						page,
+						per_page: perPage,
+					}),
+				),
+			).pipe(
+				Effect.map((items) => items.map((item) => toReleaseAsset(item as unknown as RawAsset))),
+				Effect.mapError(mapError("listReleaseAssets")),
 			),
 	})),
 );

--- a/src/layers/GitHubReleaseTest.ts
+++ b/src/layers/GitHubReleaseTest.ts
@@ -12,6 +12,8 @@ export interface GitHubReleaseTestState {
 	readonly releases: Map<string, ReleaseData>;
 	readonly createCalls: Array<{ tag: string; name: string }>;
 	readonly uploadCalls: Array<{ releaseId: number; name: string }>;
+	/** Assets per release id — populated by uploadAsset, read by listReleaseAssets. */
+	readonly assets: Map<number, Array<ReleaseAsset>>;
 }
 
 const makeTestClient = (state: GitHubReleaseTestState): typeof GitHubRelease.Service => ({
@@ -38,6 +40,9 @@ const makeTestClient = (state: GitHubReleaseTestState): typeof GitHubRelease.Ser
 			url: `https://example.com/${name}`,
 			size: 1024,
 		};
+		const existing = state.assets.get(releaseId) ?? [];
+		existing.push(asset);
+		state.assets.set(releaseId, existing);
 		return Effect.succeed(asset);
 	},
 
@@ -57,6 +62,30 @@ const makeTestClient = (state: GitHubReleaseTestState): typeof GitHubRelease.Ser
 	},
 
 	list: () => Effect.succeed(Array.from(state.releases.values())),
+
+	updateRelease: (releaseId, options) => {
+		const release = Array.from(state.releases.values()).find((r) => r.id === releaseId);
+		if (!release) {
+			return Effect.fail(
+				new GitHubReleaseError({
+					operation: "updateRelease",
+					reason: `No release with id ${releaseId}`,
+					retryable: false,
+				}),
+			);
+		}
+		const updated: ReleaseData = {
+			...release,
+			...(options.body !== undefined ? { body: options.body } : {}),
+			...(options.name !== undefined ? { name: options.name } : {}),
+			...(options.draft !== undefined ? { draft: options.draft } : {}),
+			...(options.prerelease !== undefined ? { prerelease: options.prerelease } : {}),
+		};
+		state.releases.set(updated.tag, updated);
+		return Effect.succeed(updated);
+	},
+
+	listReleaseAssets: (releaseId) => Effect.succeed(state.assets.get(releaseId) ?? []),
 });
 
 /**
@@ -75,6 +104,7 @@ export const GitHubReleaseTest = {
 			releases: new Map(),
 			createCalls: [],
 			uploadCalls: [],
+			assets: new Map(),
 		};
 		return { state, layer: Layer.succeed(GitHubReleaseTag, makeTestClient(state)) };
 	},

--- a/src/layers/GitTagLive.test.ts
+++ b/src/layers/GitTagLive.test.ts
@@ -8,7 +8,8 @@ import { GitTagLive } from "./GitTagLive.js";
 const mockCreateRef = vi.fn();
 const mockDeleteRef = vi.fn();
 const mockGetRef = vi.fn();
-const mockListMatchingRefs = vi.fn();
+const mockGetTag = vi.fn();
+const mockListTags = vi.fn();
 
 const mockClient: typeof GitHubClient.Service = {
 	rest: <T>(_operation: string, fn: (octokit: unknown) => Promise<{ data: T }>) =>
@@ -20,7 +21,10 @@ const mockClient: typeof GitHubClient.Service = {
 							createRef: mockCreateRef,
 							deleteRef: mockDeleteRef,
 							getRef: mockGetRef,
-							listMatchingRefs: mockListMatchingRefs,
+							getTag: mockGetTag,
+						},
+						repos: {
+							listTags: mockListTags,
 						},
 					},
 				}),
@@ -43,8 +47,8 @@ const mockClient: typeof GitHubClient.Service = {
 				fn(
 					{
 						rest: {
-							git: {
-								listMatchingRefs: mockListMatchingRefs,
+							repos: {
+								listTags: mockListTags,
 							},
 						},
 					},
@@ -103,37 +107,58 @@ describe("GitTagLive", () => {
 	});
 
 	describe("list", () => {
-		it("lists tags via paginate and strips refs/tags/ prefix", async () => {
-			mockListMatchingRefs.mockResolvedValue({
-				data: [{ ref: "refs/tags/v1.0.0", object: { sha: "abc123" } }],
-			});
-			const result = await run(Effect.flatMap(GitTag, (svc) => svc.list("v1.")));
-			expect(result).toEqual([{ tag: "v1.0.0", sha: "abc123" }]);
-		});
-	});
-
-	describe("list", () => {
-		it("lists tags without prefix (undefined)", async () => {
-			mockListMatchingRefs.mockResolvedValue({
+		it("maps commit.sha from repos.listTags into TagRef.sha", async () => {
+			mockListTags.mockResolvedValue({
 				data: [
-					{ ref: "refs/tags/v1.0.0", object: { sha: "abc123" } },
-					{ ref: "refs/tags/v2.0.0", object: { sha: "def456" } },
+					{ name: "v1.0.0", commit: { sha: "commit-abc" } },
+					{ name: "v1.1.0", commit: { sha: "commit-xyz" } },
 				],
 			});
 			const result = await run(Effect.flatMap(GitTag, (svc) => svc.list()));
 			expect(result).toEqual([
-				{ tag: "v1.0.0", sha: "abc123" },
-				{ tag: "v2.0.0", sha: "def456" },
+				{ tag: "v1.0.0", sha: "commit-abc" },
+				{ tag: "v1.1.0", sha: "commit-xyz" },
 			]);
-			expect(mockListMatchingRefs).toHaveBeenCalledWith(
+		});
+
+		it("lists tags without prefix (undefined)", async () => {
+			mockListTags.mockResolvedValue({
+				data: [
+					{ name: "v1.0.0", commit: { sha: "commit-abc" } },
+					{ name: "v2.0.0", commit: { sha: "commit-def" } },
+				],
+			});
+			const result = await run(Effect.flatMap(GitTag, (svc) => svc.list()));
+			expect(result).toEqual([
+				{ tag: "v1.0.0", sha: "commit-abc" },
+				{ tag: "v2.0.0", sha: "commit-def" },
+			]);
+			expect(mockListTags).toHaveBeenCalledWith(
 				expect.objectContaining({
-					ref: "tags/",
+					owner: "test-owner",
+					repo: "test-repo",
 				}),
 			);
 		});
 
+		it("filters tags client-side by prefix", async () => {
+			mockListTags.mockResolvedValue({
+				data: [
+					{ name: "v1.0.0", commit: { sha: "commit-a" } },
+					{ name: "v1.2.3", commit: { sha: "commit-b" } },
+					{ name: "v2.0.0", commit: { sha: "commit-c" } },
+					{ name: "release-1", commit: { sha: "commit-d" } },
+				],
+			});
+			const result = await run(Effect.flatMap(GitTag, (svc) => svc.list("v1.")));
+			expect(result).toEqual([
+				{ tag: "v1.0.0", sha: "commit-a" },
+				{ tag: "v1.2.3", sha: "commit-b" },
+			]);
+		});
+
 		it("maps API error to GitTagError without tag field", async () => {
-			mockListMatchingRefs.mockRejectedValue(new Error("api error"));
+			mockListTags.mockRejectedValue(new Error("api error"));
 			const result = await Effect.runPromise(
 				Effect.provide(
 					Effect.flatMap(GitTag, (svc) => svc.list("v1.")).pipe(Effect.catchAll((error) => Effect.succeed(error))),
@@ -192,12 +217,61 @@ describe("GitTagLive", () => {
 	});
 
 	describe("resolve", () => {
-		it("returns the SHA from the ref", async () => {
+		it("returns the commit SHA for a lightweight tag without calling git.getTag", async () => {
 			mockGetRef.mockResolvedValue({
-				data: { ref: "refs/tags/v1.0.0", object: { sha: "abc123" } },
+				data: { ref: "refs/tags/v1.0.0", object: { sha: "commit-abc", type: "commit" } },
 			});
 			const result = await run(Effect.flatMap(GitTag, (svc) => svc.resolve("v1.0.0")));
-			expect(result).toBe("abc123");
+			expect(result).toBe("commit-abc");
+			expect(mockGetTag).not.toHaveBeenCalled();
+		});
+
+		it("dereferences an annotated tag to its commit SHA via git.getTag", async () => {
+			mockGetRef.mockResolvedValue({
+				data: { ref: "refs/tags/v2.0.0", object: { sha: "tag-obj-sha", type: "tag" } },
+			});
+			mockGetTag.mockResolvedValue({
+				data: { object: { sha: "commit-def", type: "commit" } },
+			});
+			const result = await run(Effect.flatMap(GitTag, (svc) => svc.resolve("v2.0.0")));
+			expect(result).toBe("commit-def");
+			expect(mockGetTag).toHaveBeenCalledWith(
+				expect.objectContaining({
+					owner: "test-owner",
+					repo: "test-repo",
+					tag_sha: "tag-obj-sha",
+				}),
+			);
+		});
+
+		it("peels a multi-hop tag-of-a-tag chain to the commit SHA", async () => {
+			mockGetRef.mockResolvedValue({
+				data: { ref: "refs/tags/v3.0.0", object: { sha: "tag-obj-1", type: "tag" } },
+			});
+			mockGetTag
+				.mockResolvedValueOnce({ data: { object: { sha: "tag-obj-2", type: "tag" } } })
+				.mockResolvedValueOnce({ data: { object: { sha: "commit-final", type: "commit" } } });
+			const result = await run(Effect.flatMap(GitTag, (svc) => svc.resolve("v3.0.0")));
+			expect(result).toBe("commit-final");
+			expect(mockGetTag).toHaveBeenCalledTimes(2);
+		});
+
+		it("maps a git.getTag failure during peel to GitTagError with the tag", async () => {
+			mockGetRef.mockResolvedValue({
+				data: { ref: "refs/tags/v4.0.0", object: { sha: "tag-obj-sha", type: "tag" } },
+			});
+			mockGetTag.mockRejectedValue(new Error("tag object not found"));
+			const result = await Effect.runPromise(
+				Effect.provide(
+					Effect.flatMap(GitTag, (svc) => svc.resolve("v4.0.0")).pipe(
+						Effect.catchAll((error) => Effect.succeed(error)),
+					),
+					testLayer,
+				),
+			);
+			expect(result).toHaveProperty("_tag", "GitTagError");
+			expect(result).toHaveProperty("operation", "resolve");
+			expect(result).toHaveProperty("tag", "v4.0.0");
 		});
 	});
 });

--- a/src/layers/GitTagLive.ts
+++ b/src/layers/GitTagLive.ts
@@ -5,16 +5,32 @@ import { GitHubClient } from "../services/GitHubClient.js";
 import type { TagRef } from "../services/GitTag.js";
 import { GitTag } from "../services/GitTag.js";
 
-/** Minimal Octokit shape for git refs API calls (tags). */
+/** Safety bound on tag-object dereference depth (a tag-of-a-tag chain). */
+const MAX_TAG_PEEL = 5;
+
+/** A tag entry from the repos.listTags endpoint (commit.sha is peeled). */
+interface RawTag {
+	readonly name: string;
+	readonly commit: { readonly sha: string };
+}
+
+/** A git object reference (ref target or tag-object target). */
+interface RawGitObject {
+	readonly sha: string;
+	readonly type: string;
+}
+
+/** Minimal Octokit shape for the tag API calls. */
 interface OctokitGit {
 	readonly rest: {
 		readonly git: {
 			readonly createRef: (args: Record<string, unknown>) => Promise<{ data: unknown }>;
 			readonly deleteRef: (args: Record<string, unknown>) => Promise<{ data: unknown }>;
-			readonly getRef: (args: Record<string, unknown>) => Promise<{ data: { ref: string; object: { sha: string } } }>;
-			readonly listMatchingRefs: (
-				args: Record<string, unknown>,
-			) => Promise<{ data: Array<{ ref: string; object: { sha: string } }> }>;
+			readonly getRef: (args: Record<string, unknown>) => Promise<{ data: { ref: string; object: RawGitObject } }>;
+			readonly getTag: (args: Record<string, unknown>) => Promise<{ data: { object: RawGitObject } }>;
+		};
+		readonly repos: {
+			readonly listTags: (args: Record<string, unknown>) => Promise<{ data: Array<RawTag> }>;
 		};
 	};
 }
@@ -32,65 +48,92 @@ const mapError =
 
 export const GitTagLive: Layer.Layer<GitTag, never, GitHubClient> = Layer.effect(
 	GitTag,
-	Effect.map(GitHubClient, (client) => ({
-		create: (tag, sha) =>
-			Effect.flatMap(client.repo, ({ owner, repo }) =>
-				client.rest("git.createRef", (octokit) =>
-					asGit(octokit).rest.git.createRef({
-						owner,
-						repo,
-						ref: `refs/tags/${tag}`,
-						sha,
-					}),
-				),
-			).pipe(Effect.asVoid, Effect.mapError(mapError("create", tag))),
-
-		delete: (tag) =>
-			Effect.flatMap(client.repo, ({ owner, repo }) =>
-				client.rest("git.deleteRef", (octokit) =>
-					asGit(octokit).rest.git.deleteRef({
-						owner,
-						repo,
-						ref: `tags/${tag}`,
-					}),
-				),
-			).pipe(Effect.asVoid, Effect.mapError(mapError("delete", tag))),
-
-		list: (prefix) =>
-			Effect.flatMap(client.repo, ({ owner, repo }) =>
-				client.paginate("git.listMatchingRefs", (octokit, page, perPage) =>
-					asGit(octokit).rest.git.listMatchingRefs({
-						owner,
-						repo,
-						ref: `tags/${prefix ?? ""}`,
-						page,
-						per_page: perPage,
-					}),
-				),
+	Effect.map(GitHubClient, (client): typeof GitTag.Service => {
+		const peelToCommit = (
+			owner: string,
+			repo: string,
+			tag: string,
+			obj: RawGitObject,
+		): Effect.Effect<string, GitTagError> =>
+			Effect.iterate(
+				{ sha: obj.sha, type: obj.type, depth: 0 },
+				{
+					while: (state) => state.type === "tag" && state.depth < MAX_TAG_PEEL,
+					body: (state) =>
+						client
+							.rest("git.getTag", (octokit) => asGit(octokit).rest.git.getTag({ owner, repo, tag_sha: state.sha }))
+							.pipe(
+								Effect.map((data) => {
+									const next = (data as { object: RawGitObject }).object;
+									return { sha: next.sha, type: next.type, depth: state.depth + 1 };
+								}),
+								Effect.mapError(mapError("resolve", tag)),
+							),
+				},
 			).pipe(
-				Effect.map((items) =>
-					(items as Array<{ ref: string; object: { sha: string } }>).map(
-						(item): TagRef => ({
-							tag: item.ref.replace("refs/tags/", ""),
-							sha: item.object.sha,
+				Effect.flatMap((state) =>
+					state.type === "commit"
+						? Effect.succeed(state.sha)
+						: Effect.fail(
+								new GitTagError({
+									operation: "resolve",
+									tag,
+									reason: `Tag peel exceeded ${MAX_TAG_PEEL} levels`,
+								}),
+							),
+				),
+			);
+
+		return {
+			create: (tag, sha) =>
+				Effect.flatMap(client.repo, ({ owner, repo }) =>
+					client.rest("git.createRef", (octokit) =>
+						asGit(octokit).rest.git.createRef({
+							owner,
+							repo,
+							ref: `refs/tags/${tag}`,
+							sha,
 						}),
 					),
-				),
-				Effect.mapError(mapError("list")),
-			),
+				).pipe(Effect.asVoid, Effect.mapError(mapError("create", tag))),
 
-		resolve: (tag) =>
-			Effect.flatMap(client.repo, ({ owner, repo }) =>
-				client.rest("git.getRef", (octokit) =>
-					asGit(octokit).rest.git.getRef({
-						owner,
-						repo,
-						ref: `tags/${tag}`,
+			delete: (tag) =>
+				Effect.flatMap(client.repo, ({ owner, repo }) =>
+					client.rest("git.deleteRef", (octokit) =>
+						asGit(octokit).rest.git.deleteRef({
+							owner,
+							repo,
+							ref: `tags/${tag}`,
+						}),
+					),
+				).pipe(Effect.asVoid, Effect.mapError(mapError("delete", tag))),
+
+			list: (prefix) =>
+				Effect.flatMap(client.repo, ({ owner, repo }) =>
+					client.paginate("repos.listTags", (octokit, page, perPage) =>
+						asGit(octokit).rest.repos.listTags({ owner, repo, page, per_page: perPage }),
+					),
+				).pipe(
+					Effect.map((items) => {
+						const tags = (items as Array<RawTag>).map((item): TagRef => ({ tag: item.name, sha: item.commit.sha }));
+						return prefix ? tags.filter((t) => t.tag.startsWith(prefix)) : tags;
 					}),
+					Effect.mapError(mapError("list")),
 				),
-			).pipe(
-				Effect.map((data) => (data as { object: { sha: string } }).object.sha),
-				Effect.mapError(mapError("resolve", tag)),
-			),
-	})),
+
+			resolve: (tag) =>
+				client.repo.pipe(
+					Effect.mapError(mapError("resolve", tag)),
+					Effect.flatMap(({ owner, repo }) =>
+						client
+							.rest("git.getRef", (octokit) => asGit(octokit).rest.git.getRef({ owner, repo, ref: `tags/${tag}` }))
+							.pipe(
+								Effect.map((data) => (data as { object: RawGitObject }).object),
+								Effect.mapError(mapError("resolve", tag)),
+								Effect.flatMap((obj) => peelToCommit(owner, repo, tag, obj)),
+							),
+					),
+				),
+		};
+	}),
 );

--- a/src/layers/NpmRegistryLive.test.ts
+++ b/src/layers/NpmRegistryLive.test.ts
@@ -1,6 +1,7 @@
-import { Effect, Layer } from "effect";
+import { Effect, Layer, LogLevel, Logger, Option } from "effect";
 import { describe, expect, it } from "vitest";
 import { CommandRunnerError } from "../errors/CommandRunnerError.js";
+import type { ExecOutput } from "../services/CommandRunner.js";
 import { CommandRunner } from "../services/CommandRunner.js";
 import { NpmRegistry } from "../services/NpmRegistry.js";
 import { NpmRegistryLive } from "./NpmRegistryLive.js";
@@ -33,6 +34,80 @@ const makeMockRunner = (responses: Map<string, string>) =>
 		execJson: () => Effect.die("not used"),
 		execLines: () => Effect.die("not used"),
 	} as typeof CommandRunner.Service);
+
+/**
+ * Captures every `execCapture` invocation so a test can assert against the
+ * args the live layer actually passed to npm. The `respond` callback picks a
+ * response (or an error) per call by inspecting the args.
+ */
+const makeCapturingRunner = (
+	respond: (args: ReadonlyArray<string>) => Effect.Effect<ExecOutput, CommandRunnerError>,
+) => {
+	const calls: Array<{ command: string; args: ReadonlyArray<string> }> = [];
+	const layer = Layer.succeed(CommandRunner, {
+		exec: () => Effect.die("not used"),
+		execCapture: (command: string, args?: ReadonlyArray<string>) => {
+			const a = args ?? [];
+			calls.push({ command, args: a });
+			return respond(a);
+		},
+		execJson: () => Effect.die("not used"),
+		execLines: () => Effect.die("not used"),
+	} as typeof CommandRunner.Service);
+	return { calls, layer };
+};
+
+/**
+ * Run a getPublishedIntegrity probe with the live layer + a captured runner.
+ *
+ * @remarks
+ * `Effect.gen` inside `getPublishedIntegrity` leaks its R-channel through
+ * tsgo's type erasure even after the layer is provided, which propagates
+ * up the `NpmRegistry.pipe(Effect.flatMap(...))` chain at the call site
+ * and makes the `pipe` itself ill-typed. Wrapping the chain in this helper
+ * lets the cast live in one place rather than smearing across every test.
+ */
+const runIntegrityProbe = (
+	layer: Layer.Layer<NpmRegistry>,
+	pkg: string,
+	version: string,
+	options: { registry: string },
+): Promise<Option.Option<string>> => {
+	const program = Effect.gen(function* () {
+		const reg = yield* NpmRegistry;
+		return yield* reg.getPublishedIntegrity(pkg, version, options);
+	});
+	return Effect.runPromise(
+		program.pipe(Effect.provide(layer), Logger.withMinimumLogLevel(LogLevel.None)) as Effect.Effect<
+			Option.Option<string>,
+			never,
+			never
+		>,
+	);
+};
+
+/**
+ * Same wrapper as {@link runIntegrityProbe}, but surfaces the error channel
+ * (via `Effect.flip`) for tests asserting propagation.
+ */
+const runIntegrityProbeError = (
+	layer: Layer.Layer<NpmRegistry>,
+	pkg: string,
+	version: string,
+	options: { registry: string },
+): Promise<unknown> => {
+	const program = Effect.gen(function* () {
+		const reg = yield* NpmRegistry;
+		return yield* reg.getPublishedIntegrity(pkg, version, options);
+	});
+	return Effect.runPromise(
+		program.pipe(Effect.provide(layer), Effect.flip, Logger.withMinimumLogLevel(LogLevel.None)) as Effect.Effect<
+			unknown,
+			never,
+			never
+		>,
+	);
+};
 
 describe("NpmRegistryLive", () => {
 	it("getLatestVersion parses npm view output", async () => {
@@ -83,6 +158,43 @@ describe("NpmRegistryLive", () => {
 		expect(result).toEqual(["1.0.0"]);
 	});
 
+	it("getVersions appends --registry when registry option is supplied", async () => {
+		const { calls, layer: runner } = makeCapturingRunner(() =>
+			Effect.succeed({ exitCode: 0, stdout: JSON.stringify(["1.0.0"]), stderr: "" }),
+		);
+		const layer = NpmRegistryLive.pipe(Layer.provide(runner));
+		await Effect.runPromise(
+			NpmRegistry.pipe(
+				Effect.flatMap((reg) => reg.getVersions("my-pkg", { registry: "https://npm.pkg.github.com/" })),
+				Effect.provide(layer),
+			),
+		);
+		expect(calls).toHaveLength(1);
+		expect(calls[0]?.args).toEqual([
+			"view",
+			"my-pkg",
+			"versions",
+			"--json",
+			"--registry",
+			"https://npm.pkg.github.com/",
+		]);
+	});
+
+	it("getVersions omits --registry when no option is supplied", async () => {
+		const { calls, layer: runner } = makeCapturingRunner(() =>
+			Effect.succeed({ exitCode: 0, stdout: JSON.stringify(["1.0.0"]), stderr: "" }),
+		);
+		const layer = NpmRegistryLive.pipe(Layer.provide(runner));
+		await Effect.runPromise(
+			NpmRegistry.pipe(
+				Effect.flatMap((reg) => reg.getVersions("my-pkg")),
+				Effect.provide(layer),
+			),
+		);
+		expect(calls[0]?.args).toEqual(["view", "my-pkg", "versions", "--json"]);
+		expect(calls[0]?.args).not.toContain("--registry");
+	});
+
 	it("getPackageInfo reads flat dot-notation keys from npm view", async () => {
 		const npmOutput = JSON.stringify({
 			name: "effect",
@@ -128,6 +240,54 @@ describe("NpmRegistryLive", () => {
 		expect(result.tarball).toBe("https://example.com/effect.tgz");
 	});
 
+	it("getPackageInfo appends --registry when registry option is supplied", async () => {
+		const { calls, layer: runner } = makeCapturingRunner(() =>
+			Effect.succeed({
+				exitCode: 0,
+				stdout: JSON.stringify({ name: "effect", version: "3.2.0", "dist-tags": {} }),
+				stderr: "",
+			}),
+		);
+		const layer = NpmRegistryLive.pipe(Layer.provide(runner));
+		await Effect.runPromise(
+			NpmRegistry.pipe(
+				Effect.flatMap((reg) => reg.getPackageInfo("effect", "3.2.0", { registry: "https://registry.npmjs.org/" })),
+				Effect.provide(layer),
+			),
+		);
+		expect(calls).toHaveLength(1);
+		expect(calls[0]?.args).toEqual([
+			"view",
+			"effect@3.2.0",
+			"name",
+			"version",
+			"dist-tags",
+			"dist.integrity",
+			"dist.tarball",
+			"--json",
+			"--registry",
+			"https://registry.npmjs.org/",
+		]);
+	});
+
+	it("getPackageInfo omits --registry when no option is supplied", async () => {
+		const { calls, layer: runner } = makeCapturingRunner(() =>
+			Effect.succeed({
+				exitCode: 0,
+				stdout: JSON.stringify({ name: "effect", version: "3.2.0", "dist-tags": {} }),
+				stderr: "",
+			}),
+		);
+		const layer = NpmRegistryLive.pipe(Layer.provide(runner));
+		await Effect.runPromise(
+			NpmRegistry.pipe(
+				Effect.flatMap((reg) => reg.getPackageInfo("effect")),
+				Effect.provide(layer),
+			),
+		);
+		expect(calls[0]?.args).not.toContain("--registry");
+	});
+
 	it("getLatestVersion returns non-string data as string via String()", async () => {
 		// When npm returns a non-string JSON value (e.g. a number), it should be converted via String()
 		const runner = makeMockRunner(new Map([["dist-tags.latest", "42"]]));
@@ -166,5 +326,146 @@ describe("NpmRegistryLive", () => {
 		);
 		expect(result).toHaveProperty("_tag", "NpmRegistryError");
 		expect(result).toHaveProperty("pkg", "nonexistent");
+	});
+
+	describe("getPublishedIntegrity", () => {
+		// Structured log lines emitted by getPublishedIntegrity are silenced
+		// inside the helpers (see `Logger.withMinimumLogLevel(LogLevel.None)`).
+		// The logs themselves are validated indirectly via the layer's
+		// emission to the runner during real runs.
+
+		it("returns Option.some(integrity) on a dist.integrity response", async () => {
+			const { calls, layer: runner } = makeCapturingRunner(() =>
+				Effect.succeed({
+					exitCode: 0,
+					stdout: JSON.stringify({ "dist.integrity": "sha512-abc123==" }),
+					stderr: "",
+				}),
+			);
+			const layer = NpmRegistryLive.pipe(Layer.provide(runner));
+			const result = await runIntegrityProbe(layer, "my-pkg", "1.0.0", {
+				registry: "https://registry.npmjs.org/",
+			});
+			expect(Option.isSome(result)).toBe(true);
+			expect(Option.getOrNull(result)).toBe("sha512-abc123==");
+			// Verifies the --registry flag is on the wire — the whole point
+			// of getPublishedIntegrity is the per-target probe.
+			expect(calls[0]?.args).toEqual([
+				"view",
+				"my-pkg@1.0.0",
+				"dist.integrity",
+				"--json",
+				"--registry",
+				"https://registry.npmjs.org/",
+			]);
+		});
+
+		it("accepts the flat string form npm emits when one field is requested", async () => {
+			// `npm view <pkg>@<ver> dist.integrity --json` for an existing
+			// version flattens to a bare JSON string when exactly one field
+			// is requested.
+			const { layer: runner } = makeCapturingRunner(() =>
+				Effect.succeed({
+					exitCode: 0,
+					stdout: '"sha512-flat=="',
+					stderr: "",
+				}),
+			);
+			const layer = NpmRegistryLive.pipe(Layer.provide(runner));
+			const result = await runIntegrityProbe(layer, "my-pkg", "1.0.0", {
+				registry: "https://registry.npmjs.org/",
+			});
+			expect(Option.getOrNull(result)).toBe("sha512-flat==");
+		});
+
+		it("accepts the nested dist.integrity form", async () => {
+			const { layer: runner } = makeCapturingRunner(() =>
+				Effect.succeed({
+					exitCode: 0,
+					stdout: JSON.stringify({ dist: { integrity: "sha512-nested==" } }),
+					stderr: "",
+				}),
+			);
+			const layer = NpmRegistryLive.pipe(Layer.provide(runner));
+			const result = await runIntegrityProbe(layer, "my-pkg", "1.0.0", {
+				registry: "https://registry.npmjs.org/",
+			});
+			expect(Option.getOrNull(result)).toBe("sha512-nested==");
+		});
+
+		it("returns Option.none() on an npm E404 (version not on the registry)", async () => {
+			const { layer: runner } = makeCapturingRunner(() =>
+				Effect.fail(
+					new CommandRunnerError({
+						command: "npm",
+						args: ["view"],
+						exitCode: 1,
+						stderr: "npm error code E404\nnpm error 404 'my-pkg@1.0.0' is not in this registry.",
+						reason: "Command failed with exit code 1",
+					}),
+				),
+			);
+			const layer = NpmRegistryLive.pipe(Layer.provide(runner));
+			const result = await runIntegrityProbe(layer, "my-pkg", "1.0.0", {
+				registry: "https://registry.npmjs.org/",
+			});
+			// E404 is the normal "version not published" branch; collapsing
+			// it into Option.none() lets the orchestrator treat publish as
+			// the default action without a special-case error catch.
+			expect(Option.isNone(result)).toBe(true);
+		});
+
+		it("returns Option.none() on an empty `{}` stdout (registry knows the name but version absent)", async () => {
+			// Some registries return an empty JSON object rather than a 404 when
+			// the version is not on file. Treat that as not-published.
+			const { layer: runner } = makeCapturingRunner(() => Effect.succeed({ exitCode: 0, stdout: "{}", stderr: "" }));
+			const layer = NpmRegistryLive.pipe(Layer.provide(runner));
+			const result = await runIntegrityProbe(layer, "my-pkg", "1.0.0", {
+				registry: "https://registry.npmjs.org/",
+			});
+			expect(Option.isNone(result)).toBe(true);
+		});
+
+		it("returns Option.none() on completely empty stdout", async () => {
+			const { layer: runner } = makeCapturingRunner(() => Effect.succeed({ exitCode: 0, stdout: "", stderr: "" }));
+			const layer = NpmRegistryLive.pipe(Layer.provide(runner));
+			const result = await runIntegrityProbe(layer, "my-pkg", "1.0.0", {
+				registry: "https://registry.npmjs.org/",
+			});
+			expect(Option.isNone(result)).toBe(true);
+		});
+
+		it("propagates non-E404 CommandRunnerError as NpmRegistryError", async () => {
+			// Network/auth failures must not collapse to Option.none() — that
+			// would let an orchestrator publish over a version it can't see.
+			const { layer: runner } = makeCapturingRunner(() =>
+				Effect.fail(
+					new CommandRunnerError({
+						command: "npm",
+						args: ["view"],
+						exitCode: 1,
+						stderr: "npm error network connect ETIMEDOUT",
+						reason: "Command failed with exit code 1",
+					}),
+				),
+			);
+			const layer = NpmRegistryLive.pipe(Layer.provide(runner));
+			const error = await runIntegrityProbeError(layer, "my-pkg", "1.0.0", {
+				registry: "https://registry.npmjs.org/",
+			});
+			expect(error).toHaveProperty("_tag", "NpmRegistryError");
+			expect(error).toHaveProperty("pkg", "my-pkg");
+		});
+
+		it("returns Option.none() when the response is parseable but has no integrity field", async () => {
+			const { layer: runner } = makeCapturingRunner(() =>
+				Effect.succeed({ exitCode: 0, stdout: JSON.stringify({ name: "my-pkg" }), stderr: "" }),
+			);
+			const layer = NpmRegistryLive.pipe(Layer.provide(runner));
+			const result = await runIntegrityProbe(layer, "my-pkg", "1.0.0", {
+				registry: "https://registry.npmjs.org/",
+			});
+			expect(Option.isNone(result)).toBe(true);
+		});
 	});
 });

--- a/src/layers/NpmRegistryLive.ts
+++ b/src/layers/NpmRegistryLive.ts
@@ -1,4 +1,5 @@
-import { Effect, Layer } from "effect";
+import { Effect, Layer, Option } from "effect";
+import type { CommandRunnerError } from "../errors/CommandRunnerError.js";
 import { NpmRegistryError } from "../errors/NpmRegistryError.js";
 import { CommandRunner } from "../services/CommandRunner.js";
 import { NpmRegistry } from "../services/NpmRegistry.js";
@@ -17,6 +18,28 @@ const parseJson = (
 				reason: `Failed to parse JSON: ${error instanceof Error ? error.message : String(error)}`,
 			}),
 	});
+
+/**
+ * Append `--registry <url>` to an arg list when the option is supplied.
+ *
+ * @internal
+ */
+const withRegistry = (args: ReadonlyArray<string>, options?: { readonly registry?: string }): ReadonlyArray<string> =>
+	options?.registry ? [...args, "--registry", options.registry] : args;
+
+/**
+ * Detect an `npm view` E404 — emitted when the queried name+version is not
+ * published on the target registry. npm 11.x writes the marker line
+ * `npm error code E404` to stderr; older versions used `npm ERR! code E404`.
+ * Accept both for safety. We deliberately do not parse the JSON body for
+ * 404 markers because npm omits the JSON entirely on E404.
+ *
+ * @internal
+ */
+const isE404 = (error: CommandRunnerError): boolean => {
+	const stderr = error.stderr ?? "";
+	return /(?:npm (?:error|ERR!)\s+code\s+E404)/.test(stderr);
+};
 
 /**
  * Live NpmRegistry layer using CommandRunner.
@@ -58,44 +81,38 @@ export const NpmRegistryLive: Layer.Layer<NpmRegistry, never, CommandRunner> = L
 				Effect.map((data) => data as Record<string, string>),
 			),
 
-		getPackageInfo: (pkg: string, version?: string) => {
+		getPackageInfo: (pkg: string, version?: string, options?: { readonly registry?: string }) => {
 			const target = version ? `${pkg}@${version}` : pkg;
-			return runner
-				.execCapture("npm", [
-					"view",
-					target,
-					"name",
-					"version",
-					"dist-tags",
-					"dist.integrity",
-					"dist.tarball",
-					"--json",
-				])
-				.pipe(
-					Effect.mapError(
-						(error) =>
-							new NpmRegistryError({
-								pkg,
-								operation: "view",
-								reason: error.reason,
-							}),
-					),
-					Effect.flatMap((output) => parseJson(pkg, "view", output.stdout)),
-					Effect.map((data) => {
-						const d = data as Record<string, unknown>;
-						return {
-							name: (d.name as string) ?? pkg,
-							version: (d.version as string) ?? "0.0.0",
-							distTags: (d["dist-tags"] as Record<string, string>) ?? {},
-							integrity: (d["dist.integrity"] as string | undefined) ?? (d.dist as Record<string, string>)?.integrity,
-							tarball: (d["dist.tarball"] as string | undefined) ?? (d.dist as Record<string, string>)?.tarball,
-						};
-					}),
-				);
+			const args = withRegistry(
+				["view", target, "name", "version", "dist-tags", "dist.integrity", "dist.tarball", "--json"],
+				options,
+			);
+			return runner.execCapture("npm", args).pipe(
+				Effect.mapError(
+					(error) =>
+						new NpmRegistryError({
+							pkg,
+							operation: "view",
+							reason: error.reason,
+						}),
+				),
+				Effect.flatMap((output) => parseJson(pkg, "view", output.stdout)),
+				Effect.map((data) => {
+					const d = data as Record<string, unknown>;
+					return {
+						name: (d.name as string) ?? pkg,
+						version: (d.version as string) ?? "0.0.0",
+						distTags: (d["dist-tags"] as Record<string, string>) ?? {},
+						integrity: (d["dist.integrity"] as string | undefined) ?? (d.dist as Record<string, string>)?.integrity,
+						tarball: (d["dist.tarball"] as string | undefined) ?? (d.dist as Record<string, string>)?.tarball,
+					};
+				}),
+			);
 		},
 
-		getVersions: (pkg: string) =>
-			runner.execCapture("npm", ["view", pkg, "versions", "--json"]).pipe(
+		getVersions: (pkg: string, options?: { readonly registry?: string }) => {
+			const args = withRegistry(["view", pkg, "versions", "--json"], options);
+			return runner.execCapture("npm", args).pipe(
 				Effect.mapError(
 					(error) =>
 						new NpmRegistryError({
@@ -111,6 +128,69 @@ export const NpmRegistryLive: Layer.Layer<NpmRegistry, never, CommandRunner> = L
 					if (typeof data === "string") return [data];
 					return [];
 				}),
-			),
+			);
+		},
+
+		getPublishedIntegrity: (pkg: string, version: string, options: { readonly registry: string }) =>
+			Effect.gen(function* () {
+				yield* Effect.logInfo(`getPublishedIntegrity: ${pkg}@${version} at ${options.registry}`);
+				const target = `${pkg}@${version}`;
+				const args = ["view", target, "dist.integrity", "--json", "--registry", options.registry];
+				// `npm view <name>@<missing-version> --json` exits non-zero with
+				// `npm error code E404` and a body of `'<pkg>@<ver>' is not in
+				// this registry`. Treat that exact signal as `Option.none()`.
+				// Any other CommandRunnerError (network, auth, server 5xx)
+				// propagates as an NpmRegistryError.
+				const captured = yield* runner.execCapture("npm", args).pipe(
+					Effect.map(Option.some),
+					Effect.catchTag("CommandRunnerError", (error) =>
+						isE404(error)
+							? Effect.succeed(Option.none<{ exitCode: number; stdout: string; stderr: string }>())
+							: Effect.fail(
+									new NpmRegistryError({
+										pkg,
+										operation: "view",
+										reason: error.reason,
+									}),
+								),
+					),
+				);
+				if (Option.isNone(captured)) {
+					yield* Effect.logInfo(`getPublishedIntegrity: ${pkg}@${version} at ${options.registry} → not published`);
+					return Option.none<string>();
+				}
+				const output = captured.value;
+				// npm exited cleanly. Empty stdout (or `{}`) means the registry
+				// knows the name but the queried field is absent — treat as
+				// not-published so first-publish-after-name-creation works.
+				const trimmed = output.stdout.trim();
+				if (trimmed === "" || trimmed === "{}") {
+					yield* Effect.logInfo(`getPublishedIntegrity: ${pkg}@${version} at ${options.registry} → not published`);
+					return Option.none<string>();
+				}
+				const parsed = yield* parseJson(pkg, "view", output.stdout);
+				const data = parsed as Record<string, unknown> | string | null;
+				let integrity: string | undefined;
+				if (typeof data === "string") {
+					// `npm view <pkg>@<ver> dist.integrity --json` flattens to a
+					// JSON string when one field is requested. Treat the whole
+					// string as the integrity value.
+					integrity = data;
+				} else if (data && typeof data === "object") {
+					const obj = data as Record<string, unknown>;
+					const flat = obj["dist.integrity"];
+					const nested = (obj.dist as Record<string, unknown> | undefined)?.integrity;
+					if (typeof flat === "string") integrity = flat;
+					else if (typeof nested === "string") integrity = nested;
+				}
+				if (integrity === undefined) {
+					yield* Effect.logInfo(`getPublishedIntegrity: ${pkg}@${version} at ${options.registry} → not published`);
+					return Option.none<string>();
+				}
+				yield* Effect.logInfo(
+					`getPublishedIntegrity: ${pkg}@${version} at ${options.registry} → present (integrity=${integrity})`,
+				);
+				return Option.some(integrity);
+			}),
 	})),
 );

--- a/src/layers/NpmRegistryTest.ts
+++ b/src/layers/NpmRegistryTest.ts
@@ -1,4 +1,4 @@
-import { Effect, Layer } from "effect";
+import { Effect, Layer, Option } from "effect";
 import { NpmRegistryError } from "../errors/NpmRegistryError.js";
 import type { NpmRegistry } from "../services/NpmRegistry.js";
 import { NpmRegistry as NpmRegistryTag } from "../services/NpmRegistry.js";
@@ -64,6 +64,14 @@ const makeTestClient = (state: NpmRegistryTestState): typeof NpmRegistry.Service
 		),
 
 	getVersions: (pkg: string) => getEntry(state, pkg, "versions").pipe(Effect.map((entry) => entry.versions)),
+
+	getPublishedIntegrity: (pkg: string, version: string, _options: { readonly registry: string }) =>
+		Effect.sync(() => {
+			const entry = state.packages.get(pkg);
+			if (entry === undefined) return Option.none<string>();
+			if (!entry.versions.includes(version)) return Option.none<string>();
+			return entry.integrity !== undefined ? Option.some(entry.integrity) : Option.none<string>();
+		}),
 });
 
 /**

--- a/src/layers/OidcTokenIssuerLive.ts
+++ b/src/layers/OidcTokenIssuerLive.ts
@@ -1,0 +1,144 @@
+/**
+ * OIDC token issuer for GitHub Actions.
+ *
+ * @remarks
+ * Fetches an OIDC ID token from the GitHub Actions token service. The
+ * runner exposes two environment variables when a workflow has the
+ * `id-token: write` permission:
+ *
+ * - `ACTIONS_ID_TOKEN_REQUEST_TOKEN` — bearer token authorizing the request
+ * - `ACTIONS_ID_TOKEN_REQUEST_URL`   — token issuance endpoint
+ *
+ * Callers pass an audience (e.g. `"sigstore"` for Fulcio cert issuance) and
+ * receive a {@link Redacted} JWT. The redacted wrapper keeps the JWT out of
+ * default `toString` / log paths; the value is unwrapped only at the point
+ * where it crosses the wire to Fulcio or Rekor.
+ *
+ * The implementation depends on {@link HttpClient.HttpClient} so the service
+ * composes with `FetchHttpClient.layer` in production and an in-memory mock
+ * layer in tests — no `node:fetch` import means no undici in the bundle.
+ */
+
+import { FileSystem, HttpClient, HttpClientRequest, HttpClientResponse } from "@effect/platform";
+import { Effect, Layer, Redacted, Schema } from "effect";
+import { OidcTokenError } from "../errors/OidcTokenError.js";
+import { OidcTokenIssuer } from "../services/OidcTokenIssuer.js";
+
+/**
+ * Response shape from the GitHub Actions OIDC token service.
+ *
+ * @internal
+ */
+const OidcTokenResponse = Schema.Struct({
+	value: Schema.String,
+	count: Schema.optional(Schema.Number),
+});
+
+const ACTIONS_ID_TOKEN_REQUEST_TOKEN = "ACTIONS_ID_TOKEN_REQUEST_TOKEN" as const;
+const ACTIONS_ID_TOKEN_REQUEST_URL = "ACTIONS_ID_TOKEN_REQUEST_URL" as const;
+
+const readEnv = (name: string): Effect.Effect<string, OidcTokenError> =>
+	Effect.sync(() => process.env[name]).pipe(
+		Effect.flatMap((value) =>
+			value && value.length > 0
+				? Effect.succeed(value)
+				: Effect.fail(
+						new OidcTokenError({
+							reason: "env",
+							message: `Missing required environment variable ${name}. The workflow needs \`permissions: id-token: write\` for OIDC token issuance.`,
+						}),
+					),
+		),
+	);
+
+/**
+ * Live {@link OidcTokenIssuer} layer. Requires {@link HttpClient.HttpClient}.
+ *
+ * @public
+ */
+export const OidcTokenIssuerLive = Layer.effect(
+	OidcTokenIssuer,
+	Effect.gen(function* () {
+		const http = yield* HttpClient.HttpClient;
+
+		return {
+			getToken: (audience: string) =>
+				Effect.gen(function* () {
+					const bearer = yield* readEnv(ACTIONS_ID_TOKEN_REQUEST_TOKEN);
+					const baseUrl = yield* readEnv(ACTIONS_ID_TOKEN_REQUEST_URL);
+
+					const url = new URL(baseUrl);
+					url.searchParams.set("audience", audience);
+
+					const request = HttpClientRequest.get(url.toString()).pipe(
+						HttpClientRequest.bearerToken(bearer),
+						HttpClientRequest.acceptJson,
+					);
+
+					const response = yield* http.execute(request).pipe(
+						Effect.mapError(
+							(cause) =>
+								new OidcTokenError({
+									reason: "http",
+									message: `OIDC token request failed: ${cause.message}`,
+									cause,
+								}),
+						),
+					);
+
+					if (response.status < 200 || response.status >= 300) {
+						const body = yield* response.text.pipe(Effect.orElseSucceed(() => "<unreadable body>"));
+						return yield* Effect.fail(
+							new OidcTokenError({
+								reason: "http",
+								message: `OIDC token request returned ${response.status}: ${body.slice(0, 200)}`,
+							}),
+						);
+					}
+
+					const parsed = yield* HttpClientResponse.schemaBodyJson(OidcTokenResponse)(response).pipe(
+						Effect.mapError(
+							(cause) =>
+								new OidcTokenError({
+									reason: "decode",
+									message: `OIDC token response did not match the expected shape: ${cause}`,
+									cause,
+								}),
+						),
+					);
+
+					return Redacted.make(parsed.value);
+				}),
+		};
+	}),
+);
+
+/**
+ * Save the redacted OIDC token to disk for local inspection.
+ *
+ * @remarks
+ * Convenience helper used during development to dump the JWT payload so
+ * you can decode it (e.g. with `jwt.io`) and inspect the claims. The
+ * redacted wrapper is unwrapped at the call site so the value lands on
+ * disk as plain text — only use this against a tmpdir.
+ *
+ * @public
+ */
+export const saveToken = (
+	token: Redacted.Redacted<string>,
+	path: string,
+): Effect.Effect<void, OidcTokenError, FileSystem.FileSystem> =>
+	Effect.gen(function* () {
+		const fs = yield* FileSystem.FileSystem;
+		const payload = JSON.stringify({ token: Redacted.value(token) }, null, 2);
+		yield* fs.writeFileString(path, payload).pipe(
+			Effect.mapError(
+				(error) =>
+					new OidcTokenError({
+						reason: "save",
+						message: `Failed to write OIDC token to ${path}: ${error.message}`,
+						cause: error,
+					}),
+			),
+		);
+	});

--- a/src/layers/OidcTokenIssuerTest.ts
+++ b/src/layers/OidcTokenIssuerTest.ts
@@ -1,0 +1,11 @@
+import { Effect, Layer, Redacted } from "effect";
+import { OidcTokenIssuer } from "../services/OidcTokenIssuer.js";
+
+/**
+ * Noop OidcTokenIssuer test layer — returns a fixed dummy JWT.
+ *
+ * @public
+ */
+export const OidcTokenIssuerTest: Layer.Layer<OidcTokenIssuer> = Layer.succeed(OidcTokenIssuer, {
+	getToken: () => Effect.succeed(Redacted.make("test-oidc-token")),
+});

--- a/src/layers/PackagePublishLive.test.ts
+++ b/src/layers/PackagePublishLive.test.ts
@@ -659,6 +659,44 @@ describe("PackagePublishLive", () => {
 		expect(calls[3]?.cwd).toBe("/pkg");
 	});
 
+	it("publishToRegistries routes the publish through the target's package manager", async () => {
+		const calls: Array<{ command: string; args: ReadonlyArray<string> }> = [];
+		const runner = makeMockRunner({
+			exec: (command, args) => {
+				calls.push({ command, args });
+				return Effect.succeed(0);
+			},
+		});
+		const registry = NpmRegistryTest.empty();
+		const layer = PackagePublishLive.pipe(Layer.provide(Layer.merge(runner, registry)));
+
+		await Effect.runPromise(
+			PackagePublish.pipe(
+				Effect.flatMap((svc) =>
+					svc.publishToRegistries("/pkg", [
+						{ registry: "https://registry.npmjs.org", token: "npm-token", packageManager: "pnpm" },
+					]),
+				),
+				Effect.provide(layer),
+			),
+		);
+
+		// Auth still goes through bare npm (writes .npmrc)...
+		expect(calls[0]?.command).toBe("npm");
+		expect(calls[0]?.args).toEqual(["config", "set", "//registry.npmjs.org:_authToken", "npm-token"]);
+		// ...but the publish dispatches through `pnpm dlx npm`.
+		expect(calls[1]?.command).toBe("pnpm");
+		expect(calls[1]?.args).toEqual([
+			"dlx",
+			"npm",
+			"publish",
+			"--registry",
+			"https://registry.npmjs.org",
+			"--loglevel",
+			"verbose",
+		]);
+	});
+
 	it("publishToRegistries wraps CommandRunnerError into PackagePublishError", async () => {
 		const runner = makeMockRunner({
 			exec: (_command, args) => {

--- a/src/layers/PackagePublishLive.test.ts
+++ b/src/layers/PackagePublishLive.test.ts
@@ -1,4 +1,4 @@
-import { Effect, Layer } from "effect";
+import { Effect, Exit, Layer } from "effect";
 import { describe, expect, it } from "vitest";
 import { CommandRunnerError } from "../errors/CommandRunnerError.js";
 import { PackagePublishError } from "../errors/PackagePublishError.js";
@@ -51,6 +51,29 @@ describe("PackagePublishLive", () => {
 		expect(calls[0]?.args).toEqual(["config", "set", "//npm.pkg.github.com:_authToken", "ghp_token"]);
 	});
 
+	it("setupAuth strips the URL scheme when given a full registry URL", async () => {
+		const calls: Array<{ command: string; args: ReadonlyArray<string> }> = [];
+		const runner = makeMockRunner({
+			exec: (command, args) => {
+				calls.push({ command, args });
+				return Effect.succeed(0);
+			},
+		});
+		const registry = NpmRegistryTest.empty();
+		const layer = PackagePublishLive.pipe(Layer.provide(Layer.merge(runner, registry)));
+
+		await Effect.runPromise(
+			PackagePublish.pipe(
+				Effect.flatMap((svc) => svc.setupAuth("https://npm.pkg.github.com/", "ghp_token")),
+				Effect.provide(layer),
+			),
+		);
+
+		// npm matches `//npm.pkg.github.com/:_authToken`; keeping the scheme
+		// (`//https://…`) yields a key npm never matches → ENEEDAUTH.
+		expect(calls[0]?.args).toEqual(["config", "set", "//npm.pkg.github.com/:_authToken", "ghp_token"]);
+	});
+
 	it("publish runs npm publish with flags", async () => {
 		const calls: Array<{ command: string; args: ReadonlyArray<string> }> = [];
 		const runner = makeMockRunner({
@@ -86,6 +109,8 @@ describe("PackagePublishLive", () => {
 			"--access",
 			"public",
 			"--provenance",
+			"--loglevel",
+			"verbose",
 		]);
 	});
 
@@ -162,7 +187,7 @@ describe("PackagePublishLive", () => {
 		);
 
 		expect(calls).toHaveLength(1);
-		expect(calls[0]?.args).toEqual(["publish"]);
+		expect(calls[0]?.args).toEqual(["publish", "--loglevel", "verbose"]);
 	});
 
 	it("publish includes only registry flag when only registry is set", async () => {
@@ -183,7 +208,7 @@ describe("PackagePublishLive", () => {
 			),
 		);
 
-		expect(calls[0]?.args).toEqual(["publish", "--registry", "https://registry.npmjs.org"]);
+		expect(calls[0]?.args).toEqual(["publish", "--registry", "https://registry.npmjs.org", "--loglevel", "verbose"]);
 	});
 
 	it("publish includes only tag flag when only tag is set", async () => {
@@ -204,7 +229,7 @@ describe("PackagePublishLive", () => {
 			),
 		);
 
-		expect(calls[0]?.args).toEqual(["publish", "--tag", "beta"]);
+		expect(calls[0]?.args).toEqual(["publish", "--tag", "beta", "--loglevel", "verbose"]);
 	});
 
 	it("publish includes only access flag when only access is set", async () => {
@@ -225,7 +250,7 @@ describe("PackagePublishLive", () => {
 			),
 		);
 
-		expect(calls[0]?.args).toEqual(["publish", "--access", "restricted"]);
+		expect(calls[0]?.args).toEqual(["publish", "--access", "restricted", "--loglevel", "verbose"]);
 	});
 
 	it("publish includes only provenance flag when only provenance is set", async () => {
@@ -246,7 +271,7 @@ describe("PackagePublishLive", () => {
 			),
 		);
 
-		expect(calls[0]?.args).toEqual(["publish", "--provenance"]);
+		expect(calls[0]?.args).toEqual(["publish", "--provenance", "--loglevel", "verbose"]);
 	});
 
 	it("publish does not include provenance flag when provenance is false", async () => {
@@ -267,7 +292,121 @@ describe("PackagePublishLive", () => {
 			),
 		);
 
-		expect(calls[0]?.args).toEqual(["publish"]);
+		expect(calls[0]?.args).toEqual(["publish", "--loglevel", "verbose"]);
+	});
+
+	it("publish dispatches through `pnpm dlx npm` when packageManager is pnpm", async () => {
+		// Critical for npm trusted publishing: `pnpm dlx npm` fetches a fresh
+		// npm rather than using the runner's bundled npm. Node 24 ships npm
+		// 10.x, which has no OIDC token-exchange support; `pnpm dlx npm`
+		// pulls npm 11.5.1+, which does. The cmd flips from "npm" to "pnpm",
+		// and "dlx", "npm" is prepended to the publish args.
+		const calls: Array<{ command: string; args: ReadonlyArray<string> }> = [];
+		const runner = makeMockRunner({
+			exec: (command, args) => {
+				calls.push({ command, args });
+				return Effect.succeed(0);
+			},
+		});
+		const registry = NpmRegistryTest.empty();
+		const layer = PackagePublishLive.pipe(Layer.provide(Layer.merge(runner, registry)));
+
+		await Effect.runPromise(
+			PackagePublish.pipe(
+				Effect.flatMap((svc) =>
+					svc.publish("/pkg", {
+						registry: "https://registry.npmjs.org",
+						access: "public",
+						provenance: true,
+						packageManager: "pnpm",
+					}),
+				),
+				Effect.provide(layer),
+			),
+		);
+
+		expect(calls).toHaveLength(1);
+		expect(calls[0]?.command).toBe("pnpm");
+		expect(calls[0]?.args).toEqual([
+			"dlx",
+			"npm",
+			"publish",
+			"--registry",
+			"https://registry.npmjs.org",
+			"--access",
+			"public",
+			"--provenance",
+			"--loglevel",
+			"verbose",
+		]);
+	});
+
+	it("publish dispatches through `yarn npm` when packageManager is yarn", async () => {
+		const calls: Array<{ command: string; args: ReadonlyArray<string> }> = [];
+		const runner = makeMockRunner({
+			exec: (command, args) => {
+				calls.push({ command, args });
+				return Effect.succeed(0);
+			},
+		});
+		const registry = NpmRegistryTest.empty();
+		const layer = PackagePublishLive.pipe(Layer.provide(Layer.merge(runner, registry)));
+
+		await Effect.runPromise(
+			PackagePublish.pipe(
+				Effect.flatMap((svc) => svc.publish("/pkg", { packageManager: "yarn" })),
+				Effect.provide(layer),
+			),
+		);
+
+		expect(calls[0]?.command).toBe("yarn");
+		expect(calls[0]?.args).toEqual(["npm", "publish", "--loglevel", "verbose"]);
+	});
+
+	it("publish dispatches through `bun x npm` when packageManager is bun", async () => {
+		const calls: Array<{ command: string; args: ReadonlyArray<string> }> = [];
+		const runner = makeMockRunner({
+			exec: (command, args) => {
+				calls.push({ command, args });
+				return Effect.succeed(0);
+			},
+		});
+		const registry = NpmRegistryTest.empty();
+		const layer = PackagePublishLive.pipe(Layer.provide(Layer.merge(runner, registry)));
+
+		await Effect.runPromise(
+			PackagePublish.pipe(
+				Effect.flatMap((svc) => svc.publish("/pkg", { packageManager: "bun" })),
+				Effect.provide(layer),
+			),
+		);
+
+		expect(calls[0]?.command).toBe("bun");
+		expect(calls[0]?.args).toEqual(["x", "npm", "publish", "--loglevel", "verbose"]);
+	});
+
+	it("publish keeps the bare `npm` dispatch when packageManager is unset or 'npm'", async () => {
+		// Default preserves the prior behaviour for callers that haven't
+		// opted in. The runner's bundled npm is used.
+		const calls: Array<{ command: string; args: ReadonlyArray<string> }> = [];
+		const runner = makeMockRunner({
+			exec: (command, args) => {
+				calls.push({ command, args });
+				return Effect.succeed(0);
+			},
+		});
+		const registry = NpmRegistryTest.empty();
+		const layer = PackagePublishLive.pipe(Layer.provide(Layer.merge(runner, registry)));
+
+		await Effect.runPromise(
+			PackagePublish.pipe(
+				Effect.flatMap((svc) => svc.publish("/pkg", { packageManager: "npm" })),
+				Effect.provide(layer),
+			),
+		);
+
+		expect(calls[0]?.command).toBe("npm");
+		expect(calls[0]?.args[0]).toBe("publish");
 	});
 
 	it("publish wraps CommandRunnerError into PackagePublishError", async () => {
@@ -298,6 +437,35 @@ describe("PackagePublishLive", () => {
 		expect(error.operation).toBe("publish");
 		expect(error.registry).toBe("https://registry.npmjs.org");
 		expect(error.reason).toBe("Command failed with exit code 1");
+	});
+
+	it("publish carries the CommandRunnerError as cause on failure", async () => {
+		const sourceError = new CommandRunnerError({
+			command: "npm",
+			args: ["publish"],
+			exitCode: 1,
+			stderr: "npm error 403 Forbidden",
+			reason: "Command failed with exit code 1",
+		});
+		const runner = makeMockRunner({
+			exec: () => Effect.fail(sourceError),
+		});
+		const registry = NpmRegistryTest.empty();
+		const layer = PackagePublishLive.pipe(Layer.provide(Layer.merge(runner, registry)));
+
+		const error = await Effect.runPromise(
+			PackagePublish.pipe(
+				Effect.flatMap((svc) => svc.publish("/pkg", { registry: "https://registry.npmjs.org" })),
+				Effect.provide(layer),
+				Effect.flip,
+			),
+		);
+
+		expect(error).toBeInstanceOf(PackagePublishError);
+		expect(error.operation).toBe("publish");
+		expect(error.cause).toBe(sourceError);
+		expect((error.cause as CommandRunnerError)._tag).toBe("CommandRunnerError");
+		expect((error.cause as CommandRunnerError).stderr).toBe("npm error 403 Forbidden");
 	});
 
 	it("publish error omits registry field when registry option is not provided", async () => {
@@ -471,7 +639,7 @@ describe("PackagePublishLive", () => {
 		);
 
 		// First registry: auth + publish with tag and access
-		expect(calls[0]?.args).toEqual(["config", "set", "//https://registry.npmjs.org:_authToken", "npm-token"]);
+		expect(calls[0]?.args).toEqual(["config", "set", "//registry.npmjs.org:_authToken", "npm-token"]);
 		expect(calls[1]?.args).toEqual([
 			"publish",
 			"--registry",
@@ -480,12 +648,14 @@ describe("PackagePublishLive", () => {
 			"latest",
 			"--access",
 			"public",
+			"--loglevel",
+			"verbose",
 		]);
 		expect(calls[1]?.cwd).toBe("/pkg");
 
 		// Second registry: auth + publish without tag/access
-		expect(calls[2]?.args).toEqual(["config", "set", "//https://npm.pkg.github.com:_authToken", "ghp-token"]);
-		expect(calls[3]?.args).toEqual(["publish", "--registry", "https://npm.pkg.github.com"]);
+		expect(calls[2]?.args).toEqual(["config", "set", "//npm.pkg.github.com:_authToken", "ghp-token"]);
+		expect(calls[3]?.args).toEqual(["publish", "--registry", "https://npm.pkg.github.com", "--loglevel", "verbose"]);
 		expect(calls[3]?.cwd).toBe("/pkg");
 	});
 
@@ -552,5 +722,465 @@ describe("PackagePublishLive", () => {
 		expect(error).toBeInstanceOf(PackagePublishError);
 		expect(error.operation).toBe("publishToRegistries");
 		expect(error.reason).toBe("plain string error");
+	});
+
+	describe("dryRun", () => {
+		it("returns ok: true with size fields when npm exits cleanly", async () => {
+			const calls: Array<{ command: string; args: ReadonlyArray<string>; cwd: string | undefined }> = [];
+			const runner = makeMockRunner({
+				execCapture: (command, args, options) => {
+					calls.push({ command, args, cwd: options?.cwd });
+					// `npm publish --dry-run --json` emits a single JSON object —
+					// not an array (that is `npm pack --dry-run --json`).
+					return Effect.succeed({
+						exitCode: 0,
+						stdout: JSON.stringify({ size: 1234, unpackedSize: 5678, entryCount: 9 }),
+						stderr: "",
+					});
+				},
+			});
+			const registry = NpmRegistryTest.empty();
+			const layer = PackagePublishLive.pipe(Layer.provide(Layer.merge(runner, registry)));
+
+			const result = await Effect.runPromise(
+				PackagePublish.pipe(
+					Effect.flatMap((svc) =>
+						svc.dryRun("/pkg", {
+							registry: "https://registry.npmjs.org",
+							tag: "latest",
+							access: "public",
+							provenance: true,
+						}),
+					),
+					Effect.provide(layer),
+				),
+			);
+
+			expect(result.ok).toBe(true);
+			expect(result.packedSize).toBe(1234);
+			expect(result.unpackedSize).toBe(5678);
+			expect(result.fileCount).toBe(9);
+			expect(calls).toHaveLength(1);
+			expect(calls[0]?.command).toBe("npm");
+			expect(calls[0]?.args).toEqual([
+				"publish",
+				"--dry-run",
+				"--json",
+				"--registry",
+				"https://registry.npmjs.org",
+				"--tag",
+				"latest",
+				"--access",
+				"public",
+				"--provenance",
+			]);
+			expect(calls[0]?.cwd).toBe("/pkg");
+		});
+
+		it("returns size fields when npm emits the array form (npm pack shape)", async () => {
+			const runner = makeMockRunner({
+				execCapture: () =>
+					Effect.succeed({
+						exitCode: 0,
+						stdout: JSON.stringify([{ size: 42, unpackedSize: 84, entryCount: 3 }]),
+						stderr: "",
+					}),
+			});
+			const registry = NpmRegistryTest.empty();
+			const layer = PackagePublishLive.pipe(Layer.provide(Layer.merge(runner, registry)));
+
+			const result = await Effect.runPromise(
+				PackagePublish.pipe(
+					Effect.flatMap((svc) => svc.dryRun("/pkg")),
+					Effect.provide(layer),
+				),
+			);
+
+			expect(result.ok).toBe(true);
+			expect(result.packedSize).toBe(42);
+			expect(result.unpackedSize).toBe(84);
+			expect(result.fileCount).toBe(3);
+		});
+
+		it("returns ok: false (not an Effect failure) when npm exits non-zero", async () => {
+			const runner = makeMockRunner({
+				execCapture: () =>
+					Effect.fail(
+						new CommandRunnerError({
+							command: "npm",
+							args: ["publish", "--dry-run", "--json"],
+							exitCode: 1,
+							stderr: "E403 Forbidden",
+							reason: "Command failed with exit code 1",
+						}),
+					),
+			});
+			const registry = NpmRegistryTest.empty();
+			const layer = PackagePublishLive.pipe(Layer.provide(Layer.merge(runner, registry)));
+
+			const result = await Effect.runPromise(
+				PackagePublish.pipe(
+					Effect.flatMap((svc) => svc.dryRun("/pkg")),
+					Effect.provide(layer),
+				),
+			);
+
+			expect(result.ok).toBe(false);
+			expect(result.output).toContain("E403");
+		});
+
+		it("fails with PackagePublishError when npm output is unparseable JSON", async () => {
+			const runner = makeMockRunner({
+				execCapture: () => Effect.succeed({ exitCode: 0, stdout: "not valid json", stderr: "" }),
+			});
+			const registry = NpmRegistryTest.empty();
+			const layer = PackagePublishLive.pipe(Layer.provide(Layer.merge(runner, registry)));
+
+			const error = await Effect.runPromise(
+				PackagePublish.pipe(
+					Effect.flatMap((svc) => svc.dryRun("/pkg")),
+					Effect.provide(layer),
+					Effect.flip,
+				),
+			);
+
+			expect(error).toBeInstanceOf(PackagePublishError);
+			expect(error.operation).toBe("dryRun");
+		});
+	});
+
+	describe("publishIdempotent", () => {
+		it("publishes when the version is absent from the registry", async () => {
+			const calls: Array<{ command: string; args: ReadonlyArray<string> }> = [];
+			const runner = makeMockRunner({
+				exec: (command, args) => {
+					calls.push({ command, args });
+					return Effect.succeed(0);
+				},
+			});
+			const registry = NpmRegistryTest.layer({
+				packages: new Map([["my-pkg", { versions: [], latest: "", distTags: {} }]]),
+			});
+			const layer = PackagePublishLive.pipe(Layer.provide(Layer.merge(runner, registry)));
+
+			const result = await Effect.runPromise(
+				PackagePublish.pipe(
+					Effect.flatMap((svc) =>
+						svc.publishIdempotent({
+							packageDir: "/pkg",
+							packageName: "my-pkg",
+							version: "1.0.0",
+							digest: "sha512-abc123",
+						}),
+					),
+					Effect.provide(layer),
+				),
+			);
+
+			expect(result).toEqual({ status: "published", packageName: "my-pkg", version: "1.0.0" });
+			expect(calls).toHaveLength(1);
+			expect(calls[0]?.args[0]).toBe("publish");
+		});
+
+		it("skips when an identical version is already published", async () => {
+			const calls: Array<{ command: string; args: ReadonlyArray<string> }> = [];
+			const runner = makeMockRunner({
+				exec: (command, args) => {
+					calls.push({ command, args });
+					return Effect.succeed(0);
+				},
+			});
+			const registry = NpmRegistryTest.layer({
+				packages: new Map([
+					[
+						"my-pkg",
+						{ versions: ["1.0.0"], latest: "1.0.0", distTags: { latest: "1.0.0" }, integrity: "sha512-abc123" },
+					],
+				]),
+			});
+			const layer = PackagePublishLive.pipe(Layer.provide(Layer.merge(runner, registry)));
+
+			const result = await Effect.runPromise(
+				PackagePublish.pipe(
+					Effect.flatMap((svc) =>
+						svc.publishIdempotent({
+							packageDir: "/pkg",
+							packageName: "my-pkg",
+							version: "1.0.0",
+							digest: "sha512-abc123",
+						}),
+					),
+					Effect.provide(layer),
+				),
+			);
+
+			expect(result).toEqual({
+				status: "skipped",
+				packageName: "my-pkg",
+				version: "1.0.0",
+				skipReason: "already-published-identical",
+			});
+			expect(calls).toHaveLength(0);
+		});
+
+		it("fails when the published version has a different integrity hash", async () => {
+			const runner = makeMockRunner({});
+			const registry = NpmRegistryTest.layer({
+				packages: new Map([
+					[
+						"my-pkg",
+						{ versions: ["1.0.0"], latest: "1.0.0", distTags: { latest: "1.0.0" }, integrity: "sha512-published" },
+					],
+				]),
+			});
+			const layer = PackagePublishLive.pipe(Layer.provide(Layer.merge(runner, registry)));
+
+			const exit = await Effect.runPromiseExit(
+				PackagePublish.pipe(
+					Effect.flatMap((svc) =>
+						svc.publishIdempotent({
+							packageDir: "/pkg",
+							packageName: "my-pkg",
+							version: "1.0.0",
+							digest: "sha512-localbuild",
+						}),
+					),
+					Effect.provide(layer),
+				),
+			);
+
+			expect(Exit.isFailure(exit)).toBe(true);
+		});
+	});
+
+	describe("pack (happy path)", () => {
+		it("populates name, version, sizes, file count, and integrity from npm pack --json", async () => {
+			// Use a real temp dir + real placeholder tarball so the
+			// pack method can hash it for sha256Hex. The npm pack --json
+			// output is mocked; the file's bytes just need to exist.
+			const { mkdtempSync, writeFileSync } = await import("node:fs");
+			const { tmpdir } = await import("node:os");
+			const { join } = await import("node:path");
+			const { createHash } = await import("node:crypto");
+			const dir = mkdtempSync(join(tmpdir(), "pack-test-"));
+			const tarballName = "my-pkg-2.1.0.tgz";
+			const tarballBytes = Buffer.from("fixture tarball bytes");
+			writeFileSync(join(dir, tarballName), tarballBytes);
+			const expectedSha256 = createHash("sha256").update(tarballBytes).digest("hex");
+
+			// Fixture mirrors the real shape of `npm pack --json`: an array of
+			// entries with name/version/size/unpackedSize/entryCount/integrity.
+			// All non-tarball fields flow into PackResult, so callers don't
+			// need to re-parse npm's output downstream.
+			const fixture = JSON.stringify([
+				{
+					id: "my-pkg@2.1.0",
+					name: "my-pkg",
+					version: "2.1.0",
+					size: 4096,
+					unpackedSize: 16384,
+					shasum: "deadbeef",
+					integrity: "sha512-Yqxw3FaA==",
+					filename: tarballName,
+					entryCount: 7,
+				},
+			]);
+			const runner = makeMockRunner({
+				execCapture: () => Effect.succeed({ exitCode: 0, stdout: fixture, stderr: "" }),
+			});
+			const registry = NpmRegistryTest.empty();
+			const layer = PackagePublishLive.pipe(Layer.provide(Layer.merge(runner, registry)));
+
+			const result = await Effect.runPromise(
+				PackagePublish.pipe(
+					Effect.flatMap((svc) => svc.pack(dir)),
+					Effect.provide(layer),
+				),
+			);
+
+			expect(result).toEqual({
+				tarballPath: join(dir, tarballName),
+				digest: "sha512-Yqxw3FaA==",
+				sha256Hex: expectedSha256,
+				name: "my-pkg",
+				version: "2.1.0",
+				packedSize: 4096,
+				unpackedSize: 16384,
+				fileCount: 7,
+			});
+		});
+
+		it("fails when npm pack omits the integrity field", async () => {
+			// Without `integrity`, there is no value to compare against the
+			// registry's `dist.integrity`. Surfacing a clear error is better
+			// than silently returning a placeholder.
+			const fixture = JSON.stringify([
+				{
+					name: "my-pkg",
+					version: "1.0.0",
+					filename: "my-pkg-1.0.0.tgz",
+					size: 100,
+					unpackedSize: 200,
+					entryCount: 3,
+				},
+			]);
+			const runner = makeMockRunner({
+				execCapture: () => Effect.succeed({ exitCode: 0, stdout: fixture, stderr: "" }),
+			});
+			const registry = NpmRegistryTest.empty();
+			const layer = PackagePublishLive.pipe(Layer.provide(Layer.merge(runner, registry)));
+
+			const error = await Effect.runPromise(
+				PackagePublish.pipe(
+					Effect.flatMap((svc) => svc.pack("/pkg")),
+					Effect.provide(layer),
+					Effect.flip,
+				),
+			);
+			expect(error).toBeInstanceOf(PackagePublishError);
+			expect(error.operation).toBe("pack");
+			expect(error.reason).toContain("missing integrity");
+		});
+	});
+
+	describe("publishTarball", () => {
+		it("invokes npm publish <tarballPath> --registry <url> with no cwd", async () => {
+			const calls: Array<{ command: string; args: ReadonlyArray<string>; cwd: string | undefined }> = [];
+			const runner = makeMockRunner({
+				exec: (command, args, options) => {
+					calls.push({ command, args, cwd: options?.cwd });
+					return Effect.succeed(0);
+				},
+			});
+			const registry = NpmRegistryTest.empty();
+			const layer = PackagePublishLive.pipe(Layer.provide(Layer.merge(runner, registry)));
+
+			await Effect.runPromise(
+				PackagePublish.pipe(
+					Effect.flatMap((svc) =>
+						svc.publishTarball("/tmp/my-pkg-2.0.0.tgz", {
+							registry: "https://registry.npmjs.org/",
+							access: "public",
+							provenance: true,
+							tag: "next",
+						}),
+					),
+					Effect.provide(layer),
+				),
+			);
+
+			expect(calls).toHaveLength(1);
+			expect(calls[0]?.command).toBe("npm");
+			expect(calls[0]?.args).toEqual([
+				"publish",
+				"/tmp/my-pkg-2.0.0.tgz",
+				"--registry",
+				"https://registry.npmjs.org/",
+				"--access",
+				"public",
+				"--provenance",
+				"--tag",
+				"next",
+				"--loglevel",
+				"verbose",
+			]);
+			// publishTarball does NOT set cwd — the tarball path is absolute.
+			expect(calls[0]?.cwd).toBeUndefined();
+		});
+
+		it("omits --access, --provenance, and --tag when not provided", async () => {
+			const calls: Array<{ command: string; args: ReadonlyArray<string> }> = [];
+			const runner = makeMockRunner({
+				exec: (command, args) => {
+					calls.push({ command, args });
+					return Effect.succeed(0);
+				},
+			});
+			const registry = NpmRegistryTest.empty();
+			const layer = PackagePublishLive.pipe(Layer.provide(Layer.merge(runner, registry)));
+
+			await Effect.runPromise(
+				PackagePublish.pipe(
+					Effect.flatMap((svc) => svc.publishTarball("/tmp/pkg.tgz", { registry: "https://registry.npmjs.org/" })),
+					Effect.provide(layer),
+				),
+			);
+
+			expect(calls[0]?.args).toEqual([
+				"publish",
+				"/tmp/pkg.tgz",
+				"--registry",
+				"https://registry.npmjs.org/",
+				"--loglevel",
+				"verbose",
+			]);
+		});
+
+		it("dispatches through `pnpm dlx npm` when packageManager is pnpm", async () => {
+			const calls: Array<{ command: string; args: ReadonlyArray<string> }> = [];
+			const runner = makeMockRunner({
+				exec: (command, args) => {
+					calls.push({ command, args });
+					return Effect.succeed(0);
+				},
+			});
+			const registry = NpmRegistryTest.empty();
+			const layer = PackagePublishLive.pipe(Layer.provide(Layer.merge(runner, registry)));
+
+			await Effect.runPromise(
+				PackagePublish.pipe(
+					Effect.flatMap((svc) =>
+						svc.publishTarball("/tmp/pkg.tgz", {
+							registry: "https://registry.npmjs.org/",
+							packageManager: "pnpm",
+						}),
+					),
+					Effect.provide(layer),
+				),
+			);
+
+			expect(calls[0]?.command).toBe("pnpm");
+			expect(calls[0]?.args).toEqual([
+				"dlx",
+				"npm",
+				"publish",
+				"/tmp/pkg.tgz",
+				"--registry",
+				"https://registry.npmjs.org/",
+				"--loglevel",
+				"verbose",
+			]);
+		});
+
+		it("wraps CommandRunnerError into PackagePublishError with the registry attached", async () => {
+			const runner = makeMockRunner({
+				exec: () =>
+					Effect.fail(
+						new CommandRunnerError({
+							command: "npm",
+							args: ["publish"],
+							exitCode: 1,
+							stderr: "npm error 403 Forbidden",
+							reason: "Command failed with exit code 1",
+						}),
+					),
+			});
+			const registry = NpmRegistryTest.empty();
+			const layer = PackagePublishLive.pipe(Layer.provide(Layer.merge(runner, registry)));
+
+			const error = await Effect.runPromise(
+				PackagePublish.pipe(
+					Effect.flatMap((svc) => svc.publishTarball("/tmp/pkg.tgz", { registry: "https://npm.pkg.github.com/" })),
+					Effect.provide(layer),
+					Effect.flip,
+				),
+			);
+
+			expect(error).toBeInstanceOf(PackagePublishError);
+			expect(error.operation).toBe("publishTarball");
+			expect(error.registry).toBe("https://npm.pkg.github.com/");
+			expect(error.reason).toBe("Command failed with exit code 1");
+			expect((error.cause as CommandRunnerError).stderr).toBe("npm error 403 Forbidden");
+		});
 	});
 });

--- a/src/layers/PackagePublishLive.ts
+++ b/src/layers/PackagePublishLive.ts
@@ -289,15 +289,24 @@ export const PackagePublishLive: Layer.Layer<PackagePublish, never, CommandRunne
 						readonly token: string;
 						readonly tag?: string;
 						readonly access?: "public" | "restricted";
+						readonly packageManager?: "npm" | "pnpm" | "yarn" | "bun";
 					}>,
 				) =>
 					Effect.forEach(
 						registries,
 						(target) =>
+							// `npm config set` writes the auth token to `.npmrc`; the
+							// bundled npm handles this fine regardless of which manager
+							// runs the publish, so it stays bare `npm`.
 							runner.exec("npm", ["config", "set", authTokenKey(target.registry), target.token]).pipe(
 								Effect.asVoid,
 								Effect.flatMap(() => {
-									const args = ["publish"];
+									// Route the publish through the active manager's npm
+									// executor — same dispatch as `publish` / `publishTarball`
+									// so a caller publishing through `publishToRegistries`
+									// still gets the fresh-npm OIDC fix.
+									const { cmd, baseArgs } = getNpmCommand(target.packageManager);
+									const args = [...baseArgs, "publish"];
 									args.push("--registry", target.registry);
 									if (target.tag) args.push("--tag", target.tag);
 									if (target.access) args.push("--access", target.access);
@@ -305,7 +314,7 @@ export const PackagePublishLive: Layer.Layer<PackagePublish, never, CommandRunne
 									// See the `publish` method above — stream npm output
 									// to the runner log so failures are diagnosable, and
 									// verbose surfaces npm's OIDC exchange and HTTP requests.
-									return runner.exec("npm", args, { cwd: packageDir, streaming: true }).pipe(Effect.asVoid);
+									return runner.exec(cmd, args, { cwd: packageDir, streaming: true }).pipe(Effect.asVoid);
 								}),
 							),
 						{ discard: true },

--- a/src/layers/PackagePublishLive.ts
+++ b/src/layers/PackagePublishLive.ts
@@ -1,11 +1,90 @@
 import { createHash } from "node:crypto";
-import { readFile } from "node:fs/promises";
+import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { Effect, Layer } from "effect";
 import { PackagePublishError } from "../errors/PackagePublishError.js";
 import { CommandRunner } from "../services/CommandRunner.js";
 import { NpmRegistry } from "../services/NpmRegistry.js";
+import type { DryRunResult, IdempotentPublishInput, PackResult } from "../services/PackagePublish.js";
 import { PackagePublish } from "../services/PackagePublish.js";
+
+/**
+ * The size-bearing fields of npm's `--json` dry-run output.
+ *
+ * `npm publish --dry-run --json` emits one such object; `npm pack --dry-run
+ * --json` emits an array of them. Only the fields consumed by {@link DryRunResult}
+ * are modelled.
+ */
+interface PackedJson {
+	readonly size?: number;
+	readonly unpackedSize?: number;
+	readonly entryCount?: number;
+}
+
+/**
+ * Shape of an entry in `npm pack --json` output.
+ *
+ * @remarks
+ * `npm pack --json` emits an array of objects, one per packed tarball.
+ * Each object carries the fields modelled below; `integrity` is in the
+ * `sha512-<base64>` shape the registry stores as `dist.integrity`.
+ *
+ * @internal
+ */
+interface NpmPackJsonEntry {
+	readonly filename: string;
+	readonly name?: string;
+	readonly version?: string;
+	readonly integrity?: string;
+	readonly size?: number;
+	readonly unpackedSize?: number;
+	readonly entryCount?: number;
+}
+
+/**
+ * Build npm's `_authToken` config key for a registry.
+ *
+ * npm derives a registry's auth-config key by stripping the URL scheme and
+ * keeping a leading `//` — e.g. `https://npm.pkg.github.com/` becomes
+ * `//npm.pkg.github.com/:_authToken`. The `registry` argument may be a full
+ * URL or a bare host; both normalize to the same key. Writing the key with the
+ * scheme still attached (`//https://…`) produces a key npm never matches, so
+ * the publish is treated as unauthenticated.
+ */
+const authTokenKey = (registry: string): string => {
+	const withoutScheme = registry.replace(/^https?:\/\//, "");
+	const prefixed = withoutScheme.startsWith("//") ? withoutScheme : `//${withoutScheme}`;
+	return `${prefixed}:_authToken`;
+};
+
+/**
+ * Resolve the command + base args used to invoke `npm` under each supported
+ * package manager.
+ *
+ * @remarks
+ * Critically, `pnpm dlx npm`, `yarn npm`, and `bun x npm` each fetch a fresh
+ * `npm` rather than using the one bundled with the runner's Node. The runner's
+ * bundled `npm` lags Node by several minor versions — Node 24 ships npm 10.x,
+ * which has no support for npm trusted publishing (the OIDC token-exchange
+ * step that lets `npm publish --provenance` run without an `NPM_TOKEN`).
+ * Routing through the package manager's executor fetches npm 11.5.1+, which
+ * supports the exchange. `"npm"` keeps the bundled `npm` and is the safe
+ * default for callers that have ensured an adequate version themselves.
+ *
+ * @internal
+ */
+const getNpmCommand = (pm?: "npm" | "pnpm" | "yarn" | "bun"): { cmd: string; baseArgs: ReadonlyArray<string> } => {
+	switch (pm) {
+		case "pnpm":
+			return { cmd: "pnpm", baseArgs: ["dlx", "npm"] };
+		case "yarn":
+			return { cmd: "yarn", baseArgs: ["npm"] };
+		case "bun":
+			return { cmd: "bun", baseArgs: ["x", "npm"] };
+		default:
+			return { cmd: "npm", baseArgs: [] };
+	}
+};
 
 /**
  * Live PackagePublish layer using CommandRunner and NpmRegistry.
@@ -15,146 +94,334 @@ import { PackagePublish } from "../services/PackagePublish.js";
 export const PackagePublishLive: Layer.Layer<PackagePublish, never, CommandRunner | NpmRegistry> = Layer.effect(
 	PackagePublish,
 	Effect.all([CommandRunner, NpmRegistry]).pipe(
-		Effect.map(([runner, registry]) => ({
-			setupAuth: (registryUrl: string, token: string) =>
-				runner.exec("npm", ["config", "set", `//${registryUrl}:_authToken`, token]).pipe(
-					Effect.asVoid,
-					Effect.mapError(
-						(error) =>
-							new PackagePublishError({
-								operation: "setupAuth",
-								registry: registryUrl,
-								reason: error.reason,
-							}),
+		Effect.map(([runner, registry]) => {
+			const service: typeof PackagePublish.Service = {
+				setupAuth: (registryUrl: string, token: string) =>
+					runner.exec("npm", ["config", "set", authTokenKey(registryUrl), token]).pipe(
+						Effect.asVoid,
+						Effect.mapError(
+							(error) =>
+								new PackagePublishError({
+									operation: "setupAuth",
+									registry: registryUrl,
+									reason: error.reason,
+									cause: error,
+								}),
+						),
 					),
-				),
 
-			pack: (packageDir: string) =>
-				runner.execCapture("npm", ["pack", "--json"], { cwd: packageDir }).pipe(
-					Effect.flatMap((output) =>
-						Effect.try({
-							try: () => JSON.parse(output.stdout) as Array<{ filename: string }>,
-							catch: () =>
+				pack: (packageDir: string) =>
+					Effect.gen(function* () {
+						yield* Effect.logInfo(`pack: ${packageDir} start`);
+						const output = yield* runner.execCapture("npm", ["pack", "--json"], { cwd: packageDir }).pipe(
+							Effect.mapError(
+								(error) =>
+									new PackagePublishError({
+										operation: "pack",
+										reason: error.reason,
+										cause: error,
+									}),
+							),
+						);
+						const entries = yield* Effect.try({
+							try: () => JSON.parse(output.stdout) as ReadonlyArray<NpmPackJsonEntry>,
+							catch: (error) =>
 								new PackagePublishError({
 									operation: "pack",
 									reason: `Failed to parse npm pack JSON output: ${output.stdout.slice(0, 200)}`,
+									cause: error,
 								}),
-						}),
-					),
-					Effect.flatMap((entries) => {
+						});
 						const first = entries[0];
 						if (!first) {
-							return Effect.fail(
+							return yield* Effect.fail(
 								new PackagePublishError({
 									operation: "pack",
 									reason: "npm pack returned empty result",
 								}),
 							);
 						}
-						const tarballPath = join(packageDir, first.filename);
-						return Effect.tryPromise({
-							try: () => readFile(tarballPath),
-							catch: () =>
+						if (typeof first.integrity !== "string" || first.integrity === "") {
+							return yield* Effect.fail(
 								new PackagePublishError({
 									operation: "pack",
-									reason: `Failed to read tarball: ${tarballPath}`,
+									reason: "npm pack output missing integrity field",
 								}),
-						}).pipe(
-							Effect.map((buffer) => {
-								const hash = createHash("sha256").update(buffer).digest("hex");
-								return { tarball: first.filename, digest: `sha256-${hash}` };
-							}),
-						);
-					}),
-					Effect.mapError((error) =>
-						error instanceof PackagePublishError
-							? error
-							: new PackagePublishError({
+							);
+						}
+						// Compute sha256-hex of the tarball alongside npm's sha512-base64
+						// integrity. The two are used for different downstream APIs:
+						// `digest` (sha512-base64) compares against `dist.integrity` from
+						// the registry (the recovery decision); `sha256Hex` is the format
+						// GitHub's artifact-metadata and attestation APIs accept as the
+						// subject digest. The two are NOT interchangeable — different
+						// algorithm, different encoding.
+						const tarballPath = join(packageDir, first.filename);
+						const sha256Hex = yield* Effect.try({
+							try: () => createHash("sha256").update(readFileSync(tarballPath)).digest("hex"),
+							catch: (error) =>
+								new PackagePublishError({
 									operation: "pack",
+									reason: `Failed to compute sha256 of tarball at ${tarballPath}`,
+									cause: error,
+								}),
+						});
+						const result: PackResult = {
+							tarballPath,
+							digest: first.integrity,
+							sha256Hex,
+							name: typeof first.name === "string" ? first.name : "",
+							version: typeof first.version === "string" ? first.version : "",
+							packedSize: typeof first.size === "number" ? first.size : 0,
+							unpackedSize: typeof first.unpackedSize === "number" ? first.unpackedSize : 0,
+							fileCount: typeof first.entryCount === "number" ? first.entryCount : 0,
+						};
+						yield* Effect.logInfo(
+							`pack: ${result.name}@${result.version} packed; tarball=${result.tarballPath}; digest=${result.digest}; sha256=${result.sha256Hex}; packedSize=${result.packedSize}; files=${result.fileCount}`,
+						);
+						return result;
+					}),
+
+				publish: (
+					packageDir: string,
+					options?: {
+						readonly registry?: string;
+						readonly tag?: string;
+						readonly access?: "public" | "restricted";
+						readonly provenance?: boolean;
+						readonly packageManager?: "npm" | "pnpm" | "yarn" | "bun";
+					},
+				) => {
+					const { cmd, baseArgs } = getNpmCommand(options?.packageManager);
+					const args = [...baseArgs, "publish"];
+					if (options?.registry) args.push("--registry", options.registry);
+					if (options?.tag) args.push("--tag", options.tag);
+					if (options?.access) args.push("--access", options.access);
+					if (options?.provenance) args.push("--provenance");
+					// `--loglevel verbose` makes npm log its HTTP requests,
+					// including the OIDC trusted-publisher exchange against
+					// `<registry>/-/npm/v1/oidc/token/exchange` and the upstream
+					// PUT. Without this the exchange step is invisible — npm
+					// silently falls back to anonymous auth on exchange failure
+					// and the registry returns a 404 that reads like "package
+					// not found" but is actually "publisher not authorized."
+					// Verbose only affects publish (not validation/dry-run);
+					// safe to enable unconditionally.
+					args.push("--loglevel", "verbose");
+
+					// `streaming: true` tees npm's stdout and stderr to the
+					// host process's stdout/stderr so the GitHub Actions runner
+					// log captures the full output live. The captured strings
+					// still flow into the error (when one occurs) — streaming
+					// is additive. Without this, npm's output reached the
+					// runner log only via the truncated error.message, hiding
+					// the actual cause of a publish failure.
+					return runner.exec(cmd, args, { cwd: packageDir, streaming: true }).pipe(
+						Effect.asVoid,
+						Effect.mapError(
+							(error) =>
+								new PackagePublishError({
+									operation: "publish",
+									...(options?.registry !== undefined ? { registry: options.registry } : {}),
+									reason: error.reason,
+									cause: error,
+								}),
+						),
+					);
+				},
+
+				publishTarball: (
+					tarballPath: string,
+					options: {
+						readonly registry: string;
+						readonly access?: "public" | "restricted";
+						readonly provenance?: boolean;
+						readonly tag?: string;
+						readonly packageManager?: "npm" | "pnpm" | "yarn" | "bun";
+					},
+				) =>
+					Effect.gen(function* () {
+						yield* Effect.logInfo(
+							`publishTarball: ${tarballPath} → ${options.registry} (access=${options.access ?? "default"}, provenance=${options.provenance === true})`,
+						);
+						const { cmd, baseArgs } = getNpmCommand(options.packageManager);
+						const args = [...baseArgs, "publish", tarballPath, "--registry", options.registry];
+						if (options.access) args.push("--access", options.access);
+						if (options.provenance) args.push("--provenance");
+						if (options.tag) args.push("--tag", options.tag);
+						// See `publish` above for why verbose + streaming.
+						// `cwd` is intentionally absent — the tarball path is
+						// absolute, so npm resolves it without help.
+						args.push("--loglevel", "verbose");
+						yield* runner.exec(cmd, args, { streaming: true }).pipe(
+							Effect.asVoid,
+							Effect.mapError(
+								(error) =>
+									new PackagePublishError({
+										operation: "publishTarball",
+										registry: options.registry,
+										reason: error.reason,
+										cause: error,
+									}),
+							),
+						);
+						yield* Effect.logInfo(`publishTarball: ${tarballPath} → ${options.registry} success`);
+					}),
+
+				verifyIntegrity: (packageName: string, version: string, expectedDigest: string) =>
+					registry.getPackageInfo(packageName, version).pipe(
+						Effect.map((info) => info.integrity === expectedDigest),
+						Effect.mapError(
+							(error) =>
+								new PackagePublishError({
+									operation: "verifyIntegrity",
+									pkg: packageName,
+									reason: error.reason,
+									cause: error,
+								}),
+						),
+					),
+
+				publishToRegistries: (
+					packageDir: string,
+					registries: Array<{
+						readonly registry: string;
+						readonly token: string;
+						readonly tag?: string;
+						readonly access?: "public" | "restricted";
+					}>,
+				) =>
+					Effect.forEach(
+						registries,
+						(target) =>
+							runner.exec("npm", ["config", "set", authTokenKey(target.registry), target.token]).pipe(
+								Effect.asVoid,
+								Effect.flatMap(() => {
+									const args = ["publish"];
+									args.push("--registry", target.registry);
+									if (target.tag) args.push("--tag", target.tag);
+									if (target.access) args.push("--access", target.access);
+									args.push("--loglevel", "verbose");
+									// See the `publish` method above — stream npm output
+									// to the runner log so failures are diagnosable, and
+									// verbose surfaces npm's OIDC exchange and HTTP requests.
+									return runner.exec("npm", args, { cwd: packageDir, streaming: true }).pipe(Effect.asVoid);
+								}),
+							),
+						{ discard: true },
+					).pipe(
+						Effect.mapError(
+							(error) =>
+								new PackagePublishError({
+									operation: "publishToRegistries",
 									reason:
 										typeof error === "object" && error !== null && "reason" in error
 											? String(error.reason)
 											: String(error),
+									cause: error,
 								}),
+						),
 					),
-				),
 
-			publish: (
-				packageDir: string,
-				options?: {
-					readonly registry?: string;
-					readonly tag?: string;
-					readonly access?: "public" | "restricted";
-					readonly provenance?: boolean;
-				},
-			) => {
-				const args = ["publish"];
-				if (options?.registry) args.push("--registry", options.registry);
-				if (options?.tag) args.push("--tag", options.tag);
-				if (options?.access) args.push("--access", options.access);
-				if (options?.provenance) args.push("--provenance");
+				dryRun: (
+					packageDir: string,
+					options?: {
+						readonly registry?: string;
+						readonly tag?: string;
+						readonly access?: "public" | "restricted";
+						readonly provenance?: boolean;
+					},
+				) => {
+					const args = ["publish", "--dry-run", "--json"];
+					if (options?.registry) args.push("--registry", options.registry);
+					if (options?.tag) args.push("--tag", options.tag);
+					if (options?.access) args.push("--access", options.access);
+					if (options?.provenance) args.push("--provenance");
 
-				return runner.exec("npm", args, { cwd: packageDir }).pipe(
-					Effect.asVoid,
-					Effect.mapError(
-						(error) =>
-							new PackagePublishError({
-								operation: "publish",
-								...(options?.registry !== undefined ? { registry: options.registry } : {}),
-								reason: error.reason,
-							}),
-					),
-				);
-			},
-
-			verifyIntegrity: (packageName: string, version: string, expectedDigest: string) =>
-				registry.getPackageInfo(packageName, version).pipe(
-					Effect.map((info) => info.integrity === expectedDigest),
-					Effect.mapError(
-						(error) =>
-							new PackagePublishError({
-								operation: "verifyIntegrity",
-								pkg: packageName,
-								reason: error.reason,
-							}),
-					),
-				),
-
-			publishToRegistries: (
-				packageDir: string,
-				registries: Array<{
-					readonly registry: string;
-					readonly token: string;
-					readonly tag?: string;
-					readonly access?: "public" | "restricted";
-				}>,
-			) =>
-				Effect.forEach(
-					registries,
-					(target) =>
-						runner.exec("npm", ["config", "set", `//${target.registry}:_authToken`, target.token]).pipe(
-							Effect.asVoid,
-							Effect.flatMap(() => {
-								const args = ["publish"];
-								args.push("--registry", target.registry);
-								if (target.tag) args.push("--tag", target.tag);
-								if (target.access) args.push("--access", target.access);
-								return runner.exec("npm", args, { cwd: packageDir }).pipe(Effect.asVoid);
+					return runner.execCapture("npm", args, { cwd: packageDir }).pipe(
+						Effect.flatMap((output) =>
+							Effect.try({
+								try: () => {
+									// `npm publish --dry-run --json` emits a single JSON object.
+									// `npm pack --dry-run --json` emits an array of such objects.
+									// Tolerate both so this parser is robust to either form.
+									const parsed = JSON.parse(output.stdout) as PackedJson | ReadonlyArray<PackedJson>;
+									const first: PackedJson | undefined = Array.isArray(parsed) ? parsed[0] : parsed;
+									const result: DryRunResult = {
+										ok: true,
+										output: output.stdout,
+										...(first?.size !== undefined ? { packedSize: first.size } : {}),
+										...(first?.unpackedSize !== undefined ? { unpackedSize: first.unpackedSize } : {}),
+										...(first?.entryCount !== undefined ? { fileCount: first.entryCount } : {}),
+									};
+									return result;
+								},
+								catch: (error) =>
+									new PackagePublishError({
+										operation: "dryRun",
+										reason: `Failed to parse npm publish --dry-run --json output: ${output.stdout.slice(0, 200)}`,
+										cause: error,
+									}),
 							}),
 						),
-					{ discard: true },
-				).pipe(
-					Effect.mapError(
-						(error) =>
-							new PackagePublishError({
-								operation: "publishToRegistries",
-								reason:
-									typeof error === "object" && error !== null && "reason" in error
-										? String(error.reason)
-										: String(error),
-							}),
-					),
-				),
-		})),
+						Effect.catchTag(
+							"CommandRunnerError",
+							(error): Effect.Effect<DryRunResult, PackagePublishError> =>
+								Effect.succeed({ ok: false, output: error.stderr ?? error.reason }),
+						),
+					);
+				},
+
+				publishIdempotent: (input: IdempotentPublishInput) =>
+					Effect.gen(function* () {
+						const versions = yield* registry.getVersions(input.packageName).pipe(
+							Effect.mapError(
+								(error) =>
+									new PackagePublishError({
+										operation: "publishIdempotent",
+										pkg: input.packageName,
+										reason: error.reason,
+										cause: error,
+									}),
+							),
+						);
+						if (versions.includes(input.version)) {
+							const identical = yield* service.verifyIntegrity(input.packageName, input.version, input.digest).pipe(
+								Effect.mapError(
+									(error) =>
+										new PackagePublishError({
+											operation: "publishIdempotent",
+											pkg: input.packageName,
+											reason: error.reason,
+											cause: error,
+										}),
+								),
+							);
+							if (identical) {
+								return {
+									status: "skipped" as const,
+									packageName: input.packageName,
+									version: input.version,
+									skipReason: "already-published-identical" as const,
+								};
+							}
+							return yield* Effect.fail(
+								new PackagePublishError({
+									operation: "publishIdempotent",
+									pkg: input.packageName,
+									reason: `Published ${input.packageName}@${input.version} has a different integrity hash than the local build; refusing to republish.`,
+								}),
+							);
+						}
+						yield* service.publish(input.packageDir, input.options);
+						return {
+							status: "published" as const,
+							packageName: input.packageName,
+							version: input.version,
+						};
+					}),
+			};
+			return service;
+		}),
 	),
 );

--- a/src/layers/PackagePublishTest.ts
+++ b/src/layers/PackagePublishTest.ts
@@ -1,5 +1,13 @@
 import { Effect, Layer } from "effect";
-import type { PackResult, PackagePublish, RegistryTarget } from "../services/PackagePublish.js";
+import { PackagePublishError } from "../errors/PackagePublishError.js";
+import type {
+	DryRunResult,
+	IdempotentPublishInput,
+	IdempotentPublishResult,
+	PackResult,
+	PackagePublish,
+	RegistryTarget,
+} from "../services/PackagePublish.js";
 import { PackagePublish as PackagePublishTag } from "../services/PackagePublish.js";
 
 /**
@@ -10,14 +18,28 @@ import { PackagePublish as PackagePublishTag } from "../services/PackagePublish.
 export interface PackagePublishTestState {
 	readonly packResult: PackResult;
 	readonly integrityMatch: boolean;
+	readonly publishedVersions: ReadonlyArray<string>;
+	readonly dryRunOk: boolean;
 	readonly setupAuthCalls: Array<{ registry: string; token: string }>;
 	readonly packCalls: Array<{ packageDir: string }>;
 	readonly publishCalls: Array<{ packageDir: string; options?: Record<string, unknown> }>;
+	readonly publishTarballCalls: Array<{ tarballPath: string; options: Record<string, unknown> }>;
 	readonly verifyIntegrityCalls: Array<{ packageName: string; version: string; expectedDigest: string }>;
 	readonly publishToRegistriesCalls: Array<{ packageDir: string; registries: Array<RegistryTarget> }>;
+	readonly publishIdempotentCalls: Array<IdempotentPublishInput>;
+	readonly dryRunCalls: Array<{ packageDir: string; options?: Record<string, unknown> }>;
 }
 
-const defaultPackResult: PackResult = { tarball: "pkg-1.0.0.tgz", digest: "sha256-abc123" };
+const defaultPackResult: PackResult = {
+	tarballPath: "/tmp/pkg-1.0.0.tgz",
+	digest: "sha512-AAAA",
+	sha256Hex: "0000000000000000000000000000000000000000000000000000000000000000",
+	name: "pkg",
+	version: "1.0.0",
+	packedSize: 0,
+	unpackedSize: 0,
+	fileCount: 0,
+};
 
 const makeTestClient = (state: PackagePublishTestState): typeof PackagePublish.Service => ({
 	setupAuth: (registry, token) =>
@@ -36,6 +58,11 @@ const makeTestClient = (state: PackagePublishTestState): typeof PackagePublish.S
 			state.publishCalls.push(options ? { packageDir, options: options as Record<string, unknown> } : { packageDir });
 		}),
 
+	publishTarball: (tarballPath, options) =>
+		Effect.sync(() => {
+			state.publishTarballCalls.push({ tarballPath, options: options as Record<string, unknown> });
+		}),
+
 	verifyIntegrity: (packageName, version, expectedDigest) =>
 		Effect.sync(() => {
 			state.verifyIntegrityCalls.push({ packageName, version, expectedDigest });
@@ -46,18 +73,58 @@ const makeTestClient = (state: PackagePublishTestState): typeof PackagePublish.S
 		Effect.sync(() => {
 			state.publishToRegistriesCalls.push({ packageDir, registries });
 		}),
+
+	publishIdempotent: (input) =>
+		Effect.suspend((): Effect.Effect<IdempotentPublishResult, PackagePublishError> => {
+			state.publishIdempotentCalls.push(input);
+			if (!state.publishedVersions.includes(input.version)) {
+				return Effect.succeed({
+					status: "published" as const,
+					packageName: input.packageName,
+					version: input.version,
+				});
+			}
+			if (state.integrityMatch) {
+				return Effect.succeed({
+					status: "skipped" as const,
+					packageName: input.packageName,
+					version: input.version,
+					skipReason: "already-published-identical" as const,
+				});
+			}
+			return Effect.fail(
+				new PackagePublishError({
+					operation: "publishIdempotent",
+					pkg: input.packageName,
+					reason: "content mismatch",
+				}),
+			);
+		}),
+
+	dryRun: (packageDir, options) =>
+		Effect.sync((): DryRunResult => {
+			state.dryRunCalls.push(options ? { packageDir, options: options as Record<string, unknown> } : { packageDir });
+			return state.dryRunOk ? { ok: true, output: "dry-run ok" } : { ok: false, output: "dry-run failed" };
+		}),
 });
 
 const makeState = (
-	overrides?: Partial<Pick<PackagePublishTestState, "packResult" | "integrityMatch">>,
+	overrides?: Partial<
+		Pick<PackagePublishTestState, "packResult" | "integrityMatch" | "publishedVersions" | "dryRunOk">
+	>,
 ): PackagePublishTestState => ({
 	packResult: overrides?.packResult ?? defaultPackResult,
 	integrityMatch: overrides?.integrityMatch ?? true,
+	publishedVersions: overrides?.publishedVersions ?? [],
+	dryRunOk: overrides?.dryRunOk ?? true,
 	setupAuthCalls: [],
 	packCalls: [],
 	publishCalls: [],
+	publishTarballCalls: [],
 	verifyIntegrityCalls: [],
 	publishToRegistriesCalls: [],
+	publishIdempotentCalls: [],
+	dryRunCalls: [],
 });
 
 /**
@@ -74,7 +141,9 @@ export const PackagePublishTest = {
 
 	/** Create a test layer with custom state overrides. */
 	layer: (
-		overrides?: Partial<Pick<PackagePublishTestState, "packResult" | "integrityMatch">>,
+		overrides?: Partial<
+			Pick<PackagePublishTestState, "packResult" | "integrityMatch" | "publishedVersions" | "dryRunOk">
+		>,
 	): { state: PackagePublishTestState; layer: Layer.Layer<PackagePublish> } => {
 		const state = makeState(overrides);
 		return { state, layer: Layer.succeed(PackagePublishTag, makeTestClient(state)) };

--- a/src/layers/PullRequestLive.test.ts
+++ b/src/layers/PullRequestLive.test.ts
@@ -1,0 +1,192 @@
+import { Effect, Layer } from "effect";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { GitHubClientError } from "../errors/GitHubClientError.js";
+import { GitHubClient } from "../services/GitHubClient.js";
+import { GitHubGraphQL } from "../services/GitHubGraphQL.js";
+import { PullRequest } from "../services/PullRequest.js";
+import { PullRequestLive } from "./PullRequestLive.js";
+
+const mockGet = vi.fn();
+const mockListFiles = vi.fn();
+const mockListPRsAssociatedWithCommit = vi.fn();
+
+const mockClient: typeof GitHubClient.Service = {
+	rest: <T>(_operation: string, fn: (octokit: unknown) => Promise<{ data: T }>) =>
+		Effect.tryPromise({
+			try: () =>
+				fn({
+					rest: {
+						pulls: { get: mockGet },
+						repos: { listPullRequestsAssociatedWithCommit: mockListPRsAssociatedWithCommit },
+					},
+				}),
+			catch: (e) =>
+				new GitHubClientError({
+					operation: _operation,
+					status: undefined,
+					reason: e instanceof Error ? e.message : String(e),
+					retryable: false,
+				}),
+		}).pipe(Effect.map((r) => r.data)),
+	graphql: () => Effect.die("not used"),
+	paginate: <T>(_operation: string, fn: (octokit: unknown, page: number, perPage: number) => Promise<{ data: T[] }>) =>
+		Effect.tryPromise({
+			try: () =>
+				fn(
+					{
+						rest: {
+							pulls: { listFiles: mockListFiles },
+						},
+					},
+					1,
+					100,
+				).then((r) => r.data),
+			catch: (e) =>
+				new GitHubClientError({
+					operation: _operation,
+					status: undefined,
+					reason: e instanceof Error ? e.message : String(e),
+					retryable: false,
+				}),
+		}),
+	repo: Effect.succeed({ owner: "test-owner", repo: "test-repo" }),
+};
+
+const mockGraphQL: typeof GitHubGraphQL.Service = {
+	query: () => Effect.die("not used"),
+	mutation: () => Effect.die("not used"),
+};
+
+const testLayer = Layer.provide(
+	PullRequestLive,
+	Layer.merge(Layer.succeed(GitHubClient, mockClient), Layer.succeed(GitHubGraphQL, mockGraphQL)),
+);
+
+const run = <A, E>(effect: Effect.Effect<A, E, PullRequest>) => Effect.runPromise(Effect.provide(effect, testLayer));
+
+beforeEach(() => {
+	vi.clearAllMocks();
+});
+
+describe("PullRequestLive", () => {
+	describe("get", () => {
+		it("returns PullRequestInfo from pulls.get response", async () => {
+			mockGet.mockResolvedValue({
+				data: {
+					number: 42,
+					html_url: "https://github.com/test-owner/test-repo/pull/42",
+					node_id: "PR_node_42",
+					title: "Test PR",
+					state: "open",
+					head: { ref: "feature-branch" },
+					base: { ref: "main", sha: "base-sha-42" },
+					draft: false,
+					merged: false,
+					merged_at: null,
+					body: null,
+					merge_commit_sha: null,
+				},
+			});
+
+			const info = await run(Effect.flatMap(PullRequest, (svc) => svc.get(42)));
+			expect(info.number).toBe(42);
+			expect(info.url).toBe("https://github.com/test-owner/test-repo/pull/42");
+			expect(info.state).toBe("open");
+			expect(info.mergedAt).toBeNull();
+			expect(info.mergeCommitSha).toBeNull();
+		});
+
+		it("PullRequestInfo carries mergedAt, body, and mergeCommitSha", async () => {
+			mockGet.mockResolvedValue({
+				data: {
+					number: 7,
+					html_url: "https://github.com/test-owner/test-repo/pull/7",
+					node_id: "PR_node_7",
+					title: "Merged PR",
+					state: "closed",
+					head: { ref: "feat/thing" },
+					base: { ref: "main", sha: "base-sha-7" },
+					draft: false,
+					merged: true,
+					merged_at: "2026-05-18T00:00:00Z",
+					body: "the PR body",
+					merge_commit_sha: "abc123",
+				},
+			});
+
+			const info = await run(Effect.flatMap(PullRequest, (svc) => svc.get(7)));
+			expect(info.mergedAt).toBe("2026-05-18T00:00:00Z");
+			expect(info.body).toBe("the PR body");
+			expect(info.mergeCommitSha).toBe("abc123");
+		});
+
+		it("get maps the base SHA to baseSha", async () => {
+			mockGet.mockResolvedValue({
+				data: {
+					number: 7,
+					html_url: "https://github.com/test-owner/test-repo/pull/7",
+					node_id: "PR_node_7",
+					title: "SHA PR",
+					state: "open",
+					head: { ref: "feat/sha-test" },
+					base: { ref: "main", sha: "deadbeef1234" },
+					draft: false,
+					merged: false,
+					merged_at: null,
+					body: null,
+					merge_commit_sha: null,
+				},
+			});
+
+			const info = await run(Effect.flatMap(PullRequest, (svc) => svc.get(7)));
+			expect(info.baseSha).toBe("deadbeef1234");
+		});
+	});
+
+	describe("listFiles", () => {
+		it("listFiles returns the PR's changed files", async () => {
+			mockListFiles.mockResolvedValue({
+				data: [
+					{ filename: "src/index.ts", status: "modified" },
+					{ filename: "README.md", status: "added" },
+				],
+			});
+
+			const files = await run(Effect.flatMap(PullRequest, (svc) => svc.listFiles(7)));
+			expect(files).toHaveLength(2);
+			expect(files[0].filename).toBe("src/index.ts");
+			expect(files[0].status).toBe("modified");
+			expect(files[1].filename).toBe("README.md");
+			expect(files[1].status).toBe("added");
+		});
+	});
+
+	describe("listAssociatedWithCommit", () => {
+		it("listAssociatedWithCommit returns the associated PRs", async () => {
+			mockListPRsAssociatedWithCommit.mockResolvedValue({
+				data: [
+					{
+						number: 99,
+						html_url: "https://github.com/test-owner/test-repo/pull/99",
+						node_id: "PR_node_99",
+						title: "Associated PR",
+						state: "closed",
+						head: { ref: "feat/associated" },
+						base: { ref: "main", sha: "base-sha-99" },
+						draft: false,
+						merged: true,
+						merged_at: "2026-01-01T00:00:00Z",
+						body: null,
+						merge_commit_sha: "sha-merge-99",
+					},
+				],
+			});
+
+			const prs = await run(Effect.flatMap(PullRequest, (svc) => svc.listAssociatedWithCommit("sha123")));
+			expect(prs).toHaveLength(1);
+			expect(prs[0].number).toBe(99);
+			expect(prs[0].baseSha).toBe("base-sha-99");
+			expect(prs[0].mergeCommitSha).toBe("sha-merge-99");
+		});
+	});
+});

--- a/src/layers/PullRequestLive.ts
+++ b/src/layers/PullRequestLive.ts
@@ -4,7 +4,7 @@ import type { GitHubGraphQLError } from "../errors/GitHubGraphQLError.js";
 import { PullRequestError } from "../errors/PullRequestError.js";
 import { GitHubClient } from "../services/GitHubClient.js";
 import { GitHubGraphQL } from "../services/GitHubGraphQL.js";
-import type { PullRequestInfo } from "../services/PullRequest.js";
+import type { PullRequestFile, PullRequestInfo } from "../services/PullRequest.js";
 import { PullRequest } from "../services/PullRequest.js";
 import { DISABLE_MUTATION, ENABLE_MUTATION, MERGE_METHOD_MAP } from "../utils/AutoMerge.js";
 
@@ -15,9 +15,17 @@ interface RawPull {
 	readonly title: string;
 	readonly state: string;
 	readonly head: { readonly ref: string };
-	readonly base: { readonly ref: string };
+	readonly base: { readonly ref: string; readonly sha: string };
 	readonly draft: boolean;
 	readonly merged: boolean;
+	readonly merged_at: string | null;
+	readonly body: string | null;
+	readonly merge_commit_sha: string | null;
+}
+
+interface RawPullFile {
+	readonly filename: string;
+	readonly status: string;
 }
 
 /** Minimal Octokit shape for pulls API calls. */
@@ -26,6 +34,7 @@ interface OctokitPulls {
 		readonly pulls: {
 			readonly get: (args: Record<string, unknown>) => Promise<{ data: RawPull }>;
 			readonly list: (args: Record<string, unknown>) => Promise<{ data: RawPull[] }>;
+			readonly listFiles: (args: Record<string, unknown>) => Promise<{ data: RawPullFile[] }>;
 			readonly create: (args: Record<string, unknown>) => Promise<{ data: RawPull }>;
 			readonly update: (args: Record<string, unknown>) => Promise<{ data: RawPull }>;
 			readonly merge: (args: Record<string, unknown>) => Promise<{ data: unknown }>;
@@ -33,6 +42,9 @@ interface OctokitPulls {
 		};
 		readonly issues: {
 			readonly addLabels: (args: Record<string, unknown>) => Promise<{ data: unknown }>;
+		};
+		readonly repos: {
+			readonly listPullRequestsAssociatedWithCommit: (args: Record<string, unknown>) => Promise<{ data: RawPull[] }>;
 		};
 	};
 }
@@ -49,6 +61,15 @@ const toInfo = (raw: RawPull): PullRequestInfo => ({
 	base: raw.base.ref,
 	draft: raw.draft,
 	merged: raw.merged,
+	mergedAt: raw.merged_at,
+	body: raw.body,
+	mergeCommitSha: raw.merge_commit_sha,
+	baseSha: raw.base.sha,
+});
+
+const toPullRequestFile = (raw: RawPullFile): PullRequestFile => ({
+	filename: raw.filename,
+	status: raw.status,
 });
 
 const mapClientError =
@@ -129,6 +150,29 @@ export const PullRequestLive: Layer.Layer<PullRequest, never, GitHubClient | Git
 					}).pipe(
 						Effect.map((items) => (items as unknown as RawPull[]).map(toInfo)),
 						Effect.mapError(mapClientError("list")),
+					),
+
+				listFiles: (number) =>
+					Effect.flatMap(client.repo, ({ owner, repo }) =>
+						client.paginate(
+							"pulls.listFiles",
+							(octokit, page, perPage) =>
+								asPulls(octokit).rest.pulls.listFiles({ owner, repo, pull_number: number, page, per_page: perPage }),
+							{},
+						),
+					).pipe(
+						Effect.map((items) => (items as unknown as RawPullFile[]).map(toPullRequestFile)),
+						Effect.mapError(mapClientError("listFiles", number)),
+					),
+
+				listAssociatedWithCommit: (sha) =>
+					Effect.flatMap(client.repo, ({ owner, repo }) =>
+						client.rest("repos.listPullRequestsAssociatedWithCommit", (octokit) =>
+							asPulls(octokit).rest.repos.listPullRequestsAssociatedWithCommit({ owner, repo, commit_sha: sha }),
+						),
+					).pipe(
+						Effect.map((items) => (items as unknown as RawPull[]).map(toInfo)),
+						Effect.mapError(mapClientError("listAssociatedWithCommit")),
 					),
 
 				create: (options) =>

--- a/src/layers/PullRequestTest.ts
+++ b/src/layers/PullRequestTest.ts
@@ -1,6 +1,6 @@
 import { Effect, Layer } from "effect";
 import { PullRequestError } from "../errors/PullRequestError.js";
-import type { PullRequestInfo } from "../services/PullRequest.js";
+import type { PullRequestFile, PullRequestInfo } from "../services/PullRequest.js";
 import { PullRequest } from "../services/PullRequest.js";
 
 /**
@@ -19,7 +19,7 @@ export interface PullRequestRecord extends PullRequestInfo {
 	readonly reviewers: Array<string>;
 	readonly teamReviewers: Array<string>;
 	autoMerge: "merge" | "squash" | "rebase" | false | undefined;
-	body: string;
+	body: string | null;
 }
 
 /**
@@ -31,11 +31,18 @@ export interface PullRequestTestState {
 	readonly prs: Array<PullRequestRecord>;
 	readonly mergedPrs: Array<number>;
 	nextNumber: number;
+	/** Files per PR number, returned by listFiles. */
+	readonly files: Map<number, Array<PullRequestFile>>;
+	/** PRs associated with a commit SHA, returned by listAssociatedWithCommit. */
+	readonly associatedByCommit: Map<string, Array<PullRequestInfo>>;
 }
 
 const findPr = (state: PullRequestTestState, number: number): PullRequestRecord | undefined =>
 	state.prs.find((pr) => pr.number === number);
 
+// `body` is always present on the record (required field), while `mergedAt`, `mergeCommitSha`,
+// and `baseSha` are optional (inherited from PullRequestInfo), hence the direct assignment vs
+// conditional spreads.
 const toInfo = (record: PullRequestRecord): PullRequestInfo => ({
 	number: record.number,
 	url: record.url,
@@ -46,6 +53,10 @@ const toInfo = (record: PullRequestRecord): PullRequestInfo => ({
 	base: record.base,
 	draft: record.draft,
 	merged: record.merged,
+	...(record.mergedAt !== undefined ? { mergedAt: record.mergedAt } : {}),
+	body: record.body,
+	...(record.mergeCommitSha !== undefined ? { mergeCommitSha: record.mergeCommitSha } : {}),
+	...(record.baseSha !== undefined ? { baseSha: record.baseSha } : {}),
 });
 
 const makeTestPullRequest = (state: PullRequestTestState): typeof PullRequest.Service => ({
@@ -205,6 +216,10 @@ const makeTestPullRequest = (state: PullRequestTestState): typeof PullRequest.Se
 				return Effect.void;
 			}),
 		),
+
+	listFiles: (number) => Effect.succeed(state.files.get(number) ?? []),
+
+	listAssociatedWithCommit: (sha) => Effect.succeed(state.associatedByCommit.get(sha) ?? []),
 });
 
 /**
@@ -222,5 +237,7 @@ export const PullRequestTest = {
 		prs: [],
 		mergedPrs: [],
 		nextNumber: 1,
+		files: new Map(),
+		associatedByCommit: new Map(),
 	}),
 } as const;

--- a/src/layers/SbomLive.ts
+++ b/src/layers/SbomLive.ts
@@ -1,0 +1,202 @@
+/**
+ * SBOM service — produces a CycloneDX 1.5 BOM from a post-relink
+ * dependency graph.
+ *
+ * @remarks
+ * Uses `@cyclonedx/cyclonedx-library` directly rather than shelling out
+ * to `cdxgen` for two reasons:
+ *
+ * 1. The action bundle already vendors the library; spawning a CLI just
+ *    to serialize JSON we could produce in-process is wasted I/O.
+ * 2. The library lets us hand-build the BOM from a structured input,
+ *    which is the only way to handle the unpublished-sibling case (a
+ *    package being released that depends on a sibling being released in
+ *    the same wave — the sibling won't be on the registry yet, so any
+ *    registry-based resolver would fall down).
+ *
+ * Callers supply the resolved dependency map themselves (the builder
+ * has already parsed `package.json` and relinked workspace references),
+ * and may pass `inFlightPackages` to flag siblings being released
+ * alongside the root. This service is pure aside from the file save —
+ * no network, no subprocesses.
+ */
+
+import type * as CdxLibrary from "@cyclonedx/cyclonedx-library";
+import { FileSystem } from "@effect/platform";
+import { Effect, Layer } from "effect";
+import { SbomError } from "../errors/SbomError.js";
+import type {
+	CycloneDXBom,
+	InFlightPackage,
+	ResolvedDependency,
+	SbomAuthor,
+	SbomInput,
+	SbomSupplier,
+} from "../services/Sbom.js";
+import { Sbom } from "../services/Sbom.js";
+
+/**
+ * Lazy module cache for `@cyclonedx/cyclonedx-library`.
+ *
+ * @remarks
+ * The library statically imports several optional plugins
+ * (`ajv-formats-draft2019`, `xmlbuilder2`, `libxmljs2`) which we
+ * externalize in the bundler config; rspack emits those as top-level
+ * ESM `import * as ...` statements that fail at Node's resolution
+ * phase when the modules aren't installed. By deferring the entire
+ * `@cyclonedx/cyclonedx-library` import to inside the service methods,
+ * the chain only runs when a caller actually invokes `Sbom.generate`
+ * — provenance-only attestation paths never pay the cost.
+ */
+let cdxCache: typeof CdxLibrary | undefined;
+const loadCdx = async (): Promise<typeof CdxLibrary> => {
+	if (!cdxCache) cdxCache = await import("@cyclonedx/cyclonedx-library");
+	return cdxCache;
+};
+
+const npmPurl = (name: string, version: string): string => `pkg:npm/${encodeURIComponent(name)}@${version}`;
+
+const makeComponent = (
+	cdx: typeof CdxLibrary,
+	type: CdxLibrary.Enums.ComponentType,
+	dep: ResolvedDependency,
+): CdxLibrary.Models.Component => {
+	const component = new cdx.Models.Component(type, dep.name, {
+		version: dep.version,
+		purl: npmPurl(dep.name, dep.version),
+		bomRef: `${dep.name}@${dep.version}`,
+	});
+	if (dep.description) component.description = dep.description;
+	if (dep.license) component.licenses.add(new cdx.Models.NamedLicense(dep.license));
+	return component;
+};
+
+const makeSupplier = (cdx: typeof CdxLibrary, supplier: SbomSupplier): CdxLibrary.Models.OrganizationalEntity => {
+	const entity = new cdx.Models.OrganizationalEntity({ name: supplier.name });
+	for (const url of supplier.url ?? []) entity.url.add(url);
+	for (const contact of supplier.contact ?? []) {
+		entity.contact.add(
+			new cdx.Models.OrganizationalContact({
+				name: contact.name,
+				email: contact.email,
+				phone: contact.phone,
+			}),
+		);
+	}
+	return entity;
+};
+
+const addAuthors = (
+	cdx: typeof CdxLibrary,
+	repo: CdxLibrary.Models.OrganizationalContactRepository,
+	authors: ReadonlyArray<SbomAuthor>,
+): void => {
+	for (const author of authors) {
+		repo.add(
+			new cdx.Models.OrganizationalContact({
+				name: author.name,
+				email: author.email,
+				phone: author.phone,
+			}),
+		);
+	}
+};
+
+const buildBom = (cdx: typeof CdxLibrary, input: SbomInput): CycloneDXBom => {
+	const root = new cdx.Models.Component(cdx.Enums.ComponentType.Library, input.rootName, {
+		version: input.rootVersion,
+		purl: npmPurl(input.rootName, input.rootVersion),
+		bomRef: `${input.rootName}@${input.rootVersion}`,
+	});
+	if (input.rootDescription) root.description = input.rootDescription;
+	if (input.rootLicense) root.licenses.add(new cdx.Models.NamedLicense(input.rootLicense));
+	if (input.rootAuthor) root.author = input.rootAuthor;
+
+	const metadata = new cdx.Models.Metadata({ component: root, timestamp: new Date() });
+	if (input.supplier) metadata.supplier = makeSupplier(cdx, input.supplier);
+	if (input.authors) addAuthors(cdx, metadata.authors, input.authors);
+	const bom = new cdx.Models.Bom({ metadata });
+
+	const resolved = resolveDependencies(input.dependencies, input.inFlightPackages);
+	for (const dep of resolved) {
+		bom.components.add(makeComponent(cdx, cdx.Enums.ComponentType.Library, dep));
+	}
+	return bom;
+};
+
+const serializeBom = (cdx: typeof CdxLibrary, bom: CycloneDXBom): string => {
+	const factory = new cdx.Serialize.JSON.Normalize.Factory(cdx.Spec.Spec1dot5);
+	const serializer = new cdx.Serialize.JsonSerializer(factory);
+	return serializer.serialize(bom, { sortLists: true, space: 2 });
+};
+
+const resolveDependencies = (
+	dependencies: ReadonlyArray<ResolvedDependency>,
+	inFlight: ReadonlyArray<InFlightPackage> | undefined,
+): ResolvedDependency[] => {
+	const byName = new Map<string, ResolvedDependency>();
+	for (const dep of dependencies) byName.set(dep.name, dep);
+	for (const pkg of inFlight ?? []) {
+		// In-flight packages replace any same-named dependency entry — the
+		// registry doesn't have this version yet, so the resolver would
+		// have produced a stale answer if it returned anything at all.
+		const replacement: ResolvedDependency = pkg.license
+			? { name: pkg.name, version: pkg.version, license: pkg.license }
+			: { name: pkg.name, version: pkg.version };
+		byName.set(pkg.name, replacement);
+	}
+	return Array.from(byName.values()).sort((a, b) => a.name.localeCompare(b.name));
+};
+
+/**
+ * Live {@link Sbom} layer.
+ *
+ * @public
+ */
+export const SbomLive = Layer.succeed(Sbom, {
+	generate: (input) =>
+		Effect.tryPromise({
+			try: async () => buildBom(await loadCdx(), input),
+			catch: (cause) =>
+				new SbomError({
+					reason: "build",
+					message: `Failed to build CycloneDX BOM: ${cause instanceof Error ? cause.message : String(cause)}`,
+					cause,
+				}),
+		}),
+
+	serializeJson: (bom) =>
+		Effect.tryPromise({
+			try: async () => serializeBom(await loadCdx(), bom),
+			catch: (cause) =>
+				new SbomError({
+					reason: "serialize",
+					message: `Failed to serialize CycloneDX BOM to JSON: ${cause instanceof Error ? cause.message : String(cause)}`,
+					cause,
+				}),
+		}),
+
+	save: (bom, path) =>
+		Effect.gen(function* () {
+			const fs = yield* FileSystem.FileSystem;
+			const sbom = yield* Effect.tryPromise({
+				try: async () => serializeBom(await loadCdx(), bom),
+				catch: (cause) =>
+					new SbomError({
+						reason: "serialize",
+						message: `Failed to serialize CycloneDX BOM to JSON: ${cause instanceof Error ? cause.message : String(cause)}`,
+						cause,
+					}),
+			});
+			yield* fs.writeFileString(path, sbom).pipe(
+				Effect.mapError(
+					(error) =>
+						new SbomError({
+							reason: "save",
+							message: `Failed to write SBOM to ${path}: ${error.message}`,
+							cause: error,
+						}),
+				),
+			);
+		}),
+});

--- a/src/layers/SbomTest.ts
+++ b/src/layers/SbomTest.ts
@@ -1,0 +1,84 @@
+import { FileSystem } from "@effect/platform";
+import { Effect, Layer } from "effect";
+import type { CycloneDXBom, SbomInput } from "../services/Sbom.js";
+import { Sbom } from "../services/Sbom.js";
+
+// ─── SbomTest ────────────────────────────────────────────────────────
+
+/**
+ * Mutable state recorded by {@link SbomTest.layer}.
+ *
+ * @public
+ */
+export interface SbomTestState {
+	/** Inputs passed to every {@link Sbom.generate} call. */
+	readonly generateCalls: SbomInput[];
+	/** Path → BOM captured by {@link Sbom.save}. */
+	readonly saves: Map<string, CycloneDXBom>;
+	/** Override the BOM returned from {@link Sbom.generate}. */
+	readonly bomResponse?: CycloneDXBom;
+	/** Override the JSON returned from {@link Sbom.serializeJson}. */
+	readonly jsonResponse?: string;
+}
+
+/**
+ * Synthetic Bom-shaped stub for the test layer.
+ *
+ * @remarks
+ * Avoids importing `@cyclonedx/cyclonedx-library` at module-init time —
+ * the library's static-import chain pulls in optional plugins that
+ * fail to resolve in the bundled action when `Sbom.generate` is never
+ * called. Tests that need a real Bom should provide one via
+ * `state.bomResponse`.
+ */
+const minimalBom = (): CycloneDXBom => ({}) as unknown as CycloneDXBom;
+
+/**
+ * Build a fresh, empty {@link SbomTestState}.
+ *
+ * @public
+ */
+export const makeSbomTestState = (overrides: Partial<SbomTestState> = {}): SbomTestState => ({
+	generateCalls: [],
+	saves: new Map(),
+	...overrides,
+});
+
+const defaultJson = (): string =>
+	JSON.stringify(
+		{
+			bomFormat: "CycloneDX",
+			specVersion: "1.5",
+			version: 1,
+			metadata: { component: { type: "library", name: "test-root", version: "0.0.0" } },
+			components: [],
+		},
+		null,
+		2,
+	);
+
+/**
+ * Test layer factories for {@link Sbom}.
+ *
+ * @public
+ */
+export const SbomTest = {
+	layer: (state: SbomTestState): Layer.Layer<Sbom> =>
+		Layer.succeed(Sbom, {
+			generate: (input) =>
+				Effect.sync(() => {
+					state.generateCalls.push(input);
+					return state.bomResponse ?? minimalBom();
+				}),
+
+			serializeJson: () => Effect.sync(() => state.jsonResponse ?? defaultJson()),
+
+			save: (bom, path) =>
+				Effect.gen(function* () {
+					state.saves.set(path, bom);
+					yield* FileSystem.FileSystem;
+				}),
+		}),
+
+	empty: (): Layer.Layer<Sbom> => SbomTest.layer(makeSbomTestState()),
+};

--- a/src/layers/SigstoreSignerLive.ts
+++ b/src/layers/SigstoreSignerLive.ts
@@ -1,0 +1,155 @@
+/**
+ * Sigstore signing service — wraps `@sigstore/sign` behind an Effect
+ * surface so the bundle-building path is testable without hitting Fulcio
+ * or Rekor.
+ *
+ * @remarks
+ * The Live implementation uses {@link DSSEBundleBuilder} with a
+ * {@link FulcioSigner} (driven by the {@link OidcTokenIssuer}-issued JWT)
+ * and a {@link RekorWitness} pointing at the public-good sigstore
+ * instance. Callers that need to override the Fulcio / Rekor URLs (e.g.
+ * for staging) can compose a configured Live layer instead — exposed
+ * via {@link makeSigstoreSignerLive}.
+ *
+ * The DSSE payload type is fixed to `application/vnd.in-toto+json` per
+ * the GitHub attestations spec.
+ */
+
+import type { Bundle, BundleWithDsseEnvelope, SerializedBundle } from "@sigstore/bundle";
+import { bundleToJSON } from "@sigstore/bundle";
+import type { IdentityProvider } from "@sigstore/sign";
+import { DSSEBundleBuilder, FulcioSigner, RekorWitness } from "@sigstore/sign";
+import { Effect, Layer, Redacted } from "effect";
+import { SigstoreSignerError } from "../errors/SigstoreSignerError.js";
+import { SIGSTORE_BUNDLE_V0_3_MEDIA_TYPE, SigstoreBundle } from "../schemas/Attestation.js";
+import { OidcTokenIssuer } from "../services/OidcTokenIssuer.js";
+import type { SigstoreSignerConfig } from "../services/SigstoreSigner.js";
+import { IN_TOTO_PAYLOAD_TYPE, SIGSTORE_OIDC_AUDIENCE, SigstoreSigner } from "../services/SigstoreSigner.js";
+import { serializeStatement } from "../utils/intoto.js";
+
+/**
+ * Format a `@sigstore/sign` error with its full cause chain.
+ *
+ * @remarks
+ * `InternalError` (Fulcio / Rekor failures) wraps the underlying
+ * transport error in `cause`. The default `Error.message` only shows
+ * the outermost layer ("error creating signing certificate"), which is
+ * useless for diagnosing real-world failures. Walk the chain and pull
+ * out HTTP status / response body where available so the action log
+ * shows what Fulcio actually said.
+ *
+ * @internal
+ */
+const describeSigstoreError = (err: unknown, depth = 0): string => {
+	if (!err || depth > 4) return String(err);
+	if (typeof err !== "object") return String(err);
+	const e = err as {
+		name?: string;
+		code?: string;
+		message?: string;
+		cause?: unknown;
+		statusCode?: number;
+		status?: number;
+		stack?: string;
+	};
+	const parts: string[] = [];
+	if (e.code) parts.push(`[${e.code}]`);
+	if (e.statusCode ?? e.status) parts.push(`(HTTP ${e.statusCode ?? e.status})`);
+	parts.push(e.message ?? e.name ?? String(err));
+	// Include the first 3 stack frames for the leaf cause so a runtime
+	// TypeError ("Right-hand side of 'instanceof' is not callable") tells
+	// us *which* file/line in the bundled action threw it.
+	if (e.stack && (!e.cause || e.cause === err)) {
+		const firstFrames = e.stack
+			.split("\n")
+			.slice(1, 4)
+			.map((line) => line.trim())
+			.join(" | ");
+		if (firstFrames) parts.push(`@ ${firstFrames}`);
+	}
+	if (e.cause && e.cause !== err) {
+		parts.push(`← ${describeSigstoreError(e.cause, depth + 1)}`);
+	}
+	return parts.join(" ");
+};
+
+/**
+ * Convert a {@link Bundle} (protobuf shape) to a validated
+ * {@link SigstoreBundle} (our Schema.Class).
+ *
+ * @internal
+ */
+const toSigstoreBundle = (bundle: BundleWithDsseEnvelope): Effect.Effect<SigstoreBundle, SigstoreSignerError> =>
+	Effect.try({
+		try: () => {
+			const serialized = bundleToJSON(bundle as Bundle) as SerializedBundle;
+			return new SigstoreBundle({
+				mediaType: SIGSTORE_BUNDLE_V0_3_MEDIA_TYPE,
+				verificationMaterial: serialized.verificationMaterial,
+				dsseEnvelope: serialized.dsseEnvelope,
+			});
+		},
+		catch: (cause) =>
+			new SigstoreSignerError({
+				reason: "bundle",
+				message: `Failed to serialize Sigstore bundle: ${cause instanceof Error ? cause.message : String(cause)}`,
+				cause,
+			}),
+	});
+
+/**
+ * Build a configured Live {@link SigstoreSigner} layer.
+ *
+ * @public
+ */
+export const makeSigstoreSignerLive = (config: SigstoreSignerConfig = {}): Layer.Layer<SigstoreSigner> =>
+	Layer.succeed(SigstoreSigner, {
+		signStatement: (statement) =>
+			Effect.gen(function* () {
+				const issuer = yield* OidcTokenIssuer;
+				const tokenRedacted = yield* issuer.getToken(SIGSTORE_OIDC_AUDIENCE).pipe(
+					Effect.mapError(
+						(cause) =>
+							new SigstoreSignerError({
+								reason: "sign",
+								message: `Failed to obtain OIDC token for Sigstore: ${cause.message}`,
+								cause,
+							}),
+					),
+				);
+				const tokenValue = Redacted.value(tokenRedacted);
+
+				const identityProvider: IdentityProvider = { getToken: () => Promise.resolve(tokenValue) };
+				const signer = new FulcioSigner({
+					identityProvider,
+					...(config.fulcioBaseURL ? { fulcioBaseURL: config.fulcioBaseURL } : {}),
+				});
+				const witness = new RekorWitness({
+					entryType: "dsse",
+					...(config.rekorBaseURL ? { rekorBaseURL: config.rekorBaseURL } : {}),
+				});
+				const builder = new DSSEBundleBuilder({ signer, witnesses: [witness] });
+
+				const payload = Buffer.from(serializeStatement(statement), "utf-8");
+				const bundle = yield* Effect.tryPromise({
+					try: () => builder.create({ data: payload, type: IN_TOTO_PAYLOAD_TYPE }),
+					catch: (cause) =>
+						new SigstoreSignerError({
+							reason: "sign",
+							message: `Sigstore bundle build failed: ${describeSigstoreError(cause)}`,
+							cause,
+						}),
+				});
+
+				return yield* toSigstoreBundle(bundle);
+			}),
+	});
+
+/**
+ * Live {@link SigstoreSigner} layer using the public-good Sigstore
+ * instance (Fulcio + Rekor). Requires {@link OidcTokenIssuer} to be
+ * provided downstream.
+ *
+ * @public
+ */
+export const SigstoreSignerLive = makeSigstoreSignerLive();

--- a/src/layers/SigstoreSignerTest.ts
+++ b/src/layers/SigstoreSignerTest.ts
@@ -1,0 +1,24 @@
+import { Effect, Layer } from "effect";
+import { SIGSTORE_BUNDLE_V0_3_MEDIA_TYPE, SigstoreBundle } from "../schemas/Attestation.js";
+import { SigstoreSigner } from "../services/SigstoreSigner.js";
+
+const stubBundle = (): SigstoreBundle =>
+	new SigstoreBundle({
+		mediaType: SIGSTORE_BUNDLE_V0_3_MEDIA_TYPE,
+		verificationMaterial: { tlogEntries: [] },
+		dsseEnvelope: {
+			payload: "",
+			payloadType: "application/vnd.in-toto+json",
+			signatures: [{ sig: "test-signature", keyid: "" }],
+		},
+	});
+
+/**
+ * Noop SigstoreSigner test layer — returns a synthetic SigstoreBundle
+ * without any signing or witnessing.
+ *
+ * @public
+ */
+export const SigstoreSignerTest: Layer.Layer<SigstoreSigner> = Layer.succeed(SigstoreSigner, {
+	signStatement: () => Effect.succeed(stubBundle()),
+});

--- a/src/runtime/ActionsRuntime.test.ts
+++ b/src/runtime/ActionsRuntime.test.ts
@@ -10,11 +10,23 @@ import { ActionsRuntime } from "./ActionsRuntime.js";
 
 // -- Helpers --
 
-const run = <A>(effect: Effect.Effect<A, unknown, never>) => Effect.runPromise(effect);
+// `Effect.runPromise` wants `R: never` but `tsgo`'s narrowing of layer
+// composition leaks `any` through `Effect.provide`. Cast at the seam so each
+// call site doesn't carry the type-variance noise.
+const run = <A>(effect: Effect.Effect<A, unknown, never> | Effect.Effect<A, unknown, unknown>): Promise<A> =>
+	Effect.runPromise(effect as Effect.Effect<A, unknown, never>);
 
 const runWithDefault = <A, E, R>(effect: Effect.Effect<A, E, R>): Promise<A> =>
-	// Cast is safe: ActionsRuntime.Default satisfies all R requirements in these tests
-	Effect.runPromise(Effect.provide(effect as unknown as Effect.Effect<A, E, never>, ActionsRuntime.Default));
+	// Cast is safe: ActionsRuntime.Default satisfies all R requirements in these tests.
+	// Two casts because `tsgo` leaks `any` from the layer composition through both
+	// the input effect's R-channel and the provided effect's R-channel.
+	Effect.runPromise(
+		Effect.provide(effect as unknown as Effect.Effect<A, E, never>, ActionsRuntime.Default) as Effect.Effect<
+			A,
+			E,
+			never
+		>,
+	);
 
 // Temp file management
 

--- a/src/runtime/Step.test.ts
+++ b/src/runtime/Step.test.ts
@@ -98,6 +98,18 @@ describe("Step", () => {
 			expect(out).toContain("│ [DEBUG] probe https://npm.pkg.github.com/: HTTP 200");
 			expect(out).toContain("└ Error: integrity mismatch — local sha512-ABC ≠ remote sha512-XYZ");
 		});
+
+		it("omits the '└ Error:' trailer when the step buffered no lines", async () => {
+			const exit = await runExit(Step.withStep("bare-fail", Effect.fail(new Error("boom"))));
+
+			expect(Exit.isFailure(exit)).toBe(true);
+			const out = output();
+			// The header still carries the error message...
+			expect(out).toContain("❌ bare-fail: boom");
+			// ...but with no spill lines to close, the trailer would just
+			// repeat the header — so it is suppressed.
+			expect(out).not.toContain("└ Error:");
+		});
 	});
 
 	// -----------------------------------------------------------------

--- a/src/runtime/Step.test.ts
+++ b/src/runtime/Step.test.ts
@@ -1,0 +1,330 @@
+import { Effect, Exit, Layer, LogLevel, Logger } from "effect";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ActionsLogger } from "./ActionsLogger.js";
+import * as Step from "./Step.js";
+
+/**
+ * Test layer that installs the library's standard `ActionsLogger` so
+ * that pass-through logs (warnings outside or inside Step, debug
+ * outside Step) follow the live runtime's behaviour. Minimum log
+ * level is `All` so debug lines are observed.
+ */
+const baseLoggerLayer = Layer.merge(
+	Logger.replace(Logger.defaultLogger, ActionsLogger),
+	Logger.minimumLogLevel(LogLevel.All),
+);
+
+const run = <A, E>(effect: Effect.Effect<A, E>): Promise<A> =>
+	Effect.runPromise(Effect.provide(effect, baseLoggerLayer) as Effect.Effect<A, E, never>);
+
+const runExit = <A, E>(effect: Effect.Effect<A, E>): Promise<Exit.Exit<A, E>> =>
+	Effect.runPromiseExit(Effect.provide(effect, baseLoggerLayer) as Effect.Effect<A, E, never>);
+
+describe("Step", () => {
+	let writeSpy: ReturnType<typeof vi.spyOn>;
+	let captured: string[];
+
+	beforeEach(() => {
+		captured = [];
+		writeSpy = vi.spyOn(process.stdout, "write").mockImplementation((chunk) => {
+			captured.push(String(chunk));
+			return true;
+		});
+	});
+
+	afterEach(() => {
+		writeSpy.mockRestore();
+	});
+
+	const output = (): string => captured.join("");
+
+	// -----------------------------------------------------------------
+	// withStep — happy path
+	// -----------------------------------------------------------------
+
+	describe("withStep — happy path", () => {
+		it("emits exactly one info line (the success line), debug not printed", async () => {
+			await run(
+				Step.withStep(
+					"pack",
+					Effect.gen(function* () {
+						yield* Effect.logDebug("verbose pack detail A");
+						yield* Effect.logDebug("verbose pack detail B");
+						yield* Step.success("24.9 kB · 11 files");
+						return 42;
+					}),
+				),
+			);
+
+			const out = output();
+			// The library now prepends `✅ <name>: ` automatically — the
+			// caller passes only the outcome.
+			expect(out).toContain("✅ pack: 24.9 kB · 11 files");
+			expect(out).not.toContain("verbose pack detail A");
+			expect(out).not.toContain("verbose pack detail B");
+		});
+
+		it("withStep returns the wrapped effect's result unchanged", async () => {
+			const result = await run(
+				Step.withStep("compute", Effect.succeed(7).pipe(Effect.tap(() => Step.success("done")))),
+			);
+			expect(result).toBe(7);
+		});
+	});
+
+	// -----------------------------------------------------------------
+	// withStep — failure path
+	// -----------------------------------------------------------------
+
+	describe("withStep — failure path", () => {
+		it("emits the failure header, spills the buffer, propagates the original error", async () => {
+			const exit = await runExit(
+				Step.withStep(
+					"publish",
+					Effect.gen(function* () {
+						yield* Effect.logDebug("probe https://npm.pkg.github.com/: starting");
+						yield* Effect.logDebug("probe https://npm.pkg.github.com/: HTTP 200");
+						return yield* Effect.fail(new Error("integrity mismatch — local sha512-ABC ≠ remote sha512-XYZ"));
+					}),
+				),
+			);
+
+			expect(Exit.isFailure(exit)).toBe(true);
+			const out = output();
+			// Failure header carries the rendered error message after
+			// the step name.
+			expect(out).toContain("❌ publish: integrity mismatch — local sha512-ABC ≠ remote sha512-XYZ");
+			expect(out).toContain("│ [DEBUG] probe https://npm.pkg.github.com/: starting");
+			expect(out).toContain("│ [DEBUG] probe https://npm.pkg.github.com/: HTTP 200");
+			expect(out).toContain("└ Error: integrity mismatch — local sha512-ABC ≠ remote sha512-XYZ");
+		});
+	});
+
+	// -----------------------------------------------------------------
+	// withStep — fallback hierarchy
+	// -----------------------------------------------------------------
+
+	describe("withStep — success fallback", () => {
+		it("uses options.defaultSummary when Step.success was never called", async () => {
+			await run(
+				Step.withStep("probe", Effect.succeed({ count: 3 }), { defaultSummary: (r) => `probed ${r.count} targets` }),
+			);
+			// Library prepends `✅ <name>: `.
+			expect(output()).toContain("✅ probe: probed 3 targets");
+		});
+
+		it("falls back to '✅ <name>' when neither success nor defaultSummary is set", async () => {
+			await run(Step.withStep("bare", Effect.succeed(null)));
+			const out = output();
+			expect(out).toContain("✅ bare");
+			// The bare fallback has no trailing colon (no outcome to show).
+			expect(out).not.toContain("✅ bare:");
+		});
+
+		it("Step.success takes precedence over defaultSummary", async () => {
+			await run(
+				Step.withStep(
+					"override",
+					Effect.gen(function* () {
+						yield* Step.success("explicit success line");
+						return 1;
+					}),
+					{ defaultSummary: () => "default summary" },
+				),
+			);
+			expect(output()).toContain("✅ override: explicit success line");
+			expect(output()).not.toContain("default summary");
+		});
+	});
+
+	// -----------------------------------------------------------------
+	// withStep — nested
+	// -----------------------------------------------------------------
+
+	describe("withStep — nested", () => {
+		it("indents nested success lines under the parent", async () => {
+			await run(
+				Step.withStep(
+					"parent",
+					Effect.gen(function* () {
+						yield* Step.withStep(
+							"child-a",
+							Effect.gen(function* () {
+								yield* Step.success("done");
+								return 1;
+							}),
+						);
+						yield* Step.withStep(
+							"child-b",
+							Effect.gen(function* () {
+								yield* Step.success("done");
+								return 2;
+							}),
+						);
+						yield* Step.success("done");
+						return null;
+					}),
+				),
+			);
+
+			const out = output();
+			// Children indent by two spaces under the parent (depth 1).
+			expect(out).toContain("  ✅ child-a: done");
+			expect(out).toContain("  ✅ child-b: done");
+			// Parent is depth 0 — no leading indent.
+			expect(out).toMatch(/(^|\n)✅ parent: done/);
+		});
+
+		it("child failure prints its spill at the child's depth, then propagates to parent", async () => {
+			const exit = await runExit(
+				Step.withStep(
+					"parent",
+					Effect.gen(function* () {
+						yield* Step.withStep(
+							"child",
+							Effect.gen(function* () {
+								yield* Effect.logDebug("child detail 1");
+								yield* Effect.logDebug("child detail 2");
+								return yield* Effect.fail(new Error("child failed"));
+							}),
+						);
+						// Unreachable — child propagates.
+						yield* Step.success("✅ parent done");
+						return null;
+					}),
+				),
+			);
+
+			expect(Exit.isFailure(exit)).toBe(true);
+			const out = output();
+			// Child failure header is indented one level under the parent,
+			// and the error message is appended after the step name.
+			expect(out).toContain("  ❌ child: child failed");
+			// Child buffer lines are at the child's depth + 3-space prefix.
+			expect(out).toContain("     │ [DEBUG] child detail 1");
+			expect(out).toContain("     │ [DEBUG] child detail 2");
+			expect(out).toContain("     └ Error: child failed");
+			// Parent emits its OWN failure block since the child's
+			// failure propagated out of the parent's body. The parent's
+			// own buffer is empty (it logged nothing of its own).
+			expect(out).toContain("❌ parent: child failed");
+			expect(out).toContain("└ Error: child failed");
+		});
+	});
+
+	// -----------------------------------------------------------------
+	// Step.collapse
+	// -----------------------------------------------------------------
+
+	describe("Step.collapse", () => {
+		it("all-success → emits ONE info line (the reducer's output)", async () => {
+			const results = await run(
+				Step.collapse(
+					[
+						{ name: "probe a", effect: Effect.succeed("present") },
+						{ name: "probe b", effect: Effect.succeed("present") },
+					],
+					(rs) => `✅ Probe ${rs.length} registries: ${rs.map((r) => `${r.name}=${r.result}`).join(", ")}`,
+				),
+			);
+
+			expect(results).toEqual(["present", "present"]);
+			const out = output();
+			expect(out).toContain("✅ Probe 2 registries: probe a=present, probe b=present");
+			// Individual lines should NOT appear.
+			expect(out).not.toContain("✅ probe a");
+			expect(out).not.toContain("✅ probe b");
+		});
+
+		it("mixed outcomes → collapse abandoned; each child emits independently; failure propagates", async () => {
+			const exit = await runExit(
+				Step.collapse(
+					[
+						{ name: "probe a", effect: Effect.succeed("present") },
+						{
+							name: "probe b",
+							effect: Effect.gen(function* () {
+								yield* Effect.logDebug("probe b detail");
+								return yield* Effect.fail(new Error("probe b failed"));
+							}),
+						},
+					],
+					() => "✅ all probes happy",
+				),
+			);
+
+			expect(Exit.isFailure(exit)).toBe(true);
+			const out = output();
+			// Collapsed line must NOT appear.
+			expect(out).not.toContain("✅ all probes happy");
+			// Each child's own line shows up.
+			expect(out).toContain("✅ probe a");
+			expect(out).toContain("❌ probe b");
+			expect(out).toContain("│ [DEBUG] probe b detail");
+			expect(out).toContain("└ Error: probe b failed");
+		});
+
+		it("reducer-returns-null → collapse abandoned even on all-success", async () => {
+			await run(
+				Step.collapse(
+					[
+						{ name: "probe a", effect: Effect.succeed("present") },
+						{ name: "probe b", effect: Effect.succeed("not-published") },
+					],
+					(rs) => {
+						// Divergent results — opt out of collapse.
+						const distinct = new Set(rs.map((r) => r.result));
+						return distinct.size === 1 ? `✅ all ${rs.length}: ${[...distinct][0]}` : null;
+					},
+				),
+			);
+
+			const out = output();
+			// No collapsed line.
+			expect(out).not.toContain("✅ all");
+			// Each child emits its own.
+			expect(out).toContain("✅ probe a");
+			expect(out).toContain("✅ probe b");
+		});
+	});
+
+	// -----------------------------------------------------------------
+	// Pass-through behaviour
+	// -----------------------------------------------------------------
+
+	describe("pass-through", () => {
+		it("Effect.logWarning inside withStep prints live, NOT buffered", async () => {
+			await run(
+				Step.withStep(
+					"work",
+					Effect.gen(function* () {
+						yield* Effect.logWarning("careful now");
+						yield* Step.success("done");
+						return null;
+					}),
+				),
+			);
+
+			const out = output();
+			// Warning emerges as a `::warning::` workflow command.
+			expect(out).toContain("::warning::careful now");
+			// And it appears in the output (live), not at the end.
+			const warningIndex = out.indexOf("::warning::careful now");
+			const successIndex = out.indexOf("✅ work: done");
+			expect(warningIndex).toBeGreaterThanOrEqual(0);
+			expect(successIndex).toBeGreaterThanOrEqual(0);
+			expect(warningIndex).toBeLessThan(successIndex);
+		});
+
+		it("Effect.logInfo OUTSIDE withStep prints live", async () => {
+			await run(Effect.logInfo("hello"));
+			expect(output()).toContain("hello");
+		});
+
+		it("Step.success outside a withStep envelope is a no-op", async () => {
+			// Should not throw and should produce no success-line output.
+			await run(Step.success("stray success"));
+			expect(output()).not.toContain("stray success");
+		});
+	});
+});

--- a/src/runtime/Step.ts
+++ b/src/runtime/Step.ts
@@ -1,0 +1,324 @@
+import { Cause, Effect, Exit, FiberRef, HashSet } from "effect";
+import { ActionLogger } from "../services/ActionLogger.js";
+import type { BufferedLine, StepBuffer, StepFrame } from "./StepRuntime.js";
+import { StepStack, emitFailure, emitSuccess, indent, makeStepBufferingLogger } from "./StepRuntime.js";
+
+/**
+ * Step-buffered logging primitives.
+ *
+ * Wrap an Effect in {@link withStep} to:
+ *
+ *   1. Open a fresh debug buffer scoped to that step.
+ *   2. Run the wrapped Effect with debug/info logs captured (not
+ *      printed live).
+ *   3. On success — emit ONE info-level summary line and discard
+ *      the buffer.
+ *   4. On failure — emit a `❌ <name>` header, spill the buffered
+ *      lines indented under it, then propagate the original error
+ *      untouched.
+ *
+ * Warnings and errors are pass-through inside `withStep` because
+ * they map to GitHub Actions annotations whose UI affordances would
+ * be lost if buffered.
+ *
+ * For the design, see `docs/superpowers/specs/2026-05-20-step-buffered-logging-design.md`.
+ *
+ * @public
+ */
+
+/**
+ * Options for {@link withStep}.
+ *
+ * @public
+ */
+export interface WithStepOptions<A> {
+	/**
+	 * Default summary builder. Called with the step's result if the step
+	 * body never explicitly set a summary via {@link success}. Useful
+	 * for steps whose info line is always the same shape (e.g.
+	 * `"✅ <name>"` by default).
+	 */
+	readonly defaultSummary?: (result: A) => string;
+}
+
+/**
+ * Render the error message for the failure block. Pulls the first
+ * failure from the cause if present; falls back to the prettified
+ * cause for defects.
+ */
+const renderErrorMessage = (cause: Cause.Cause<unknown>): string => {
+	const failure = Cause.failureOption(cause);
+	if (failure._tag === "Some") {
+		const value: unknown = failure.value;
+		if (value instanceof Error) return value.message;
+		if (typeof value === "string") return value;
+		if (typeof value === "object" && value !== null && "message" in value && typeof value.message === "string") {
+			return value.message;
+		}
+		return String(value);
+	}
+	return Cause.pretty(cause);
+};
+
+/**
+ * Compute the success summary for a step.
+ *
+ * Returns the outcome string the caller wants RIGHT of the
+ * library-managed `✅ <name>: ` prefix. Resolution order:
+ *
+ *   1. The explicit `frame.successLine` if the step body called
+ *      `Step.success`.
+ *   2. `options.defaultSummary(result)` if the caller passed one.
+ *   3. `null` — emit only the bare `✅ <name>` line.
+ *
+ * The icon and step name are always added by
+ * {@link "./StepRuntime.js".emitSuccess}; this function never
+ * returns either of them itself.
+ */
+const resolveSummary = <A>(frame: StepFrame, result: A, options?: WithStepOptions<A>): string | null => {
+	if (frame.successLine !== null) return frame.successLine;
+	if (options?.defaultSummary !== undefined) return options.defaultSummary(result);
+	return null;
+};
+
+/**
+ * Wrap an Effect in the step lifecycle.
+ *
+ * On success, emits exactly one info-level summary line:
+ * `"<indent>✅ <name>: <line>"` when the body called
+ * {@link success} (or `options.defaultSummary` returned a string),
+ * or the bare `"<indent>✅ <name>"` when neither is set. The debug
+ * buffer is discarded.
+ *
+ * On failure, emits `"<indent>❌ <name>: <error message>"`, spills the
+ * debug buffer indented under the failure header, then propagates the
+ * original error untouched. The buffered lines retain their
+ * chronological order.
+ *
+ * The library is the single source of truth for the `✅` / `❌`
+ * icon and the `<name>:` prefix. Consumers pass ONLY the outcome
+ * to {@link success}.
+ *
+ * Nested `withStep` calls track depth automatically via the
+ * fiber-local step stack. The outermost step is depth 0; each child
+ * indents by two spaces.
+ *
+ * @public
+ */
+export const withStep = <A, E, R>(
+	name: string,
+	effect: Effect.Effect<A, E, R>,
+	options?: WithStepOptions<A>,
+): Effect.Effect<A, E, R> =>
+	Effect.gen(function* () {
+		const stack = yield* FiberRef.get(StepStack);
+		const buffer: StepBuffer = { entries: [] };
+		const frame: StepFrame = {
+			name,
+			depth: stack.length,
+			successLine: null,
+			buffer,
+		};
+
+		// Install the step's buffering logger as the sole logger for
+		// this scope. Using `FiberRef.locallyWith(currentLoggers, ...)`
+		// (rather than `Logger.replace(Logger.defaultLogger, ...)`)
+		// guarantees that pre-installed loggers (e.g. `ActionsLogger`
+		// in `ActionsRuntime.Default`) don't fire alongside us and
+		// double-print buffered debug lines. The HashSet is restored
+		// automatically when the inner scope exits.
+		const buffered = effect.pipe(
+			Effect.locally(FiberRef.currentLoggers, HashSet.make(makeStepBufferingLogger(buffer))),
+			Effect.locally(StepStack, [...stack, frame]),
+		);
+
+		const exit = yield* Effect.exit(buffered);
+
+		if (Exit.isFailure(exit)) {
+			emitFailure(frame, renderErrorMessage(exit.cause));
+			return yield* Effect.failCause(exit.cause);
+		}
+
+		const summary = resolveSummary(frame, exit.value, options);
+		emitSuccess(frame, summary);
+		return exit.value;
+	});
+
+/**
+ * Set the success summary line for the current step. Calling outside
+ * a {@link withStep} envelope is a no-op (with a defensive debug log).
+ *
+ * @example
+ * ```ts
+ * Step.withStep("pack dist/npm", Effect.gen(function* () {
+ *   const result = yield* publishSvc.pack(directory)
+ *   yield* Step.success(`pack ${result.name}@${result.version}: ${humanizeBytes(result.packedSize)}`)
+ *   return result
+ * }))
+ * ```
+ *
+ * @public
+ */
+export const success = (line: string): Effect.Effect<void> =>
+	Effect.gen(function* () {
+		const stack = yield* FiberRef.get(StepStack);
+		if (stack.length === 0) {
+			yield* Effect.logDebug("Step.success called outside a withStep envelope; ignoring.");
+			return;
+		}
+		// Mutate the innermost frame. `StepFrame` is intentionally
+		// mutable on `successLine` so the body can record its
+		// outcome without re-threading state through the Effect.
+		const innermost = stack[stack.length - 1];
+		if (innermost !== undefined) {
+			innermost.successLine = line;
+		}
+	});
+
+/**
+ * One entry in the {@link collapse} input list.
+ *
+ * @public
+ */
+export interface CollapseStep<A> {
+	readonly name: string;
+	readonly effect: Effect.Effect<A, unknown>;
+}
+
+/**
+ * The shape passed to the {@link collapse} reducer.
+ *
+ * @public
+ */
+export interface CollapseResult<A> {
+	readonly name: string;
+	readonly result: A;
+}
+
+/**
+ * Run N steps in parallel.
+ *
+ * On all-success, the reducer is called with `{ name, result }`
+ * pairs in input order; if it returns a string, that single info
+ * line is emitted **instead of** N per-step lines. If the reducer
+ * returns `null`, the collapse is abandoned and each child step
+ * emits its own line as if it had been wrapped in `withStep`
+ * directly.
+ *
+ * On any child failure, the collapse is also abandoned — each child
+ * emits its own success line or failure block. The first child
+ * failure's cause is then propagated.
+ *
+ * Concurrency is unbounded — the spec is for parallel registry
+ * probes / attestations where the N is small (typically 2-4).
+ *
+ * @public
+ */
+export const collapse = <A>(
+	steps: ReadonlyArray<CollapseStep<A>>,
+	reducer: (results: ReadonlyArray<CollapseResult<A>>) => string | null,
+): Effect.Effect<ReadonlyArray<A>, unknown> =>
+	Effect.gen(function* () {
+		const parentStack = yield* FiberRef.get(StepStack);
+		const depth = parentStack.length;
+
+		interface ChildOutcome {
+			readonly frame: StepFrame;
+			readonly exit: Exit.Exit<A, unknown>;
+		}
+
+		// Run all children in parallel. Each child owns its own buffer
+		// and frame; the result is captured *without* emitting the
+		// per-child success/failure block, so the outer collapse can
+		// decide whether to substitute one collapsed line.
+		const outcomes = yield* Effect.all(
+			steps.map(
+				(step): Effect.Effect<ChildOutcome> =>
+					Effect.gen(function* () {
+						const buffer: StepBuffer = { entries: [] };
+						const frame: StepFrame = {
+							name: step.name,
+							depth,
+							successLine: null,
+							buffer,
+						};
+						const exit = yield* Effect.exit(
+							step.effect.pipe(
+								Effect.locally(FiberRef.currentLoggers, HashSet.make(makeStepBufferingLogger(buffer))),
+								Effect.locally(StepStack, [...parentStack, frame]),
+							),
+						);
+						return { frame, exit };
+					}),
+			),
+			{ concurrency: "unbounded" },
+		);
+
+		// Decide between collapsed-line and per-child emission.
+		const allSucceeded = outcomes.every((o) => Exit.isSuccess(o.exit));
+		const collapsedLine = allSucceeded
+			? reducer(
+					outcomes.map(
+						(o): CollapseResult<A> => ({
+							name: o.frame.name,
+							// Safe: `allSucceeded` is true.
+							result: (o.exit as Exit.Success<A, unknown>).value,
+						}),
+					),
+				)
+			: null;
+
+		if (collapsedLine !== null) {
+			// One info line, at the parent's depth. Use indent for
+			// alignment with whatever group/step is wrapping us.
+			process.stdout.write(`${indent(depth)}${collapsedLine}\n`);
+			return outcomes.map((o) => (o.exit as Exit.Success<A, unknown>).value);
+		}
+
+		// Abandoned collapse: emit each child's own line, in input
+		// order. Failures emit their full spill block.
+		for (const outcome of outcomes) {
+			if (Exit.isFailure(outcome.exit)) {
+				emitFailure(outcome.frame, renderErrorMessage(outcome.exit.cause));
+			} else {
+				const summary = resolveSummary(outcome.frame, outcome.exit.value);
+				emitSuccess(outcome.frame, summary);
+			}
+		}
+
+		// If any child failed, propagate the first failure's cause.
+		const firstFailure = outcomes.find((o): o is ChildOutcome & { exit: Exit.Failure<A, unknown> } =>
+			Exit.isFailure(o.exit),
+		);
+		if (firstFailure !== undefined) {
+			return yield* Effect.failCause(firstFailure.exit.cause);
+		}
+
+		return outcomes.map((o) => (o.exit as Exit.Success<A, unknown>).value);
+	});
+
+/**
+ * Wrap an Effect in both {@link "../services/ActionLogger.js".ActionLogger.group}
+ * AND {@link withStep}. The natural choice for a phase's outer scope
+ * (Phase 1, Phase 2, Phase 3): a collapsible GitHub Actions block
+ * containing a step-summary at the end.
+ *
+ * @public
+ */
+export const groupStep = <A, E, R>(
+	name: string,
+	effect: Effect.Effect<A, E, R>,
+	options?: WithStepOptions<A>,
+): Effect.Effect<A, E, R | ActionLogger> =>
+	Effect.gen(function* () {
+		const logger = yield* ActionLogger;
+		return yield* logger.group(name, withStep(name, effect, options));
+	});
+
+/**
+ * Re-export the buffered-line shape for consumers that want to
+ * inspect the buffer in tests.
+ *
+ * @public
+ */
+export type { BufferedLine };

--- a/src/runtime/StepRuntime.ts
+++ b/src/runtime/StepRuntime.ts
@@ -1,0 +1,198 @@
+import { FiberRef, Inspectable, LogLevel, Logger } from "effect";
+import * as WorkflowCommand from "./WorkflowCommand.js";
+
+/**
+ * Internal mechanics for the {@link "./Step.js" | Step} primitive — the
+ * mutable buffer object, the FiberRef-tracked step stack, and the
+ * helpers that render buffered output.
+ *
+ * Not part of the public API. Re-exported only through the `Step.*`
+ * namespace facade.
+ *
+ * @internal
+ */
+
+/**
+ * Mutable per-step buffer object. One instance is created per
+ * `withStep` invocation and closed over by the step's buffering
+ * logger. The buffer is discarded on the step's success and flushed
+ * to stdout on failure.
+ *
+ * The `entries` array is `push`ed in place by the buffering logger
+ * (synchronous, runs inside `Logger.make`'s callback). Since each
+ * `withStep` creates its own buffer object, concurrent siblings never
+ * share state.
+ *
+ * @internal
+ */
+export interface StepBuffer {
+	readonly entries: Array<BufferedLine>;
+}
+
+/**
+ * One buffered log line.
+ *
+ * @internal
+ */
+export interface BufferedLine {
+	readonly level: "debug" | "info";
+	readonly text: string;
+	readonly timestamp: number;
+}
+
+/**
+ * One frame on the active step stack.
+ *
+ * `successLine` is the only mutable field; it is set by
+ * {@link "./Step.js".success} during the step body and read by
+ * {@link "./Step.js".withStep} after the body resolves.
+ *
+ * `buffer` is the step's debug buffer — held on the frame rather than
+ * in a separate FiberRef so the parent step can read the child's
+ * spill if the child fails.
+ *
+ * @internal
+ */
+export interface StepFrame {
+	readonly name: string;
+	readonly depth: number;
+	successLine: string | null;
+	readonly buffer: StepBuffer;
+}
+
+/**
+ * Stack of active steps in the current fiber. Outermost first; newest
+ * pushed onto the end. Empty when no `withStep` is active.
+ *
+ * `FiberRef.unsafeMake` is the only constructor that returns a
+ * `FiberRef` directly (not an `Effect`) so this module-level state
+ * can be exported without entering a Scope. The ref is forked per
+ * `Effect.fork`, so concurrent steps don't pollute each other's
+ * stacks.
+ *
+ * @internal
+ */
+export const StepStack: FiberRef.FiberRef<ReadonlyArray<StepFrame>> = FiberRef.unsafeMake<ReadonlyArray<StepFrame>>([]);
+
+/**
+ * Convert any `Effect.log*` payload into a flat string. Mirrors the
+ * normalisation in {@link "./ActionsLogger.js".ActionsLogger}.
+ *
+ * @internal
+ */
+export const formatMessage = (message: unknown): string => {
+	const parts = Array.isArray(message) ? message : [message];
+	return parts.map((p) => Inspectable.toStringUnknown(p)).join(" ");
+};
+
+/**
+ * Pass-through emission — what `ActionsLogger` does for the matching
+ * level, but called directly so we don't loop through the logger that
+ * invoked us.
+ *
+ * Used when no `withStep` is active OR for warning/error levels that
+ * always pass through.
+ *
+ * @internal
+ */
+export const emitPassThrough = (logLevel: LogLevel.LogLevel, text: string): void => {
+	if (LogLevel.greaterThanEqual(logLevel, LogLevel.Error)) {
+		WorkflowCommand.issue("error", {}, text);
+	} else if (LogLevel.greaterThanEqual(logLevel, LogLevel.Warning)) {
+		WorkflowCommand.issue("warning", {}, text);
+	} else if (LogLevel.greaterThanEqual(logLevel, LogLevel.Info)) {
+		process.stdout.write(`${text}\n`);
+	} else {
+		WorkflowCommand.issue("debug", {}, text);
+	}
+};
+
+/**
+ * Build the logger installed for the duration of one `withStep`. The
+ * buffer is the step's own mutable `StepBuffer`; the logger closes
+ * over it and pushes debug/info entries directly while letting
+ * warnings and errors pass through to the GitHub Actions workflow
+ * commands.
+ *
+ * The logger's behaviour table:
+ *
+ * - **Warning / Error / Fatal** — always pass through. They map to
+ *   GitHub Actions annotations whose UI affordance would be lost if
+ *   buffered.
+ * - **Info / Debug** — pushed into the step's `buffer.entries` array.
+ *   On success the buffer is dropped by `withStep`; on failure it is
+ *   spilled to stdout with `│ [DEBUG]` / `│ [INFO]` indentation.
+ *
+ * @internal
+ */
+export const makeStepBufferingLogger = (buffer: StepBuffer): Logger.Logger<unknown, void> =>
+	Logger.make(({ logLevel, message }) => {
+		const text = formatMessage(message);
+
+		// Warnings and errors are pass-through even inside a step.
+		if (LogLevel.greaterThanEqual(logLevel, LogLevel.Warning)) {
+			emitPassThrough(logLevel, text);
+			return;
+		}
+
+		const level: BufferedLine["level"] = LogLevel.greaterThanEqual(logLevel, LogLevel.Info) ? "info" : "debug";
+		buffer.entries.push({ level, text, timestamp: Date.now() });
+	});
+
+/**
+ * Indent rendering — `"  "` per depth. Used both for live success
+ * lines and for failure spill prefixes.
+ *
+ * @internal
+ */
+export const indent = (depth: number): string => "  ".repeat(depth);
+
+/**
+ * Emit the success summary line for a step. Called from `withStep`
+ * after the wrapped effect resolves successfully.
+ *
+ * Format:
+ *
+ * - When `line` is non-null and non-empty → `<indent>✅ <name>: <line>`.
+ * - When `line` is `null` or empty → `<indent>✅ <name>` (bare fallback).
+ *
+ * The library is the single source of truth for the `✅ <name>:`
+ * prefix. Consumers passing a line through `Step.success` should
+ * provide ONLY the outcome — not the step name and not the icon.
+ *
+ * @internal
+ */
+export const emitSuccess = (frame: StepFrame, line: string | null): void => {
+	const prefix = indent(frame.depth);
+	if (line !== null && line.length > 0) {
+		process.stdout.write(`${prefix}✅ ${frame.name}: ${line}\n`);
+	} else {
+		process.stdout.write(`${prefix}✅ ${frame.name}\n`);
+	}
+};
+
+/**
+ * Emit the failure block for a step. Writes the failure header,
+ * then each buffered line with a `│ [LEVEL]` prefix, then a trailing
+ * `└ Error:` line that carries the original error's message.
+ *
+ * The spill is written **directly to stdout** at the child's depth.
+ * The parent step's buffer is not modified — its failure block (if
+ * the parent also fails) will appear above this one in chronological
+ * order because of standard streaming output.
+ *
+ * Failure header format mirrors the success path: `❌ <name>: <error>`.
+ * The library prepends the icon and step name; callers' error
+ * messages should describe the outcome only.
+ *
+ * @internal
+ */
+export const emitFailure = (frame: StepFrame, errorText: string): void => {
+	const prefix = indent(frame.depth);
+	process.stdout.write(`${prefix}❌ ${frame.name}: ${errorText}\n`);
+	for (const entry of frame.buffer.entries) {
+		const label = entry.level === "debug" ? "[DEBUG]" : "[INFO]";
+		process.stdout.write(`${prefix}   │ ${label} ${entry.text}\n`);
+	}
+	process.stdout.write(`${prefix}   └ Error: ${errorText}\n`);
+};

--- a/src/runtime/StepRuntime.ts
+++ b/src/runtime/StepRuntime.ts
@@ -172,9 +172,10 @@ export const emitSuccess = (frame: StepFrame, line: string | null): void => {
 };
 
 /**
- * Emit the failure block for a step. Writes the failure header,
- * then each buffered line with a `│ [LEVEL]` prefix, then a trailing
- * `└ Error:` line that carries the original error's message.
+ * Emit the failure block for a step. Writes the failure header, then
+ * each buffered line with a `│ [LEVEL]` prefix, then — only when there
+ * were buffered lines — a trailing `└ Error:` line that closes the spill
+ * block.
  *
  * The spill is written **directly to stdout** at the child's depth.
  * The parent step's buffer is not modified — its failure block (if
@@ -183,7 +184,9 @@ export const emitSuccess = (frame: StepFrame, line: string | null): void => {
  *
  * Failure header format mirrors the success path: `❌ <name>: <error>`.
  * The library prepends the icon and step name; callers' error
- * messages should describe the outcome only.
+ * messages should describe the outcome only. When the buffer is empty
+ * the `└ Error:` trailer is suppressed — with no spill lines to close,
+ * it would just repeat the header's error text on the next line.
  *
  * @internal
  */
@@ -194,5 +197,7 @@ export const emitFailure = (frame: StepFrame, errorText: string): void => {
 		const label = entry.level === "debug" ? "[DEBUG]" : "[INFO]";
 		process.stdout.write(`${prefix}   │ ${label} ${entry.text}\n`);
 	}
-	process.stdout.write(`${prefix}   └ Error: ${errorText}\n`);
+	if (frame.buffer.entries.length > 0) {
+		process.stdout.write(`${prefix}   └ Error: ${errorText}\n`);
+	}
 };

--- a/src/schemas/Attestation.ts
+++ b/src/schemas/Attestation.ts
@@ -1,0 +1,119 @@
+/**
+ * Schema definitions for in-toto statements, Sigstore bundles, and the
+ * attestation service's public input/output shapes.
+ *
+ * @remarks
+ * Stays decoupled from any HTTP or crypto primitives so consumers can
+ * reason about (and serialize) attestation artifacts before any signing
+ * or upload happens. Modeled after the same JSON shapes that GitHub's
+ * REST API (`POST /repos/{owner}/{repo}/attestations`) and
+ * `@actions/attest` produce, so a bundle built here interoperates with
+ * existing sigstore tooling (cosign verify-blob, slsa-verifier, etc.).
+ */
+
+import { Schema } from "effect";
+
+// ---------------------------------------------------------------------------
+// in-toto Statement v1
+// ---------------------------------------------------------------------------
+
+/**
+ * Type URI for in-toto Statement v1. Stored verbatim as the `_type` field of
+ * every statement we emit.
+ *
+ * @see https://github.com/in-toto/attestation/blob/main/spec/v1/statement.md
+ */
+export const IN_TOTO_STATEMENT_V1 = "https://in-toto.io/Statement/v1" as const;
+
+/** Subject of an in-toto statement: a content-addressed artifact. */
+export class InTotoSubject extends Schema.Class<InTotoSubject>("InTotoSubject")({
+	/**
+	 * Name of the subject. Conventionally a PURL for npm packages
+	 * (e.g. `pkg:npm/@scope/name@1.0.0`) but the spec only requires
+	 * uniqueness within the statement.
+	 */
+	name: Schema.String,
+	/**
+	 * One or more algorithm → hex digest mappings for the artifact.
+	 * SHA-256 is conventionally provided as `{ sha256: "<64 hex chars>" }`.
+	 */
+	digest: Schema.Record({ key: Schema.String, value: Schema.String }),
+}) {}
+
+/**
+ * In-toto Statement v1. The `predicate` body is intentionally typed as
+ * `unknown` — different predicate types (SLSA provenance, CycloneDX SBOM,
+ * SPDX, etc.) carry different shapes, and the statement layer doesn't
+ * need to introspect them.
+ */
+export class InTotoStatement extends Schema.Class<InTotoStatement>("InTotoStatement")({
+	_type: Schema.Literal(IN_TOTO_STATEMENT_V1),
+	subject: Schema.Array(InTotoSubject),
+	predicateType: Schema.String,
+	predicate: Schema.Unknown,
+}) {}
+
+// ---------------------------------------------------------------------------
+// Predicate type URIs we support out of the box
+// ---------------------------------------------------------------------------
+
+/** SLSA Provenance v1.0 predicate URI. */
+export const SLSA_PROVENANCE_V1 = "https://slsa.dev/provenance/v1" as const;
+/** CycloneDX BOM predicate URI. Used for SBOM attestations. */
+export const CYCLONEDX_BOM = "https://cyclonedx.org/bom" as const;
+/** SPDX SBOM predicate URI. */
+export const SPDX_V2_3 = "https://spdx.dev/Document/v2.3" as const;
+
+// ---------------------------------------------------------------------------
+// Sigstore Bundle v0.3
+// ---------------------------------------------------------------------------
+
+/**
+ * Sigstore Bundle media type, v0.3. GitHub's `POST /repos/.../attestations`
+ * endpoint expects bundles in this shape.
+ */
+export const SIGSTORE_BUNDLE_V0_3_MEDIA_TYPE = "application/vnd.dev.sigstore.bundle.v0.3+json" as const;
+
+/**
+ * A Sigstore bundle — the wire format for attestations. The exact
+ * `verificationMaterial` and `dsseEnvelope` shapes are defined by the
+ * sigstore protobuf-specs; we model them as `unknown` at this layer and
+ * delegate construction to `@sigstore/sign`. The bundle is opaque to
+ * callers that just want to upload it.
+ *
+ * @see https://github.com/sigstore/protobuf-specs/blob/main/protos/sigstore_bundle.proto
+ */
+export class SigstoreBundle extends Schema.Class<SigstoreBundle>("SigstoreBundle")({
+	mediaType: Schema.Literal(SIGSTORE_BUNDLE_V0_3_MEDIA_TYPE),
+	verificationMaterial: Schema.Unknown,
+	dsseEnvelope: Schema.Unknown,
+}) {}
+
+// ---------------------------------------------------------------------------
+// Public input/output shapes for the Attest service
+// ---------------------------------------------------------------------------
+
+/**
+ * Common input for any attestation operation.
+ *
+ * @remarks
+ * Either a list of pre-built {@link InTotoSubject} entries or a
+ * single subject (name + digest) — matching `@actions/attest`'s
+ * convenience overload.
+ */
+export interface AttestInput {
+	readonly subjects: ReadonlyArray<InTotoSubject>;
+	readonly predicateType: string;
+	readonly predicate: unknown;
+}
+
+/**
+ * Result of a successful end-to-end attestation: the statement,
+ * the signed Sigstore bundle, and the GitHub attestation record.
+ */
+export interface AttestationRecord {
+	readonly statement: InTotoStatement;
+	readonly bundle: SigstoreBundle;
+	readonly attestationId: number;
+	readonly attestationUrl: string;
+}

--- a/src/services/Attest.bundle.test.ts
+++ b/src/services/Attest.bundle.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Step-3 tests for the Attest service: bundle construction.
+ *
+ * @remarks
+ * Drives `AttestLive.buildBundle` against a stub `SigstoreSigner` so we
+ * exercise the orchestration (build statement → hand off to signer →
+ * map errors) without spinning up the real Fulcio/Rekor path.
+ *
+ * The Live `SigstoreSigner` against the public-good Sigstore instance
+ * is exercised end-to-end in the integration repo run, not here.
+ */
+
+import type { Context } from "effect";
+import { Cause, Effect, Exit, Layer } from "effect";
+import { describe, expect, it } from "vitest";
+import type { InTotoStatement } from "../testing.js";
+import {
+	Attest,
+	AttestLive,
+	IN_TOTO_STATEMENT_V1,
+	OidcTokenIssuer,
+	SIGSTORE_BUNDLE_V0_3_MEDIA_TYPE,
+	SLSA_PROVENANCE_V1,
+	SigstoreBundle,
+	SigstoreSigner,
+	SigstoreSignerError,
+	npmPurl,
+	subject,
+} from "../testing.js";
+
+const stubBundle = (subjectName: string): SigstoreBundle =>
+	new SigstoreBundle({
+		mediaType: SIGSTORE_BUNDLE_V0_3_MEDIA_TYPE,
+		verificationMaterial: { tlogEntries: [], stub: true, subjectName },
+		dsseEnvelope: { payload: "base64-payload", payloadType: "application/vnd.in-toto+json", signatures: [] },
+	});
+
+interface SignerCalls {
+	statements: InTotoStatement[];
+}
+
+const stubSignerLayer = (
+	calls: SignerCalls,
+	respond: (statement: InTotoStatement) => SigstoreBundle | SigstoreSignerError,
+): Layer.Layer<SigstoreSigner> =>
+	Layer.succeed(SigstoreSigner, {
+		signStatement: (statement) =>
+			Effect.gen(function* () {
+				calls.statements.push(statement);
+				const result = respond(statement);
+				if (result instanceof SigstoreSignerError) return yield* Effect.fail(result);
+				return result;
+			}),
+	});
+
+const noopOidcLayer: Layer.Layer<OidcTokenIssuer> = Layer.succeed(OidcTokenIssuer, {
+	getToken: () => Effect.die("OidcTokenIssuer should not be reached when SigstoreSigner is stubbed"),
+});
+
+describe("Attest.buildBundle — step 3: orchestration", () => {
+	it("builds an in-toto statement and hands it to SigstoreSigner", async () => {
+		const calls: SignerCalls = { statements: [] };
+		const layer = Layer.mergeAll(
+			AttestLive,
+			stubSignerLayer(calls, (s) => stubBundle(s.subject[0].name)),
+			noopOidcLayer,
+		);
+
+		const bundle = await Effect.runPromise(
+			Effect.gen(function* () {
+				const attest = yield* Attest;
+				return yield* attest.buildBundle({
+					subjects: [subject(npmPurl("@savvy-web/example", "1.0.0"), "a".repeat(64))],
+					predicateType: SLSA_PROVENANCE_V1,
+					predicate: { buildType: "https://example.com/build" },
+				});
+			}).pipe(Effect.provide(layer)),
+		);
+
+		expect(calls.statements).toHaveLength(1);
+		const statement = calls.statements[0];
+		expect(statement._type).toBe(IN_TOTO_STATEMENT_V1);
+		expect(statement.subject).toHaveLength(1);
+		expect(statement.subject[0].name).toBe("pkg:npm/@savvy-web/example@1.0.0");
+		expect(statement.subject[0].digest).toEqual({ sha256: "a".repeat(64) });
+
+		expect(bundle.mediaType).toBe(SIGSTORE_BUNDLE_V0_3_MEDIA_TYPE);
+		const material = bundle.verificationMaterial as { subjectName: string };
+		expect(material.subjectName).toBe("pkg:npm/@savvy-web/example@1.0.0");
+	});
+
+	it("maps SigstoreSigner failures to AttestError(reason: sign)", async () => {
+		const calls: SignerCalls = { statements: [] };
+		const failingLayer = stubSignerLayer(
+			calls,
+			() => new SigstoreSignerError({ reason: "witness", message: "rekor: tlog returned 502" }),
+		);
+		const layer = Layer.mergeAll(AttestLive, failingLayer, noopOidcLayer);
+
+		const exit = await Effect.runPromise(
+			Effect.gen(function* () {
+				const attest = yield* Attest;
+				return yield* attest.buildBundle({
+					subjects: [subject("pkg:npm/x@1.0.0", "b".repeat(64))],
+					predicateType: SLSA_PROVENANCE_V1,
+					predicate: {},
+				});
+			}).pipe(Effect.provide(layer), Effect.exit),
+		);
+
+		expect(Exit.isFailure(exit)).toBe(true);
+		if (Exit.isFailure(exit)) {
+			const failure = Cause.failureOption(exit.cause);
+			expect(failure._tag).toBe("Some");
+			if (failure._tag === "Some") {
+				expect(failure.value._tag).toBe("AttestError");
+				expect(failure.value.reason).toBe("sign");
+				expect(failure.value.message).toContain("rekor: tlog returned 502");
+				expect(failure.value.cause).toBeInstanceOf(SigstoreSignerError);
+			}
+		}
+	});
+
+	it("declares SigstoreSigner + OidcTokenIssuer as required dependencies", () => {
+		// This is a compile-time check disguised as a runtime test — if the
+		// service surface ever drops the dependency declaration, the type
+		// of the effect changes and this test fails to typecheck.
+		const program = Effect.gen(function* () {
+			const attest = yield* Attest;
+			return yield* attest.buildBundle({
+				subjects: [subject("pkg:npm/y@1.0.0", "c".repeat(64))],
+				predicateType: SLSA_PROVENANCE_V1,
+				predicate: {},
+			});
+		});
+		type RequiredContext = Effect.Effect.Context<typeof program>;
+		const hasAttest: Context.Tag.Identifier<Attest> = null as never as Context.Tag.Identifier<Attest>;
+		const hasSigner: Context.Tag.Identifier<SigstoreSigner> = null as never as Context.Tag.Identifier<SigstoreSigner>;
+		const hasOidc: Context.Tag.Identifier<OidcTokenIssuer> = null as never as Context.Tag.Identifier<OidcTokenIssuer>;
+		const _required: RequiredContext = hasAttest as unknown as RequiredContext;
+		void hasSigner;
+		void hasOidc;
+		void _required;
+		expect(true).toBe(true);
+	});
+});

--- a/src/services/Attest.list.test.ts
+++ b/src/services/Attest.list.test.ts
@@ -1,0 +1,254 @@
+/**
+ * Tests for `Attest.listForSubject` — the "already attested?" probe
+ * used by the publish orchestrator to keep recovery runs idempotent.
+ *
+ * @remarks
+ * Exercises both layers:
+ *
+ *  - the live implementation against a {@link GitHubClient} test layer
+ *    that returns synthetic `GET /repos/.../attestations/{digest}` bodies;
+ *  - the {@link AttestTest} layer's seed/capture state.
+ *
+ * The 404 path is verified directly through the GitHubClient test
+ * layer's missing-response behaviour (which raises a 404-shaped
+ * GitHubClientError) plus a hand-rolled layer that throws a 404
+ * synchronously so we cover both code paths.
+ */
+
+import { Effect, Layer } from "effect";
+import { describe, expect, it } from "vitest";
+import {
+	Attest,
+	AttestLive,
+	AttestTest,
+	CYCLONEDX_BOM,
+	GitHubClient,
+	GitHubClientTest,
+	OidcTokenIssuer,
+	SLSA_PROVENANCE_V1,
+	SigstoreSigner,
+	makeAttestTestState,
+} from "../testing.js";
+
+// ─── Fixtures ──────────────────────────────────────────────────────
+
+/** Encode an in-toto statement as the DSSE payload field would. */
+const dssePayload = (statement: Record<string, unknown>): string =>
+	Buffer.from(JSON.stringify(statement), "utf-8").toString("base64");
+
+/**
+ * Build a synthetic attestations-list response shaped like
+ * `GET /repos/{owner}/{repo}/attestations/{digest}` returns.
+ */
+const listResponse = (
+	entries: ReadonlyArray<{ readonly id: number; readonly predicateType: string; readonly subjectName?: string }>,
+) => ({
+	attestations: entries.map((e) => ({
+		id: e.id,
+		bundle: {
+			mediaType: "application/vnd.dev.sigstore.bundle.v0.3+json",
+			verificationMaterial: {},
+			dsseEnvelope: {
+				payload: dssePayload({
+					_type: "https://in-toto.io/Statement/v1",
+					subject: [{ name: e.subjectName ?? "pkg:npm/x@1.0.0", digest: { sha256: "a".repeat(64) } }],
+					predicateType: e.predicateType,
+					predicate: {},
+				}),
+				payloadType: "application/vnd.in-toto+json",
+				signatures: [],
+			},
+		},
+		repository_id: 1234,
+		bundle_url: `https://example.test/bundles/${e.id}`,
+		initiator: "test",
+	})),
+});
+
+/** Build a synthetic GitHubClient that returns a fixed REST response and ignores graphql/paginate. */
+const fixedGitHubClient = (
+	restData: unknown,
+	repo = { owner: "savvy-web", repo: "workflow-release-action" },
+): Layer.Layer<GitHubClient> =>
+	Layer.succeed(GitHubClient, {
+		rest: <T>(_op: string, fn: (octokit: unknown) => Promise<{ data: T }>) =>
+			Effect.tryPromise({
+				try: () =>
+					fn({
+						request: (_route: string, _params: Record<string, unknown>) => Promise.resolve({ data: restData }),
+					}),
+				catch: (e) => e as never,
+			}).pipe(Effect.map((r) => r.data)),
+		graphql: () => Effect.die("graphql not used"),
+		paginate: () => Effect.die("paginate not used"),
+		repo: Effect.succeed(repo),
+	});
+
+/** GitHubClient that throws a 404-shaped error from the request callback. */
+const throwingGitHubClient = (status: number): Layer.Layer<GitHubClient> =>
+	Layer.succeed(GitHubClient, {
+		rest: <T>(_op: string, fn: (octokit: unknown) => Promise<{ data: T }>) =>
+			Effect.tryPromise({
+				try: () =>
+					fn({
+						request: (_route: string, _params: Record<string, unknown>) => {
+							const error = new Error(`HTTP ${status}`) as Error & { status: number };
+							error.status = status;
+							return Promise.reject(error);
+						},
+					}),
+				catch: (e) => e as never,
+			}).pipe(Effect.map((r) => r.data)),
+		graphql: () => Effect.die("graphql not used"),
+		paginate: () => Effect.die("paginate not used"),
+		repo: Effect.succeed({ owner: "savvy-web", repo: "workflow-release-action" }),
+	});
+
+const noopOidc: Layer.Layer<OidcTokenIssuer> = Layer.succeed(OidcTokenIssuer, {
+	getToken: () => Effect.die("OidcTokenIssuer not used in list tests"),
+});
+
+const noopSigner: Layer.Layer<SigstoreSigner> = Layer.succeed(SigstoreSigner, {
+	signStatement: () => Effect.die("SigstoreSigner not used in list tests"),
+});
+
+// ─── AttestLive.listForSubject ─────────────────────────────────────
+
+describe("Attest.listForSubject — live implementation", () => {
+	const SUBJECT = "abc123".padEnd(64, "0");
+
+	it("returns every attestation when no predicateType filter is provided", async () => {
+		const layer = Layer.mergeAll(
+			AttestLive,
+			noopSigner,
+			noopOidc,
+			fixedGitHubClient(
+				listResponse([
+					{ id: 1, predicateType: SLSA_PROVENANCE_V1 },
+					{ id: 2, predicateType: CYCLONEDX_BOM },
+				]),
+				{ owner: "acme", repo: "widgets" },
+			),
+		);
+
+		const entries = await Effect.runPromise(
+			Effect.gen(function* () {
+				const attest = yield* Attest;
+				return yield* attest.listForSubject(SUBJECT);
+			}).pipe(Effect.provide(layer)),
+		);
+
+		expect(entries).toHaveLength(2);
+		expect(entries[0]?.attestationUrl).toBe("https://github.com/acme/widgets/attestations/1");
+		expect(entries[0]?.predicateType).toBe(SLSA_PROVENANCE_V1);
+		expect(entries[1]?.attestationUrl).toBe("https://github.com/acme/widgets/attestations/2");
+		expect(entries[1]?.predicateType).toBe(CYCLONEDX_BOM);
+	});
+
+	it("filters by predicateType client-side", async () => {
+		const layer = Layer.mergeAll(
+			AttestLive,
+			noopSigner,
+			noopOidc,
+			fixedGitHubClient(
+				listResponse([
+					{ id: 1, predicateType: SLSA_PROVENANCE_V1 },
+					{ id: 2, predicateType: CYCLONEDX_BOM },
+					{ id: 3, predicateType: SLSA_PROVENANCE_V1 },
+				]),
+			),
+		);
+
+		const entries = await Effect.runPromise(
+			Effect.gen(function* () {
+				const attest = yield* Attest;
+				return yield* attest.listForSubject(SUBJECT, { predicateType: SLSA_PROVENANCE_V1 });
+			}).pipe(Effect.provide(layer)),
+		);
+
+		expect(entries).toHaveLength(2);
+		expect(entries.every((e) => e.predicateType === SLSA_PROVENANCE_V1)).toBe(true);
+	});
+
+	it("returns [] when the API responds with an empty attestations array", async () => {
+		const layer = Layer.mergeAll(AttestLive, noopSigner, noopOidc, fixedGitHubClient({ attestations: [] }));
+
+		const entries = await Effect.runPromise(
+			Effect.gen(function* () {
+				const attest = yield* Attest;
+				return yield* attest.listForSubject(SUBJECT);
+			}).pipe(Effect.provide(layer)),
+		);
+
+		expect(entries).toEqual([]);
+	});
+
+	it("returns [] on a 404 (subject has no attestations at all)", async () => {
+		const layer = Layer.mergeAll(AttestLive, noopSigner, noopOidc, throwingGitHubClient(404));
+
+		const entries = await Effect.runPromise(
+			Effect.gen(function* () {
+				const attest = yield* Attest;
+				return yield* attest.listForSubject(SUBJECT);
+			}).pipe(Effect.provide(layer)),
+		);
+
+		expect(entries).toEqual([]);
+	});
+});
+
+// ─── AttestTest.listForSubject ─────────────────────────────────────
+
+describe("Attest.listForSubject — test layer", () => {
+	const SUBJECT = "deadbeef".padEnd(64, "0");
+
+	it("returns the seeded entries for a subject", async () => {
+		const state = makeAttestTestState();
+		state.seedAttestations.set(SUBJECT, [
+			{ attestationUrl: "https://github.com/acme/repo/attestations/1", predicateType: SLSA_PROVENANCE_V1 },
+			{ attestationUrl: "https://github.com/acme/repo/attestations/2", predicateType: CYCLONEDX_BOM },
+		]);
+
+		const entries = await Effect.runPromise(
+			Effect.gen(function* () {
+				const attest = yield* Attest;
+				return yield* attest.listForSubject(SUBJECT);
+			}).pipe(Effect.provide(Layer.merge(AttestTest.layer(state), GitHubClientTest.empty()))),
+		);
+
+		expect(entries).toHaveLength(2);
+		expect(state.listForSubjectCalls).toEqual([{ subjectSha256: SUBJECT, predicateType: undefined }]);
+	});
+
+	it("filters seeded entries by predicateType when requested", async () => {
+		const state = makeAttestTestState();
+		state.seedAttestations.set(SUBJECT, [
+			{ attestationUrl: "u1", predicateType: SLSA_PROVENANCE_V1 },
+			{ attestationUrl: "u2", predicateType: CYCLONEDX_BOM },
+		]);
+
+		const entries = await Effect.runPromise(
+			Effect.gen(function* () {
+				const attest = yield* Attest;
+				return yield* attest.listForSubject(SUBJECT, { predicateType: CYCLONEDX_BOM });
+			}).pipe(Effect.provide(Layer.merge(AttestTest.layer(state), GitHubClientTest.empty()))),
+		);
+
+		expect(entries).toEqual([{ attestationUrl: "u2", predicateType: CYCLONEDX_BOM }]);
+		expect(state.listForSubjectCalls).toEqual([{ subjectSha256: SUBJECT, predicateType: CYCLONEDX_BOM }]);
+	});
+
+	it("returns [] for an unseeded subject", async () => {
+		const state = makeAttestTestState();
+
+		const entries = await Effect.runPromise(
+			Effect.gen(function* () {
+				const attest = yield* Attest;
+				return yield* attest.listForSubject(SUBJECT);
+			}).pipe(Effect.provide(Layer.merge(AttestTest.layer(state), GitHubClientTest.empty()))),
+		);
+
+		expect(entries).toEqual([]);
+		expect(state.listForSubjectCalls).toHaveLength(1);
+	});
+});

--- a/src/services/Attest.sbom.test.ts
+++ b/src/services/Attest.sbom.test.ts
@@ -1,0 +1,209 @@
+/**
+ * Tests for `Attest.sbom` — the explicit-BOM path added so consumers
+ * can attest a pre-built CycloneDX document (with full NTIA / supplier
+ * metadata) rather than re-deriving an empty-deps BOM from scratch.
+ *
+ * @remarks
+ * Covers both branches:
+ *
+ *  - {@link SbomAttestationInput.bomDocument} present → live impl uses
+ *    the supplied document as the in-toto predicate verbatim;
+ *  - {@link SbomAttestationInput.dependencies} present → live impl
+ *    delegates to the {@link Sbom} service and the dependency list
+ *    flows through into the attested BOM;
+ *  - neither field → live impl falls back to an empty-deps BOM and
+ *    emits a debug log; tests assert on the predicate shape only,
+ *    not on log output (Effect's default logger drops debug-level
+ *    messages in the test runtime).
+ */
+
+import { Effect, Layer } from "effect";
+import { describe, expect, it } from "vitest";
+import {
+	Attest,
+	AttestLive,
+	AttestTest,
+	CYCLONEDX_BOM,
+	GitHubClient,
+	GitHubClientTest,
+	OidcTokenIssuer,
+	Sbom,
+	SbomTest,
+	SigstoreSigner,
+	makeAttestTestState,
+	makeSbomTestState,
+} from "../testing.js";
+
+// ─── Common scaffolding ────────────────────────────────────────────
+
+const stubSigner: Layer.Layer<SigstoreSigner> = Layer.succeed(SigstoreSigner, {
+	signStatement: () =>
+		Effect.succeed({
+			mediaType: "application/vnd.dev.sigstore.bundle.v0.3+json",
+			verificationMaterial: { tlogEntries: [] },
+			dsseEnvelope: {
+				payload: "",
+				payloadType: "application/vnd.in-toto+json",
+				signatures: [{ sig: "stub", keyid: "" }],
+			},
+		} as never),
+});
+
+const noopOidc: Layer.Layer<OidcTokenIssuer> = Layer.succeed(OidcTokenIssuer, {
+	getToken: () => Effect.die("OidcTokenIssuer not reached when SigstoreSigner is stubbed"),
+});
+
+const SUBJECT = "feedface".padEnd(64, "0");
+
+// ─── AttestLive.sbom — bomDocument path ────────────────────────────
+
+describe("AttestLive.sbom — explicit BOM document", () => {
+	it("does NOT call Sbom.generate when bomDocument is supplied", async () => {
+		// Arrange: seed a SbomTest state whose generate would record a
+		// call. The test passes only if the live sbom impl skips that
+		// branch entirely.
+		const sbomState = makeSbomTestState();
+		const layer = Layer.mergeAll(
+			AttestLive,
+			stubSigner,
+			noopOidc,
+			GitHubClientTest.layer({
+				restResponses: new Map([["repos.createAttestation", { data: 7 }]]),
+				graphqlResponses: new Map(),
+				paginateResponses: new Map(),
+				repo: { owner: "acme", repo: "widgets" },
+			}),
+			SbomTest.layer(sbomState),
+		);
+
+		const bomDocument = {
+			bomFormat: "CycloneDX" as const,
+			specVersion: "1.5" as const,
+			version: 1 as const,
+			metadata: { component: { name: "@savvy-web/example", version: "1.0.0" } },
+			components: [{ type: "library", name: "lodash", version: "4.17.21" }],
+		};
+
+		// Act
+		const record = await Effect.runPromise(
+			Effect.gen(function* () {
+				const attest = yield* Attest;
+				return yield* attest.sbom({
+					rootName: "@savvy-web/example",
+					rootVersion: "1.0.0",
+					subjectSha256: SUBJECT,
+					bomDocument,
+				});
+			}).pipe(Effect.provide(layer)),
+		);
+
+		// Assert — Sbom.generate was not invoked; the supplied document
+		// flowed through as the in-toto predicate verbatim.
+		expect(sbomState.generateCalls).toHaveLength(0);
+		expect(record.statement.predicateType).toBe(CYCLONEDX_BOM);
+		expect(record.statement.predicate).toEqual(bomDocument);
+	});
+
+	it("calls Sbom.generate on the dependency-list path", async () => {
+		const sbomState = makeSbomTestState();
+		const layer = Layer.mergeAll(
+			AttestLive,
+			stubSigner,
+			noopOidc,
+			GitHubClientTest.layer({
+				restResponses: new Map([["repos.createAttestation", { data: 11 }]]),
+				graphqlResponses: new Map(),
+				paginateResponses: new Map(),
+				repo: { owner: "acme", repo: "widgets" },
+			}),
+			SbomTest.layer(sbomState),
+		);
+
+		await Effect.runPromise(
+			Effect.gen(function* () {
+				const attest = yield* Attest;
+				return yield* attest.sbom({
+					rootName: "@savvy-web/example",
+					rootVersion: "1.0.0",
+					subjectSha256: SUBJECT,
+					dependencies: [{ name: "lodash", version: "4.17.21" }],
+				});
+			}).pipe(Effect.provide(layer)),
+		);
+
+		// Assert — Sbom.generate fired with the supplied dependency
+		// list; the bomDocument path was NOT taken.
+		expect(sbomState.generateCalls).toHaveLength(1);
+		expect(sbomState.generateCalls[0]?.dependencies).toEqual([{ name: "lodash", version: "4.17.21" }]);
+	});
+
+	it("falls back to empty-deps when neither field is supplied", async () => {
+		const sbomState = makeSbomTestState();
+		const layer = Layer.mergeAll(
+			AttestLive,
+			stubSigner,
+			noopOidc,
+			GitHubClientTest.layer({
+				restResponses: new Map([["repos.createAttestation", { data: 13 }]]),
+				graphqlResponses: new Map(),
+				paginateResponses: new Map(),
+				repo: { owner: "acme", repo: "widgets" },
+			}),
+			SbomTest.layer(sbomState),
+		);
+
+		await Effect.runPromise(
+			Effect.gen(function* () {
+				const attest = yield* Attest;
+				return yield* attest.sbom({
+					rootName: "@savvy-web/example",
+					rootVersion: "1.0.0",
+					subjectSha256: SUBJECT,
+				});
+			}).pipe(Effect.provide(layer)),
+		);
+
+		// Assert — Sbom.generate was invoked with empty deps (no
+		// bomDocument, no dependencies → fallback path).
+		expect(sbomState.generateCalls).toHaveLength(1);
+		expect(sbomState.generateCalls[0]?.dependencies).toEqual([]);
+	});
+});
+
+// ─── AttestTest.sbom — bomDocument capture ─────────────────────────
+
+describe("AttestTest.sbom — captured calls expose bomDocument", () => {
+	it("records the bomDocument on the captured call", async () => {
+		const state = makeAttestTestState();
+		const bomDocument = {
+			bomFormat: "CycloneDX" as const,
+			specVersion: "1.5" as const,
+			components: [{ type: "library", name: "abc", version: "1.0.0" }],
+		};
+
+		await Effect.runPromise(
+			Effect.gen(function* () {
+				const attest = yield* Attest;
+				return yield* attest.sbom({
+					rootName: "root",
+					rootVersion: "1.0.0",
+					subjectSha256: SUBJECT,
+					bomDocument,
+				});
+			}).pipe(
+				Effect.provide(
+					Layer.mergeAll(AttestTest.layer(state), SbomTest.empty(), GitHubClientTest.empty(), stubSigner, noopOidc),
+				),
+			),
+		);
+
+		expect(state.sbomCalls).toHaveLength(1);
+		expect(state.sbomCalls[0]?.bomDocument).toEqual(bomDocument);
+	});
+});
+
+// Avoid an unused-import lint complaint when the type-only `GitHubClient`
+// reference is dropped by tree-shaking — Effect's testing helpers re-export
+// from a different module so the tag itself isn't used by name here.
+void GitHubClient;
+void Sbom;

--- a/src/services/Attest.statement.test.ts
+++ b/src/services/Attest.statement.test.ts
@@ -1,0 +1,142 @@
+/**
+ * Step-1 tests for the Attest service: in-toto statement construction
+ * + local file save through the in-memory FileSystem.
+ *
+ * @remarks
+ * Subsequent steps (OIDC, sigstore bundle, GitHub upload) will land
+ * their own targeted tests against test layers; this file stays scoped
+ * to the pure builder + the save-to-disk path so it can survive the
+ * upstreaming move to `@savvy-web/github-action-effects` unchanged.
+ */
+
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { FileSystem } from "@effect/platform";
+import { NodeFileSystem } from "@effect/platform-node";
+import { Effect, Layer } from "effect";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+	Attest,
+	AttestLive,
+	CYCLONEDX_BOM,
+	IN_TOTO_STATEMENT_V1,
+	SLSA_PROVENANCE_V1,
+	npmPurl,
+	serializeStatement,
+	subject,
+} from "../testing.js";
+
+const layer = Layer.merge(AttestLive, NodeFileSystem.layer);
+
+const run = <A, E>(effect: Effect.Effect<A, E, Attest | FileSystem.FileSystem>): Promise<A> =>
+	Effect.runPromise(Effect.provide(effect, layer));
+
+describe("Attest service — step 1: statement + save", () => {
+	let tmp: string;
+
+	beforeEach(() => {
+		tmp = mkdtempSync(join(tmpdir(), "attest-step1-"));
+	});
+
+	afterEach(() => {
+		rmSync(tmp, { recursive: true, force: true });
+	});
+
+	describe("buildStatement", () => {
+		it("builds a valid in-toto v1 statement with single subject", async () => {
+			const statement = await run(
+				Effect.gen(function* () {
+					const attest = yield* Attest;
+					return yield* attest.buildStatement({
+						subjects: [subject(npmPurl("@savvy-web/example", "1.0.0"), "a".repeat(64))],
+						predicateType: SLSA_PROVENANCE_V1,
+						predicate: { buildType: "https://example.com/build" },
+					});
+				}),
+			);
+
+			expect(statement._type).toBe(IN_TOTO_STATEMENT_V1);
+			expect(statement.subject).toHaveLength(1);
+			expect(statement.subject[0].name).toBe("pkg:npm/@savvy-web/example@1.0.0");
+			expect(statement.subject[0].digest).toEqual({ sha256: "a".repeat(64) });
+			expect(statement.predicateType).toBe(SLSA_PROVENANCE_V1);
+			expect(statement.predicate).toEqual({ buildType: "https://example.com/build" });
+		});
+
+		it("strips a leading `sha256:` prefix from the digest", async () => {
+			const statement = await run(
+				Effect.gen(function* () {
+					const attest = yield* Attest;
+					return yield* attest.buildStatement({
+						subjects: [subject("pkg:npm/foo@1.0.0", `sha256:${"b".repeat(64)}`)],
+						predicateType: CYCLONEDX_BOM,
+						predicate: { bomFormat: "CycloneDX" },
+					});
+				}),
+			);
+
+			expect(statement.subject[0].digest).toEqual({ sha256: "b".repeat(64) });
+		});
+
+		it("accepts multiple subjects in one statement", async () => {
+			const statement = await run(
+				Effect.gen(function* () {
+					const attest = yield* Attest;
+					return yield* attest.buildStatement({
+						subjects: [subject("pkg:npm/a@1.0.0", "1".repeat(64)), subject("pkg:npm/b@2.0.0", "2".repeat(64))],
+						predicateType: CYCLONEDX_BOM,
+						predicate: { bomFormat: "CycloneDX", specVersion: "1.5" },
+					});
+				}),
+			);
+
+			expect(statement.subject).toHaveLength(2);
+			expect(statement.subject.map((s) => s.name)).toEqual(["pkg:npm/a@1.0.0", "pkg:npm/b@2.0.0"]);
+		});
+	});
+
+	describe("save", () => {
+		it("writes the statement as pretty-printed JSON", async () => {
+			const outPath = join(tmp, "attestation.statement.json");
+
+			await run(
+				Effect.gen(function* () {
+					const attest = yield* Attest;
+					const statement = yield* attest.buildStatement({
+						subjects: [subject(npmPurl("@savvy-web/example", "1.0.0"), "c".repeat(64))],
+						predicateType: SLSA_PROVENANCE_V1,
+						predicate: { foo: "bar" },
+					});
+					yield* attest.save(statement, outPath);
+				}),
+			);
+
+			const written = readFileSync(outPath, "utf-8");
+			const parsed = JSON.parse(written);
+			expect(parsed._type).toBe(IN_TOTO_STATEMENT_V1);
+			expect(parsed.subject[0].name).toBe("pkg:npm/@savvy-web/example@1.0.0");
+			expect(written).toMatch(/^\{\n {2}/); // pretty-printed with 2-space indent
+		});
+
+		it("round-trips through serializeStatement", async () => {
+			const outPath = join(tmp, "roundtrip.statement.json");
+
+			const statement = await run(
+				Effect.gen(function* () {
+					const attest = yield* Attest;
+					const s = yield* attest.buildStatement({
+						subjects: [subject("pkg:npm/x@1.2.3", "d".repeat(64))],
+						predicateType: CYCLONEDX_BOM,
+						predicate: { spec: "1.5" },
+					});
+					yield* attest.save(s, outPath);
+					return s;
+				}),
+			);
+
+			const onDisk = readFileSync(outPath, "utf-8");
+			expect(onDisk).toBe(serializeStatement(statement));
+		});
+	});
+});

--- a/src/services/Attest.test.ts
+++ b/src/services/Attest.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Step-4 tests for the Attest service: end-to-end attestation upload.
+ *
+ * @remarks
+ * Drives `AttestLive.attest` against a stub `SigstoreSigner` and the
+ * upstream `GitHubClientTest` layer so the full
+ * statement → sign → upload chain is exercised without touching the
+ * network. The Live Sigstore + GitHub path is exercised in the
+ * silk-integration repo run, not here.
+ */
+
+import { Cause, Effect, Exit, Layer } from "effect";
+import { describe, expect, it } from "vitest";
+import type { InTotoStatement } from "../testing.js";
+import {
+	Attest,
+	AttestLive,
+	GitHubClient,
+	GitHubClientError,
+	GitHubClientTest,
+	OidcTokenIssuer,
+	SIGSTORE_BUNDLE_V0_3_MEDIA_TYPE,
+	SLSA_PROVENANCE_V1,
+	SigstoreBundle,
+	SigstoreSigner,
+	npmPurl,
+	subject,
+} from "../testing.js";
+
+const stubBundle = (subjectName: string): SigstoreBundle =>
+	new SigstoreBundle({
+		mediaType: SIGSTORE_BUNDLE_V0_3_MEDIA_TYPE,
+		verificationMaterial: { tlogEntries: [], subjectName },
+		dsseEnvelope: {
+			payload: "base64-payload",
+			payloadType: "application/vnd.in-toto+json",
+			signatures: [{ sig: "stub-sig", keyid: "" }],
+		},
+	});
+
+const stubSignerLayer: Layer.Layer<SigstoreSigner> = Layer.succeed(SigstoreSigner, {
+	signStatement: (statement: InTotoStatement) => Effect.succeed(stubBundle(statement.subject[0].name)),
+});
+
+const noopOidcLayer: Layer.Layer<OidcTokenIssuer> = Layer.succeed(OidcTokenIssuer, {
+	getToken: () => Effect.die("OidcTokenIssuer should not be reached when SigstoreSigner is stubbed"),
+});
+
+const makeGitHubClientLayer = (
+	restResponse: { data: unknown } | undefined,
+	repo = { owner: "savvy-web", repo: "workflow-release-action" },
+): Layer.Layer<GitHubClient> =>
+	GitHubClientTest.layer({
+		restResponses: restResponse ? new Map([["repos.createAttestation", restResponse]]) : new Map(),
+		graphqlResponses: new Map(),
+		paginateResponses: new Map(),
+		repo,
+	});
+
+describe("Attest.attest — step 4: end-to-end upload", () => {
+	it("builds, signs, and POSTs the attestation, returning the full record", async () => {
+		const layer = Layer.mergeAll(
+			AttestLive,
+			stubSignerLayer,
+			noopOidcLayer,
+			makeGitHubClientLayer({ data: 42 }, { owner: "savvy-web", repo: "silk-integration" }),
+		);
+
+		const record = await Effect.runPromise(
+			Effect.gen(function* () {
+				const attest = yield* Attest;
+				return yield* attest.attest({
+					subjects: [subject(npmPurl("@savvy-web/example", "1.0.0"), "a".repeat(64))],
+					predicateType: SLSA_PROVENANCE_V1,
+					predicate: { buildType: "https://example.com/build" },
+				});
+			}).pipe(Effect.provide(layer)),
+		);
+
+		expect(record.attestationId).toBe(42);
+		expect(record.attestationUrl).toBe("https://github.com/savvy-web/silk-integration/attestations/42");
+		expect(record.statement.subject[0].name).toBe("pkg:npm/@savvy-web/example@1.0.0");
+		expect(record.bundle.mediaType).toBe(SIGSTORE_BUNDLE_V0_3_MEDIA_TYPE);
+		const material = record.bundle.verificationMaterial as { subjectName: string };
+		expect(material.subjectName).toBe("pkg:npm/@savvy-web/example@1.0.0");
+	});
+
+	it("maps GitHubClient failures to AttestError(reason: upload)", async () => {
+		const failingClientLayer: Layer.Layer<GitHubClient> = Layer.succeed(GitHubClient, {
+			rest: () =>
+				Effect.fail(
+					new GitHubClientError({
+						operation: "repos.createAttestation",
+						status: 403,
+						reason: "permission denied: missing attestations:write",
+						retryable: false,
+					}),
+				),
+			graphql: () => Effect.die("graphql should not be called"),
+			paginate: () => Effect.die("paginate should not be called"),
+			repo: Effect.succeed({ owner: "savvy-web", repo: "silk-integration" }),
+		});
+
+		const layer = Layer.mergeAll(AttestLive, stubSignerLayer, noopOidcLayer, failingClientLayer);
+
+		const exit = await Effect.runPromise(
+			Effect.gen(function* () {
+				const attest = yield* Attest;
+				return yield* attest.attest({
+					subjects: [subject("pkg:npm/x@1.0.0", "b".repeat(64))],
+					predicateType: SLSA_PROVENANCE_V1,
+					predicate: {},
+				});
+			}).pipe(Effect.provide(layer), Effect.exit),
+		);
+
+		expect(Exit.isFailure(exit)).toBe(true);
+		if (Exit.isFailure(exit)) {
+			const failure = Cause.failureOption(exit.cause);
+			expect(failure._tag).toBe("Some");
+			if (failure._tag === "Some") {
+				expect(failure.value._tag).toBe("AttestError");
+				expect(failure.value.reason).toBe("upload");
+				expect(failure.value.message).toContain("permission denied");
+			}
+		}
+	});
+
+	it("uses the GitHubClient repo context for the attestation URL", async () => {
+		const layer = Layer.mergeAll(
+			AttestLive,
+			stubSignerLayer,
+			noopOidcLayer,
+			makeGitHubClientLayer({ data: 99 }, { owner: "acme", repo: "widgets" }),
+		);
+
+		const record = await Effect.runPromise(
+			Effect.gen(function* () {
+				const attest = yield* Attest;
+				return yield* attest.attest({
+					subjects: [subject("pkg:npm/x@1.0.0", "c".repeat(64))],
+					predicateType: SLSA_PROVENANCE_V1,
+					predicate: {},
+				});
+			}).pipe(Effect.provide(layer)),
+		);
+
+		expect(record.attestationId).toBe(99);
+		expect(record.attestationUrl).toBe("https://github.com/acme/widgets/attestations/99");
+	});
+});

--- a/src/services/Attest.ts
+++ b/src/services/Attest.ts
@@ -1,0 +1,214 @@
+/**
+ * Attest service tag.
+ */
+
+import type { FileSystem } from "@effect/platform";
+import type { Effect } from "effect";
+import { Context } from "effect";
+import type { AttestError } from "../errors/AttestError.js";
+import type { AttestInput, InTotoStatement, SigstoreBundle } from "../schemas/Attestation.js";
+import type { OidcTokenIssuer } from "./OidcTokenIssuer.js";
+import type { Sbom, SbomInput } from "./Sbom.js";
+import type { SigstoreSigner } from "./SigstoreSigner.js";
+
+/**
+ * Input for {@link Attest.sbom}.
+ *
+ * @remarks
+ * Callers supply EITHER `dependencies` (the existing path — the
+ * service builds a CycloneDX BOM from the resolved dependency graph)
+ * OR `bomDocument` (the new path — the caller hands in a pre-built
+ * BOM and the service attests it verbatim). The contract is "you give
+ * us the BOM, we attest it" — the library does not validate the
+ * BOM's NTIA fields, supplier completeness, or component shape on
+ * the `bomDocument` path.
+ *
+ * If neither field is provided, the live implementation falls back
+ * to building an empty-deps BOM and logs a debug warning. This keeps
+ * existing callers working mid-migration; new code should always
+ * supply one of the two fields.
+ *
+ * `dependencies` is widened to optional on this shape (vs the
+ * required `dependencies` on {@link SbomInput}) so callers can pick
+ * the `bomDocument` path without needing a dummy dependency list.
+ *
+ * @public
+ */
+export interface SbomAttestationInput extends Omit<SbomInput, "dependencies"> {
+	/**
+	 * Hex-encoded SHA-256 of the package tarball (or other artifact bytes)
+	 * the BOM describes. The runtime in-toto subject becomes
+	 * `pkg:npm/{rootName}@{rootVersion}` with this digest.
+	 */
+	readonly subjectSha256: string;
+	/**
+	 * Resolved direct dependencies of the root package. When provided,
+	 * the live implementation builds a CycloneDX BOM from the list and
+	 * attests it. Mutually exclusive with {@link bomDocument}.
+	 */
+	readonly dependencies?: SbomInput["dependencies"];
+	/**
+	 * Pre-built CycloneDX BOM document to attest verbatim. Used when the
+	 * caller (e.g. a publish orchestrator) has already generated the BOM
+	 * with full NTIA / supplier metadata via {@link Sbom.generate} and
+	 * just wants this service to wrap it in an in-toto envelope, sign it,
+	 * and POST it. Mutually exclusive with {@link dependencies}.
+	 */
+	readonly bomDocument?: Record<string, unknown>;
+}
+
+/**
+ * One entry in the {@link Attest.listForSubject} result.
+ *
+ * @public
+ */
+export interface AttestationListEntry {
+	/** GitHub UI URL for the attestation (`/{owner}/{repo}/attestations/{id}`). */
+	readonly attestationUrl: string;
+	/** Predicate type URI carried by the in-toto statement inside the bundle. */
+	readonly predicateType: string;
+}
+
+/**
+ * Input for {@link Attest.provenance}.
+ *
+ * @public
+ */
+export interface ProvenanceAttestationInput {
+	/** PURL or other in-toto subject name (e.g. `pkg:npm/@scope/pkg@1.0.0`). */
+	readonly subjectName: string;
+	/** Hex-encoded SHA-256 of the artifact. */
+	readonly subjectSha256: string;
+	/** SLSA Provenance v1 predicate (build-definition + run-details). */
+	readonly predicate: unknown;
+}
+
+/**
+ * Attest service surface. Implementation lives in {@link "./live.ts"}.
+ *
+ * @remarks
+ * The Effect signatures land incrementally; for step 1 only
+ * `buildStatement` and `save` are usable. The remaining members are
+ * declared up-front so consumers see the full API and tests can stub a
+ * complete service shape with `AttestTest.empty()`.
+ *
+ * @public
+ */
+export class Attest extends Context.Tag("github-action-effects/Attest")<
+	Attest,
+	{
+		/**
+		 * Build a {@link InTotoStatement} from subjects + predicate. Pure;
+		 * runs synchronously aside from the Effect wrapping.
+		 */
+		readonly buildStatement: (input: AttestInput) => Effect.Effect<InTotoStatement, AttestError>;
+
+		/**
+		 * Write an in-toto statement or Sigstore bundle to a local JSON
+		 * file. Used during development to inspect what would be uploaded.
+		 * Requires {@link FileSystem.FileSystem} so it composes with
+		 * `NodeFileSystem.layer` in production and `FileSystem`'s test
+		 * implementation in tests.
+		 */
+		readonly save: (
+			data: InTotoStatement | SigstoreBundle,
+			path: string,
+		) => Effect.Effect<void, AttestError, FileSystem.FileSystem>;
+
+		/**
+		 * Build a signed Sigstore bundle (no upload).
+		 *
+		 * @remarks
+		 * Delegates to {@link SigstoreSigner} which fetches an OIDC token
+		 * via {@link OidcTokenIssuer}, signs the in-toto statement through
+		 * Fulcio, and witnesses it on Rekor. The returned
+		 * {@link SigstoreBundle} is what the GitHub attestations API
+		 * accepts as the `bundle` field of the upload payload.
+		 */
+		readonly buildBundle: (
+			input: AttestInput,
+		) => Effect.Effect<SigstoreBundle, AttestError, SigstoreSigner | OidcTokenIssuer>;
+
+		/**
+		 * Full end-to-end attestation: build the in-toto statement, sign it
+		 * via {@link SigstoreSigner}, and POST the resulting Sigstore bundle
+		 * to `POST /repos/{owner}/{repo}/attestations`. Returns the local
+		 * statement + bundle plus the GitHub-issued attestation id and a
+		 * UI URL pointing at the attestation listing.
+		 */
+		readonly attest: (
+			input: AttestInput,
+		) => Effect.Effect<
+			import("../schemas/Attestation.js").AttestationRecord,
+			AttestError,
+			SigstoreSigner | OidcTokenIssuer | import("./GitHubClient.js").GitHubClient
+		>;
+
+		/**
+		 * Generate a CycloneDX SBOM, then attest the artifact with it as
+		 * the predicate ({@link CYCLONEDX_BOM} predicateType).
+		 *
+		 * @remarks
+		 * Composes {@link Sbom} (BOM generation) with {@link attest}
+		 * (sign + upload). The artifact subject is derived from
+		 * `rootName` + `rootVersion` + `subjectSha256` — that's the
+		 * identity GitHub records against the attestation.
+		 */
+		readonly sbom: (
+			input: SbomAttestationInput,
+		) => Effect.Effect<
+			import("../schemas/Attestation.js").AttestationRecord,
+			AttestError,
+			Sbom | SigstoreSigner | OidcTokenIssuer | import("./GitHubClient.js").GitHubClient
+		>;
+
+		/**
+		 * Attest an artifact with a caller-supplied SLSA Provenance v1
+		 * predicate.
+		 *
+		 * @remarks
+		 * The caller is responsible for assembling the SLSA predicate
+		 * (the runner's buildDefinition + runDetails); this method just
+		 * wraps it in the in-toto envelope and uploads.
+		 */
+		readonly provenance: (
+			input: ProvenanceAttestationInput,
+		) => Effect.Effect<
+			import("../schemas/Attestation.js").AttestationRecord,
+			AttestError,
+			SigstoreSigner | OidcTokenIssuer | import("./GitHubClient.js").GitHubClient
+		>;
+
+		/**
+		 * List existing attestations for a tarball digest.
+		 *
+		 * @remarks
+		 * Hits `GET /repos/{owner}/{repo}/attestations/sha256:{hex}`. The
+		 * GitHub REST API returns one entry per existing attestation; each
+		 * entry's Sigstore bundle is parsed to recover the in-toto
+		 * statement's `predicateType` (e.g. `https://slsa.dev/provenance/v1`
+		 * for provenance, `https://cyclonedx.org/bom` for SBOM).
+		 *
+		 * `options.predicateType` filters the result client-side so callers
+		 * can ask "is there a provenance attestation already?" or "is there
+		 * an SBOM attestation already?" without re-fetching. Returns an
+		 * empty array when the subject has no attestations or the API
+		 * returns a 404 — only true errors (auth, network, rate limit)
+		 * surface as {@link AttestError}.
+		 *
+		 * The orchestrator uses presence to decide whether to skip a
+		 * write — reuse the existing URL when found, otherwise call
+		 * {@link provenance} or {@link sbom} to write a fresh one. This
+		 * keeps recovery runs idempotent against the artifact attestation
+		 * store.
+		 *
+		 * @param subjectSha256 - Hex-encoded SHA-256 of the artifact (no
+		 *   `sha256:` prefix; the implementation adds it).
+		 * @param options - Optional client-side filter.
+		 */
+		readonly listForSubject: (
+			subjectSha256: string,
+			options?: { readonly predicateType?: string },
+		) => Effect.Effect<ReadonlyArray<AttestationListEntry>, AttestError, import("./GitHubClient.js").GitHubClient>;
+	}
+>() {}

--- a/src/services/Attest.wrappers.test.ts
+++ b/src/services/Attest.wrappers.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Step-6 tests for the Attest service: sbom + provenance wrappers.
+ *
+ * @remarks
+ * Exercises the two convenience methods by stubbing `SigstoreSigner`
+ * and capturing the in-toto statement that lands at the signing
+ * boundary. The full sign → upload chain is the same code path as
+ * `attest()` (covered in attest-end-to-end.test.ts), so these tests
+ * focus on the wrapper-specific behavior: subject construction,
+ * predicate type selection, and BOM-as-predicate composition.
+ */
+
+import { Effect, Layer } from "effect";
+import { describe, expect, it } from "vitest";
+import type { InTotoStatement } from "../testing.js";
+import {
+	Attest,
+	AttestLive,
+	CYCLONEDX_BOM,
+	GitHubClientTest,
+	OidcTokenIssuer,
+	SIGSTORE_BUNDLE_V0_3_MEDIA_TYPE,
+	SLSA_PROVENANCE_V1,
+	SbomLive,
+	SigstoreBundle,
+	SigstoreSigner,
+} from "../testing.js";
+
+interface SignerCalls {
+	statements: InTotoStatement[];
+}
+
+const stubBundle = (): SigstoreBundle =>
+	new SigstoreBundle({
+		mediaType: SIGSTORE_BUNDLE_V0_3_MEDIA_TYPE,
+		verificationMaterial: { tlogEntries: [] },
+		dsseEnvelope: {
+			payload: "base64-payload",
+			payloadType: "application/vnd.in-toto+json",
+			signatures: [{ sig: "stub-sig", keyid: "" }],
+		},
+	});
+
+const stubSignerLayer = (calls: SignerCalls): Layer.Layer<SigstoreSigner> =>
+	Layer.succeed(SigstoreSigner, {
+		signStatement: (statement) =>
+			Effect.sync(() => {
+				calls.statements.push(statement);
+				return stubBundle();
+			}),
+	});
+
+const noopOidcLayer: Layer.Layer<OidcTokenIssuer> = Layer.succeed(OidcTokenIssuer, {
+	getToken: () => Effect.die("OidcTokenIssuer should not be reached when SigstoreSigner is stubbed"),
+});
+
+const githubClientLayer = GitHubClientTest.layer({
+	restResponses: new Map([["repos.createAttestation", { data: 7 }]]),
+	graphqlResponses: new Map(),
+	paginateResponses: new Map(),
+	repo: { owner: "savvy-web", repo: "silk-integration" },
+});
+
+describe("Attest.sbom — step 6", () => {
+	it("attaches a CycloneDX BOM as predicate and uses CYCLONEDX_BOM predicateType", async () => {
+		const calls: SignerCalls = { statements: [] };
+		const layer = Layer.mergeAll(AttestLive, SbomLive, stubSignerLayer(calls), noopOidcLayer, githubClientLayer);
+
+		const record = await Effect.runPromise(
+			Effect.gen(function* () {
+				const attest = yield* Attest;
+				return yield* attest.sbom({
+					rootName: "@savvy-web/example",
+					rootVersion: "1.0.0",
+					rootLicense: "MIT",
+					subjectSha256: "a".repeat(64),
+					dependencies: [
+						{ name: "lodash", version: "4.17.21", license: "MIT" },
+						{ name: "@savvy-web/package-2", version: "0.9.0" },
+					],
+					inFlightPackages: [{ name: "@savvy-web/package-2", version: "1.0.0", license: "MIT" }],
+				});
+			}).pipe(Effect.provide(layer)),
+		);
+
+		expect(record.attestationId).toBe(7);
+		expect(record.attestationUrl).toBe("https://github.com/savvy-web/silk-integration/attestations/7");
+
+		expect(calls.statements).toHaveLength(1);
+		const statement = calls.statements[0];
+		expect(statement.predicateType).toBe(CYCLONEDX_BOM);
+		expect(statement.subject).toHaveLength(1);
+		expect(statement.subject[0].name).toBe("pkg:npm/@savvy-web/example@1.0.0");
+		expect(statement.subject[0].digest).toEqual({ sha256: "a".repeat(64) });
+
+		const predicate = statement.predicate as {
+			bomFormat: string;
+			specVersion: string;
+			components: Array<{ name: string; version: string }>;
+		};
+		expect(predicate.bomFormat).toBe("CycloneDX");
+		expect(predicate.specVersion).toBe("1.5");
+		const sibling = predicate.components.find((c) => c.name === "@savvy-web/package-2");
+		expect(sibling?.version).toBe("1.0.0");
+	});
+});
+
+describe("Attest.provenance — step 6", () => {
+	it("wraps a caller-supplied SLSA predicate with SLSA_PROVENANCE_V1 predicateType", async () => {
+		const calls: SignerCalls = { statements: [] };
+		const layer = Layer.mergeAll(AttestLive, stubSignerLayer(calls), noopOidcLayer, githubClientLayer);
+
+		const slsaPredicate = {
+			buildDefinition: {
+				buildType: "https://github.com/savvy-web/workflow-release-action/release/v1",
+				externalParameters: { workflow: { ref: "refs/heads/main" } },
+			},
+			runDetails: {
+				builder: { id: "https://github.com/actions/runner" },
+				metadata: { invocationId: "abc-123" },
+			},
+		};
+
+		const record = await Effect.runPromise(
+			Effect.gen(function* () {
+				const attest = yield* Attest;
+				return yield* attest.provenance({
+					subjectName: "pkg:npm/@savvy-web/example@1.0.0",
+					subjectSha256: "b".repeat(64),
+					predicate: slsaPredicate,
+				});
+			}).pipe(Effect.provide(layer)),
+		);
+
+		expect(record.attestationId).toBe(7);
+
+		expect(calls.statements).toHaveLength(1);
+		const statement = calls.statements[0];
+		expect(statement.predicateType).toBe(SLSA_PROVENANCE_V1);
+		expect(statement.subject[0].name).toBe("pkg:npm/@savvy-web/example@1.0.0");
+		expect(statement.subject[0].digest).toEqual({ sha256: "b".repeat(64) });
+		expect(statement.predicate).toEqual(slsaPredicate);
+	});
+
+	it("strips a leading sha256: prefix from the digest", async () => {
+		const calls: SignerCalls = { statements: [] };
+		const layer = Layer.mergeAll(AttestLive, stubSignerLayer(calls), noopOidcLayer, githubClientLayer);
+
+		await Effect.runPromise(
+			Effect.gen(function* () {
+				const attest = yield* Attest;
+				return yield* attest.provenance({
+					subjectName: "pkg:npm/x@1.0.0",
+					subjectSha256: `sha256:${"c".repeat(64)}`,
+					predicate: { buildDefinition: {}, runDetails: {} },
+				});
+			}).pipe(Effect.provide(layer)),
+		);
+
+		expect(calls.statements[0].subject[0].digest).toEqual({ sha256: "c".repeat(64) });
+	});
+});

--- a/src/services/CheckRun.test.ts
+++ b/src/services/CheckRun.test.ts
@@ -26,8 +26,8 @@ describe("CheckRun", () => {
 	describe("create", () => {
 		it("creates a check run and returns an ID", async () => {
 			const state = CheckRunTest.empty();
-			const id = await run(state, create("lint", "abc123"));
-			expect(id).toBe(1);
+			const data = await run(state, create("lint", "abc123"));
+			expect(data.id).toBe(1);
 			expect(state.runs).toHaveLength(1);
 			expect(state.runs[0]).toMatchObject({
 				id: 1,
@@ -39,10 +39,18 @@ describe("CheckRun", () => {
 
 		it("assigns incrementing IDs", async () => {
 			const state = CheckRunTest.empty();
-			const id1 = await run(state, create("lint", "abc"));
-			const id2 = await run(state, create("test", "def"));
-			expect(id2).toBe(id1 + 1);
+			const data1 = await run(state, create("lint", "abc"));
+			const data2 = await run(state, create("test", "def"));
+			expect(data2.id).toBe(data1.id + 1);
 			expect(state.runs).toHaveLength(2);
+		});
+
+		it("returns CheckRunData with htmlUrl", async () => {
+			const state = CheckRunTest.empty();
+			const data = await run(state, create("build", "sha1"));
+			expect(data.htmlUrl).toBe("https://github.com/test/checks/1");
+			expect(data.status).toBe("in_progress");
+			expect(data.conclusion).toBeNull();
 		});
 	});
 
@@ -63,8 +71,8 @@ describe("CheckRun", () => {
 				state,
 				Effect.gen(function* () {
 					const svc = yield* CheckRun;
-					const id = yield* svc.create("lint", "abc123");
-					yield* svc.update(id, { title: "Results", summary: "All good" });
+					const checkRun = yield* svc.create("lint", "abc123");
+					yield* svc.update(checkRun.id, { title: "Results", summary: "All good" });
 				}),
 			);
 			expect(state.runs[0].outputs).toHaveLength(1);
@@ -80,9 +88,9 @@ describe("CheckRun", () => {
 				state,
 				Effect.gen(function* () {
 					const svc = yield* CheckRun;
-					const id = yield* svc.create("lint", "abc123");
-					yield* svc.update(id, { title: "Step 1", summary: "Done" });
-					yield* svc.update(id, { title: "Step 2", summary: "Done" });
+					const checkRun = yield* svc.create("lint", "abc123");
+					yield* svc.update(checkRun.id, { title: "Step 1", summary: "Done" });
+					yield* svc.update(checkRun.id, { title: "Step 2", summary: "Done" });
 				}),
 			);
 			expect(state.runs[0].outputs).toHaveLength(2);
@@ -105,8 +113,8 @@ describe("CheckRun", () => {
 				state,
 				Effect.gen(function* () {
 					const svc = yield* CheckRun;
-					const id = yield* svc.create("lint", "abc123");
-					yield* svc.complete(id, "success");
+					const checkRun = yield* svc.create("lint", "abc123");
+					yield* svc.complete(checkRun.id, "success");
 				}),
 			);
 			expect(state.runs[0].status).toBe("completed");
@@ -119,8 +127,8 @@ describe("CheckRun", () => {
 				state,
 				Effect.gen(function* () {
 					const svc = yield* CheckRun;
-					const id = yield* svc.create("lint", "abc123");
-					yield* svc.complete(id, "failure", { title: "Failed", summary: "2 errors" });
+					const checkRun = yield* svc.create("lint", "abc123");
+					yield* svc.complete(checkRun.id, "failure", { title: "Failed", summary: "2 errors" });
 				}),
 			);
 			expect(state.runs[0].conclusion).toBe("failure");

--- a/src/services/CheckRun.ts
+++ b/src/services/CheckRun.ts
@@ -50,6 +50,19 @@ export interface CheckRunOutput {
 }
 
 /**
+ * Data describing a check run.
+ *
+ * @public
+ */
+export interface CheckRunData {
+	readonly id: number;
+	readonly name: string;
+	readonly status: "queued" | "in_progress" | "completed";
+	readonly conclusion: CheckRunConclusion | null;
+	readonly htmlUrl: string;
+}
+
+/**
  * Service for GitHub check run operations.
  *
  * @public
@@ -57,8 +70,11 @@ export interface CheckRunOutput {
 export class CheckRun extends Context.Tag("github-action-effects/CheckRun")<
 	CheckRun,
 	{
-		/** Create a new check run. Returns the check run ID. */
-		readonly create: (name: string, headSha: string) => Effect.Effect<number, CheckRunError>;
+		/** Create a new check run. Returns the created check run. */
+		readonly create: (name: string, headSha: string) => Effect.Effect<CheckRunData, CheckRunError>;
+
+		/** Get a check run by id. */
+		readonly get: (checkRunId: number) => Effect.Effect<CheckRunData, CheckRunError>;
 
 		/** Update an in-progress check run with output. */
 		readonly update: (checkRunId: number, output: CheckRunOutput) => Effect.Effect<void, CheckRunError>;

--- a/src/services/GitHubArtifactMetadata.ts
+++ b/src/services/GitHubArtifactMetadata.ts
@@ -1,0 +1,41 @@
+import type { Effect } from "effect";
+import { Context } from "effect";
+import type { GitHubArtifactMetadataError } from "../errors/GitHubArtifactMetadataError.js";
+
+/**
+ * Input for creating a GitHub Packages artifact-metadata storage record.
+ *
+ * @public
+ */
+export interface StorageRecordInput {
+	/** Package URL (purl), e.g. `"pkg:npm/@scope/pkg@1.2.3"`. */
+	readonly name: string;
+	/** Artifact digest. */
+	readonly digest: string;
+	/** Package version. */
+	readonly version: string;
+	/** Registry URL, e.g. `"https://npm.pkg.github.com/"`. */
+	readonly registryUrl: string;
+	/** The artifact's GitHub Packages URL. */
+	readonly artifactUrl: string;
+	/** Unscoped package / repo name. */
+	readonly repo: string;
+}
+
+/**
+ * Service for GitHub Packages artifact-metadata operations.
+ *
+ * @public
+ */
+export class GitHubArtifactMetadata extends Context.Tag("github-action-effects/GitHubArtifactMetadata")<
+	GitHubArtifactMetadata,
+	{
+		/**
+		 * Create an artifact-metadata storage record linking an attestation to a
+		 * published GitHub Packages artifact. Returns the created record IDs.
+		 */
+		readonly createStorageRecord: (
+			input: StorageRecordInput,
+		) => Effect.Effect<ReadonlyArray<number>, GitHubArtifactMetadataError>;
+	}
+>() {}

--- a/src/services/GitHubCommit.ts
+++ b/src/services/GitHubCommit.ts
@@ -1,0 +1,67 @@
+import type { Effect } from "effect";
+import { Context } from "effect";
+import type { GitHubCommitError } from "../errors/GitHubCommitError.js";
+
+/**
+ * A commit summary as returned by list and compare.
+ *
+ * @public
+ */
+export interface CommitSummary {
+	readonly sha: string;
+	readonly message: string;
+	readonly author: string;
+}
+
+/**
+ * A single commit with its parent SHAs.
+ *
+ * @public
+ */
+export interface CommitDetail extends CommitSummary {
+	readonly parents: ReadonlyArray<{ readonly sha: string }>;
+}
+
+/**
+ * A file changed between two commits/refs.
+ *
+ * @public
+ */
+export interface CommitFile {
+	readonly filename: string;
+	readonly status: string;
+}
+
+/**
+ * Result of comparing two commits/refs (base...head).
+ *
+ * @public
+ */
+export interface CommitComparison {
+	readonly commits: ReadonlyArray<CommitSummary>;
+	readonly files: ReadonlyArray<CommitFile>;
+}
+
+/**
+ * Service for reading the GitHub commit graph.
+ *
+ * @remarks
+ * Distinct from `GitCommit`, which wraps the local `git` CLI. This service
+ * wraps the GitHub REST API (`repos.getCommit` / `listCommits` /
+ * `compareCommits`).
+ *
+ * @public
+ */
+export class GitHubCommit extends Context.Tag("github-action-effects/GitHubCommit")<
+	GitHubCommit,
+	{
+		/** Get a single commit by ref (SHA or branch name). */
+		readonly get: (ref: string) => Effect.Effect<CommitDetail, GitHubCommitError>;
+
+		/** List commits reachable from a ref, paginated. */
+		readonly list: (ref: string) => Effect.Effect<ReadonlyArray<CommitSummary>, GitHubCommitError>;
+
+		/** Compare two commits/refs; returns the commits and changed files between base and head. */
+		readonly compare: (base: string, head: string) => Effect.Effect<CommitComparison, GitHubCommitError>;
+	}
+>() {}

--- a/src/services/GitHubContent.ts
+++ b/src/services/GitHubContent.ts
@@ -1,0 +1,22 @@
+import type { Effect } from "effect";
+import { Context } from "effect";
+import type { GitHubContentError } from "../errors/GitHubContentError.js";
+
+/**
+ * Service for reading repository file contents.
+ *
+ * @public
+ */
+export class GitHubContent extends Context.Tag("github-action-effects/GitHubContent")<
+	GitHubContent,
+	{
+		/**
+		 * Read a file's decoded UTF-8 contents at a ref.
+		 *
+		 * `ref` is optional; when omitted the repository's default branch is used.
+		 * Fails with `GitHubContentError` when the path does not resolve to a file
+		 * (missing, a directory, or a submodule).
+		 */
+		readonly getFile: (path: string, ref?: string) => Effect.Effect<string, GitHubContentError>;
+	}
+>() {}

--- a/src/services/GitHubIssue.ts
+++ b/src/services/GitHubIssue.ts
@@ -12,6 +12,10 @@ export interface IssueData {
 	readonly title: string;
 	readonly state: string;
 	readonly labels: Array<string>;
+	/** The issue's HTML URL. */
+	readonly htmlUrl?: string;
+	/** The issue's GraphQL node id. */
+	readonly nodeId?: string;
 }
 
 /**
@@ -39,6 +43,9 @@ export class GitHubIssue extends Context.Tag("github-action-effects/GitHubIssue"
 
 		/** Add a comment to an issue. */
 		readonly comment: (issueNumber: number, body: string) => Effect.Effect<{ id: number }, GitHubIssueError>;
+
+		/** Get a single issue by number. */
+		readonly get: (issueNumber: number) => Effect.Effect<IssueData, GitHubIssueError>;
 
 		/** Get issues linked to a pull request via closing references. */
 		readonly getLinkedIssues: (

--- a/src/services/GitHubRelease.ts
+++ b/src/services/GitHubRelease.ts
@@ -63,5 +63,19 @@ export class GitHubRelease extends Context.Tag("github-action-effects/GitHubRele
 			readonly perPage?: number;
 			readonly maxPages?: number;
 		}) => Effect.Effect<Array<ReleaseData>, GitHubReleaseError>;
+
+		/** Update an existing release's fields; returns the updated release. */
+		readonly updateRelease: (
+			releaseId: number,
+			options: {
+				readonly body?: string;
+				readonly name?: string;
+				readonly draft?: boolean;
+				readonly prerelease?: boolean;
+			},
+		) => Effect.Effect<ReleaseData, GitHubReleaseError>;
+
+		/** List all assets attached to a release. */
+		readonly listReleaseAssets: (releaseId: number) => Effect.Effect<Array<ReleaseAsset>, GitHubReleaseError>;
 	}
 >() {}

--- a/src/services/GitTag.ts
+++ b/src/services/GitTag.ts
@@ -3,12 +3,16 @@ import { Context } from "effect";
 import type { GitTagError } from "../errors/GitTagError.js";
 
 /**
- * A tag name and the SHA it points to.
+ * A tag name and the commit SHA it resolves to.
  *
  * @public
  */
 export interface TagRef {
 	readonly tag: string;
+	/**
+	 * The commit SHA the tag resolves to. Annotated tags are dereferenced,
+	 * so this is always a commit SHA — never a raw tag-object SHA.
+	 */
 	readonly sha: string;
 }
 
@@ -29,7 +33,7 @@ export class GitTag extends Context.Tag("github-action-effects/GitTag")<
 		/** List tags, optionally filtered by prefix. */
 		readonly list: (prefix?: string) => Effect.Effect<Array<TagRef>, GitTagError>;
 
-		/** Resolve a tag to its SHA. */
+		/** Resolve a tag to its commit SHA, dereferencing annotated tags. */
 		readonly resolve: (tag: string) => Effect.Effect<string, GitTagError>;
 	}
 >() {}

--- a/src/services/NpmRegistry.ts
+++ b/src/services/NpmRegistry.ts
@@ -1,4 +1,4 @@
-import type { Effect } from "effect";
+import type { Effect, Option } from "effect";
 import { Context } from "effect";
 import type { NpmRegistryError } from "../errors/NpmRegistryError.js";
 import type { NpmPackageInfo } from "../schemas/NpmPackage.js";
@@ -13,7 +13,52 @@ export class NpmRegistry extends Context.Tag("github-action-effects/NpmRegistry"
 	{
 		readonly getLatestVersion: (pkg: string) => Effect.Effect<string, NpmRegistryError>;
 		readonly getDistTags: (pkg: string) => Effect.Effect<Record<string, string>, NpmRegistryError>;
-		readonly getPackageInfo: (pkg: string, version?: string) => Effect.Effect<NpmPackageInfo, NpmRegistryError>;
-		readonly getVersions: (pkg: string) => Effect.Effect<Array<string>, NpmRegistryError>;
+		/**
+		 * Fetch package metadata.
+		 *
+		 * @param pkg - Package name.
+		 * @param version - Optional specific version; omitted reads the
+		 *   distribution's `latest`.
+		 * @param options - Optional overrides. When `registry` is supplied
+		 *   the underlying `npm view` invocation appends
+		 *   `--registry <registry>`; otherwise npm's default registry is used.
+		 */
+		readonly getPackageInfo: (
+			pkg: string,
+			version?: string,
+			options?: { readonly registry?: string },
+		) => Effect.Effect<NpmPackageInfo, NpmRegistryError>;
+		/**
+		 * List published versions.
+		 *
+		 * @param pkg - Package name.
+		 * @param options - Optional overrides. When `registry` is supplied
+		 *   the underlying `npm view` invocation appends
+		 *   `--registry <registry>`; otherwise npm's default registry is used.
+		 */
+		readonly getVersions: (
+			pkg: string,
+			options?: { readonly registry?: string },
+		) => Effect.Effect<Array<string>, NpmRegistryError>;
+		/**
+		 * Probe a specific registry for the published integrity hash of a
+		 * package version. Returns `Option.some(integrity)` when the version
+		 * is on that registry with a `dist.integrity` value, and
+		 * `Option.none()` when the version is not published there (collapses
+		 * an `npm view` E404 into "not present" rather than an error, since
+		 * a missing version is a normal branch of the publish flow). Other
+		 * failures (network, auth, malformed JSON) propagate as
+		 * `NpmRegistryError`.
+		 *
+		 * @param pkg - Package name.
+		 * @param version - Specific version to probe.
+		 * @param options - Required registry override; the probe always
+		 *   targets a specific registry rather than npm's default.
+		 */
+		readonly getPublishedIntegrity: (
+			pkg: string,
+			version: string,
+			options: { readonly registry: string },
+		) => Effect.Effect<Option.Option<string>, NpmRegistryError>;
 	}
 >() {}

--- a/src/services/OidcTokenIssuer.test.ts
+++ b/src/services/OidcTokenIssuer.test.ts
@@ -1,0 +1,229 @@
+/**
+ * Step-2 tests for the Attest service: OIDC token issuer.
+ *
+ * @remarks
+ * Drives `OidcTokenIssuerLive` against a mocked `HttpClient` so we can
+ * exercise the env-var, transport, and decode error paths without
+ * hitting the real GitHub Actions token endpoint.
+ */
+
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { FileSystem } from "@effect/platform";
+import { HttpClient, HttpClientResponse } from "@effect/platform";
+import { NodeFileSystem } from "@effect/platform-node";
+import { Effect, Exit, Layer, Redacted } from "effect";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { OidcTokenError, OidcTokenIssuer, OidcTokenIssuerLive, saveToken } from "../testing.js";
+
+interface MockResponse {
+	readonly status: number;
+	readonly body: string;
+}
+
+const mockHttpClient = (
+	respond: (url: string, headers: Record<string, string>) => MockResponse,
+): Layer.Layer<HttpClient.HttpClient> =>
+	Layer.succeed(
+		HttpClient.HttpClient,
+		HttpClient.make((request, url) =>
+			Effect.sync(() => {
+				const headers: Record<string, string> = {};
+				for (const [k, v] of Object.entries(request.headers)) {
+					if (typeof v === "string") headers[k.toLowerCase()] = v;
+				}
+				const { status, body } = respond(url.toString(), headers);
+				return HttpClientResponse.fromWeb(
+					request,
+					new Response(body, { status, headers: { "content-type": "application/json" } }),
+				);
+			}),
+		),
+	);
+
+const withEnv = <A, E, R>(
+	env: Record<string, string | undefined>,
+	effect: Effect.Effect<A, E, R>,
+): Effect.Effect<A, E, R> =>
+	Effect.acquireUseRelease(
+		Effect.sync(() => {
+			const prev: Record<string, string | undefined> = {};
+			for (const [k, v] of Object.entries(env)) {
+				prev[k] = process.env[k];
+				if (v === undefined) delete process.env[k];
+				else process.env[k] = v;
+			}
+			return prev;
+		}),
+		() => effect,
+		(prev) =>
+			Effect.sync(() => {
+				for (const [k, v] of Object.entries(prev)) {
+					if (v === undefined) delete process.env[k];
+					else process.env[k] = v;
+				}
+			}),
+	);
+
+describe("OidcTokenIssuer — step 2: token issuance", () => {
+	let tmp: string;
+
+	beforeEach(() => {
+		tmp = mkdtempSync(join(tmpdir(), "attest-oidc-"));
+	});
+
+	afterEach(() => {
+		rmSync(tmp, { recursive: true, force: true });
+	});
+
+	describe("getToken", () => {
+		it("returns a redacted JWT on a successful request", async () => {
+			let capturedUrl = "";
+			let capturedAuth = "";
+			const http = mockHttpClient((url, headers) => {
+				capturedUrl = url;
+				capturedAuth = headers.authorization ?? "";
+				return { status: 200, body: JSON.stringify({ value: "header.payload.signature", count: 1 }) };
+			});
+
+			const program = Effect.gen(function* () {
+				const issuer = yield* OidcTokenIssuer;
+				return yield* issuer.getToken("sigstore");
+			});
+
+			const token = await Effect.runPromise(
+				withEnv(
+					{
+						ACTIONS_ID_TOKEN_REQUEST_TOKEN: "runner-bearer-token",
+						ACTIONS_ID_TOKEN_REQUEST_URL: "https://token.actions.githubusercontent.com/foo?api-version=2.0",
+					},
+					program.pipe(Effect.provide(Layer.provide(OidcTokenIssuerLive, http))),
+				),
+			);
+
+			expect(Redacted.value(token)).toBe("header.payload.signature");
+			expect(capturedUrl).toBe("https://token.actions.githubusercontent.com/foo?api-version=2.0&audience=sigstore");
+			expect(capturedAuth).toBe("Bearer runner-bearer-token");
+		});
+
+		it("fails with `reason: env` when ACTIONS_ID_TOKEN_REQUEST_TOKEN is missing", async () => {
+			const http = mockHttpClient(() => ({ status: 200, body: JSON.stringify({ value: "x" }) }));
+
+			const program = Effect.gen(function* () {
+				const issuer = yield* OidcTokenIssuer;
+				return yield* issuer.getToken("sigstore");
+			});
+
+			const exit = await Effect.runPromise(
+				withEnv(
+					{
+						ACTIONS_ID_TOKEN_REQUEST_TOKEN: undefined,
+						ACTIONS_ID_TOKEN_REQUEST_URL: "https://token.example/",
+					},
+					program.pipe(Effect.provide(Layer.provide(OidcTokenIssuerLive, http)), Effect.exit),
+				),
+			);
+
+			expect(Exit.isFailure(exit)).toBe(true);
+			if (Exit.isFailure(exit)) {
+				const cause = JSON.stringify(exit.cause);
+				expect(cause).toContain("ACTIONS_ID_TOKEN_REQUEST_TOKEN");
+				expect(cause).toContain('"reason":"env"');
+			}
+		});
+
+		it("fails with `reason: env` when ACTIONS_ID_TOKEN_REQUEST_URL is missing", async () => {
+			const http = mockHttpClient(() => ({ status: 200, body: JSON.stringify({ value: "x" }) }));
+
+			const exit = await Effect.runPromise(
+				withEnv(
+					{
+						ACTIONS_ID_TOKEN_REQUEST_TOKEN: "tok",
+						ACTIONS_ID_TOKEN_REQUEST_URL: undefined,
+					},
+					Effect.gen(function* () {
+						const issuer = yield* OidcTokenIssuer;
+						return yield* issuer.getToken("sigstore");
+					}).pipe(Effect.provide(Layer.provide(OidcTokenIssuerLive, http)), Effect.exit),
+				),
+			);
+
+			expect(Exit.isFailure(exit)).toBe(true);
+			if (Exit.isFailure(exit)) {
+				expect(JSON.stringify(exit.cause)).toContain("ACTIONS_ID_TOKEN_REQUEST_URL");
+			}
+		});
+
+		it("fails with `reason: http` on a non-2xx response", async () => {
+			const http = mockHttpClient(() => ({ status: 403, body: '{"message":"Forbidden"}' }));
+
+			const exit = await Effect.runPromise(
+				withEnv(
+					{
+						ACTIONS_ID_TOKEN_REQUEST_TOKEN: "tok",
+						ACTIONS_ID_TOKEN_REQUEST_URL: "https://token.example/",
+					},
+					Effect.gen(function* () {
+						const issuer = yield* OidcTokenIssuer;
+						return yield* issuer.getToken("sigstore");
+					}).pipe(Effect.provide(Layer.provide(OidcTokenIssuerLive, http)), Effect.exit),
+				),
+			);
+
+			expect(Exit.isFailure(exit)).toBe(true);
+			if (Exit.isFailure(exit)) {
+				const cause = JSON.stringify(exit.cause);
+				expect(cause).toContain('"reason":"http"');
+				expect(cause).toContain("403");
+				expect(cause).toContain("Forbidden");
+			}
+		});
+
+		it("fails with `reason: decode` when the response shape is wrong", async () => {
+			const http = mockHttpClient(() => ({ status: 200, body: '{"not_value": "oops"}' }));
+
+			const exit = await Effect.runPromise(
+				withEnv(
+					{
+						ACTIONS_ID_TOKEN_REQUEST_TOKEN: "tok",
+						ACTIONS_ID_TOKEN_REQUEST_URL: "https://token.example/",
+					},
+					Effect.gen(function* () {
+						const issuer = yield* OidcTokenIssuer;
+						return yield* issuer.getToken("sigstore");
+					}).pipe(Effect.provide(Layer.provide(OidcTokenIssuerLive, http)), Effect.exit),
+				),
+			);
+
+			expect(Exit.isFailure(exit)).toBe(true);
+			if (Exit.isFailure(exit)) {
+				expect(JSON.stringify(exit.cause)).toContain('"reason":"decode"');
+			}
+		});
+
+		it("error class is OidcTokenError with the correct _tag", () => {
+			const err = new OidcTokenError({ reason: "env", message: "x" });
+			expect(err._tag).toBe("OidcTokenError");
+			expect(err.reason).toBe("env");
+		});
+	});
+
+	describe("saveToken", () => {
+		it("writes the redacted JWT to disk as JSON", async () => {
+			const outPath = join(tmp, "token.json");
+			const token = Redacted.make("eyJhbGciOiJSUzI1NiJ9.payload.sig");
+
+			await Effect.runPromise(
+				saveToken(token, outPath).pipe(
+					Effect.provide(NodeFileSystem.layer) as <A, E>(
+						eff: Effect.Effect<A, E, FileSystem.FileSystem>,
+					) => Effect.Effect<A, E>,
+				),
+			);
+
+			const parsed = JSON.parse(readFileSync(outPath, "utf-8"));
+			expect(parsed.token).toBe("eyJhbGciOiJSUzI1NiJ9.payload.sig");
+		});
+	});
+});

--- a/src/services/OidcTokenIssuer.ts
+++ b/src/services/OidcTokenIssuer.ts
@@ -1,0 +1,26 @@
+import type { Effect, Redacted } from "effect";
+import { Context } from "effect";
+import type { OidcTokenError } from "../errors/OidcTokenError.js";
+
+/**
+ * OIDC token issuer service surface.
+ *
+ * @remarks
+ * Fetches an OIDC ID token from the GitHub Actions token service. The
+ * runner exposes `ACTIONS_ID_TOKEN_REQUEST_TOKEN` and
+ * `ACTIONS_ID_TOKEN_REQUEST_URL` when a workflow has `id-token: write`.
+ *
+ * @public
+ */
+export class OidcTokenIssuer extends Context.Tag("github-action-effects/OidcTokenIssuer")<
+	OidcTokenIssuer,
+	{
+		/**
+		 * Request an OIDC ID token from the GitHub Actions token service.
+		 *
+		 * @param audience - The `aud` claim to encode in the JWT
+		 *   (e.g. `"sigstore"` for Fulcio cert issuance).
+		 */
+		readonly getToken: (audience: string) => Effect.Effect<Redacted.Redacted<string>, OidcTokenError>;
+	}
+>() {}

--- a/src/services/PackagePublish.test.ts
+++ b/src/services/PackagePublish.test.ts
@@ -1,4 +1,4 @@
-import { Effect } from "effect";
+import { Effect, Exit } from "effect";
 import { describe, expect, it } from "vitest";
 import { PackagePublishTest } from "../layers/PackagePublishTest.js";
 import { PackagePublish } from "./PackagePublish.js";
@@ -15,9 +15,18 @@ describe("PackagePublish", () => {
 		expect(state.setupAuthCalls).toEqual([{ registry: "npm.pkg.github.com", token: "ghp_abc123" }]);
 	});
 
-	it("pack returns tarball and digest", async () => {
+	it("pack returns tarballPath, digest, and pack metadata", async () => {
 		const { state, layer } = PackagePublishTest.layer({
-			packResult: { tarball: "my-pkg-2.0.0.tgz", digest: "sha256-def456" },
+			packResult: {
+				tarballPath: "/path/to/pkg/my-pkg-2.0.0.tgz",
+				digest: "sha512-def456",
+				sha256Hex: "abc123abc123abc123abc123abc123abc123abc123abc123abc123abc123abc1",
+				name: "my-pkg",
+				version: "2.0.0",
+				packedSize: 1234,
+				unpackedSize: 5678,
+				fileCount: 9,
+			},
 		});
 		const result = await Effect.runPromise(
 			PackagePublish.pipe(
@@ -25,7 +34,16 @@ describe("PackagePublish", () => {
 				Effect.provide(layer),
 			),
 		);
-		expect(result).toEqual({ tarball: "my-pkg-2.0.0.tgz", digest: "sha256-def456" });
+		expect(result).toEqual({
+			tarballPath: "/path/to/pkg/my-pkg-2.0.0.tgz",
+			digest: "sha512-def456",
+			sha256Hex: "abc123abc123abc123abc123abc123abc123abc123abc123abc123abc123abc1",
+			name: "my-pkg",
+			version: "2.0.0",
+			packedSize: 1234,
+			unpackedSize: 5678,
+			fileCount: 9,
+		});
 		expect(state.packCalls).toEqual([{ packageDir: "/path/to/pkg" }]);
 	});
 
@@ -80,5 +98,94 @@ describe("PackagePublish", () => {
 			),
 		);
 		expect(state.publishToRegistriesCalls).toEqual([{ packageDir: "/path/to/pkg", registries }]);
+	});
+
+	it("publishIdempotent publishes when the version is absent", async () => {
+		const { state, layer } = PackagePublishTest.layer({ publishedVersions: [] });
+		const result = await Effect.runPromise(
+			PackagePublish.pipe(
+				Effect.flatMap((svc) =>
+					svc.publishIdempotent({
+						packageDir: "/pkg",
+						packageName: "my-pkg",
+						version: "1.0.0",
+						digest: "sha512-abc",
+					}),
+				),
+				Effect.provide(layer),
+			),
+		);
+		expect(result).toEqual({ status: "published", packageName: "my-pkg", version: "1.0.0" });
+		expect(state.publishIdempotentCalls).toHaveLength(1);
+	});
+
+	it("publishIdempotent skips when an identical version is already published", async () => {
+		const { layer } = PackagePublishTest.layer({ publishedVersions: ["1.0.0"], integrityMatch: true });
+		const result = await Effect.runPromise(
+			PackagePublish.pipe(
+				Effect.flatMap((svc) =>
+					svc.publishIdempotent({
+						packageDir: "/pkg",
+						packageName: "my-pkg",
+						version: "1.0.0",
+						digest: "sha512-abc",
+					}),
+				),
+				Effect.provide(layer),
+			),
+		);
+		expect(result).toEqual({
+			status: "skipped",
+			packageName: "my-pkg",
+			version: "1.0.0",
+			skipReason: "already-published-identical",
+		});
+	});
+
+	it("publishIdempotent fails on a content mismatch", async () => {
+		const { layer } = PackagePublishTest.layer({ publishedVersions: ["1.0.0"], integrityMatch: false });
+		const exit = await Effect.runPromiseExit(
+			PackagePublish.pipe(
+				Effect.flatMap((svc) =>
+					svc.publishIdempotent({
+						packageDir: "/pkg",
+						packageName: "my-pkg",
+						version: "1.0.0",
+						digest: "sha512-wrong",
+					}),
+				),
+				Effect.provide(layer),
+			),
+		);
+		expect(Exit.isFailure(exit)).toBe(true);
+	});
+
+	it("dryRun returns ok: true by default and records the call", async () => {
+		const { state, layer } = PackagePublishTest.empty();
+		const result = await Effect.runPromise(
+			PackagePublish.pipe(
+				Effect.flatMap((svc) => svc.dryRun("/path/to/pkg", { registry: "https://registry.npmjs.org" })),
+				Effect.provide(layer),
+			),
+		);
+		expect(result.ok).toBe(true);
+		expect(result.output).toBe("dry-run ok");
+		expect(state.dryRunCalls).toEqual([
+			{ packageDir: "/path/to/pkg", options: { registry: "https://registry.npmjs.org" } },
+		]);
+	});
+
+	it("dryRun returns ok: false when dryRunOk is false", async () => {
+		const { state, layer } = PackagePublishTest.layer({ dryRunOk: false });
+		const result = await Effect.runPromise(
+			PackagePublish.pipe(
+				Effect.flatMap((svc) => svc.dryRun("/path/to/pkg")),
+				Effect.provide(layer),
+			),
+		);
+		expect(result.ok).toBe(false);
+		expect(result.output).toBe("dry-run failed");
+		expect(state.dryRunCalls).toHaveLength(1);
+		expect(state.dryRunCalls[0]?.packageDir).toBe("/path/to/pkg");
 	});
 });

--- a/src/services/PackagePublish.ts
+++ b/src/services/PackagePublish.ts
@@ -3,13 +3,45 @@ import { Context } from "effect";
 import type { PackagePublishError } from "../errors/PackagePublishError.js";
 
 /**
- * Result of packing a package.
+ * Result of packing a package directory into a tarball.
+ *
+ * @remarks
+ * `digest` is in the integrity format `sha512-<base64>` — the same shape
+ * the registry stores as `dist.integrity` — so a direct string compare
+ * against the value returned by {@link NpmRegistry.getPublishedIntegrity}
+ * tells the orchestrator whether the local tarball matches the
+ * already-published one.
  *
  * @public
  */
 export interface PackResult {
-	readonly tarball: string;
+	/** Absolute path to the packed tarball on disk. */
+	readonly tarballPath: string;
+	/**
+	 * Integrity digest of the tarball, in npm's `dist.integrity` format
+	 * (`sha512-<base64>`). Sourced from `npm pack --json`'s emitted
+	 * `integrity` field rather than recomputed locally so the value
+	 * matches byte-for-byte what the registry would store.
+	 */
 	readonly digest: string;
+	/**
+	 * SHA-256 of the tarball, as a lowercase hex string (no `sha256:`
+	 * prefix). Computed locally from {@link tarballPath}. This is the
+	 * digest format the GitHub artifact-metadata and attestation APIs
+	 * accept as the subject. It is NOT interchangeable with {@link digest}:
+	 * different algorithm, different encoding.
+	 */
+	readonly sha256Hex: string;
+	/** Package name as reported by `npm pack --json`. */
+	readonly name: string;
+	/** Package version as reported by `npm pack --json`. */
+	readonly version: string;
+	/** Tarball size on disk, in bytes (`size` from `npm pack --json`). */
+	readonly packedSize: number;
+	/** Unpacked package size in bytes (`unpackedSize` from `npm pack --json`). */
+	readonly unpackedSize: number;
+	/** File count in the tarball (`entryCount` from `npm pack --json`). */
+	readonly fileCount: number;
 }
 
 /**
@@ -25,6 +57,65 @@ export interface RegistryTarget {
 }
 
 /**
+ * Input for {@link PackagePublish.publishIdempotent}.
+ *
+ * @public
+ */
+export interface IdempotentPublishInput {
+	/** Directory of the package to publish. */
+	readonly packageDir: string;
+	/** Package name, used for the registry version lookup. */
+	readonly packageName: string;
+	/** Version being published. */
+	readonly version: string;
+	/**
+	 * Content digest of the package tarball, from a prior {@link PackagePublish.pack}
+	 * call. Compared against the registry's published integrity hash.
+	 */
+	readonly digest: string;
+	/** Publish options forwarded to {@link PackagePublish.publish}. */
+	readonly options?: {
+		readonly registry?: string;
+		readonly tag?: string;
+		readonly access?: "public" | "restricted";
+		readonly provenance?: boolean;
+		readonly packageManager?: "npm" | "pnpm" | "yarn" | "bun";
+	};
+}
+
+/**
+ * Outcome of {@link PackagePublish.publishIdempotent}.
+ *
+ * @public
+ */
+export interface IdempotentPublishResult {
+	/** `"published"` when the package was published; `"skipped"` when an identical version already existed. */
+	readonly status: "published" | "skipped";
+	readonly packageName: string;
+	readonly version: string;
+	/** Set only when `status` is `"skipped"`. */
+	readonly skipReason?: "already-published-identical";
+}
+
+/**
+ * Outcome of a `npm publish --dry-run`.
+ *
+ * @public
+ */
+export interface DryRunResult {
+	/** `true` when `npm publish --dry-run` exited cleanly — the package would publish. */
+	readonly ok: boolean;
+	/** Packed tarball size in bytes, when npm reported it. */
+	readonly packedSize?: number;
+	/** Unpacked size in bytes, when npm reported it. */
+	readonly unpackedSize?: number;
+	/** File count in the tarball, when npm reported it. */
+	readonly fileCount?: number;
+	/** Raw npm output (stdout on success, stderr/​reason on failure) — for diagnostics. */
+	readonly output: string;
+}
+
+/**
  * Service for npm package publishing workflow.
  *
  * @public
@@ -35,7 +126,7 @@ export class PackagePublish extends Context.Tag("github-action-effects/PackagePu
 		/** Configure npm authentication for a registry. */
 		readonly setupAuth: (registry: string, token: string) => Effect.Effect<void, PackagePublishError>;
 
-		/** Pack a package directory into a tarball and compute its digest. */
+		/** Pack a package directory into a tarball and capture its size, file count, and integrity digest. */
 		readonly pack: (packageDir: string) => Effect.Effect<PackResult, PackagePublishError>;
 
 		/** Publish a package to a registry. */
@@ -46,6 +137,46 @@ export class PackagePublish extends Context.Tag("github-action-effects/PackagePu
 				readonly tag?: string;
 				readonly access?: "public" | "restricted";
 				readonly provenance?: boolean;
+				/**
+				 * Active package manager — controls how `npm publish` is
+				 * invoked. `"npm"` runs the runner's bundled `npm`, `"pnpm"`
+				 * runs `pnpm dlx npm`, `"yarn"` runs `yarn npm`, `"bun"`
+				 * runs `bun x npm`. The non-npm dispatchers fetch a fresh
+				 * `npm` rather than using the runner's bundled version,
+				 * which is critical for OIDC trusted publishing (requires
+				 * npm ≥ 11.5.1; GitHub-hosted runners on Node 24 ship npm
+				 * 10.x). Default `"npm"` preserves prior behaviour.
+				 */
+				readonly packageManager?: "npm" | "pnpm" | "yarn" | "bun";
+			},
+		) => Effect.Effect<void, PackagePublishError>;
+
+		/**
+		 * Publish a previously-packed tarball to a registry.
+		 *
+		 * @remarks
+		 * Unlike {@link publish}, which takes a directory and lets `npm`
+		 * pack it implicitly, `publishTarball` accepts the absolute path
+		 * to a `.tgz` from a prior {@link pack} call and uploads its
+		 * bytes directly — no second pack happens. Two targets pointing
+		 * at the same tarball upload byte-identical content, which is
+		 * what makes the integrity-compare branch of a recovery run
+		 * meaningful: the digest the caller compared against the
+		 * registry is also the digest of what gets uploaded.
+		 *
+		 * `registry` is required because the whole point of this method
+		 * is "upload this specific tarball to that specific registry";
+		 * an absent registry would invite a silent default-registry
+		 * dispatch, which is exactly the bug this method exists to fix.
+		 */
+		readonly publishTarball: (
+			tarballPath: string,
+			options: {
+				readonly registry: string;
+				readonly access?: "public" | "restricted";
+				readonly provenance?: boolean;
+				readonly tag?: string;
+				readonly packageManager?: "npm" | "pnpm" | "yarn" | "bun";
 			},
 		) => Effect.Effect<void, PackagePublishError>;
 
@@ -61,5 +192,53 @@ export class PackagePublish extends Context.Tag("github-action-effects/PackagePu
 			packageDir: string,
 			registries: Array<RegistryTarget>,
 		) => Effect.Effect<void, PackagePublishError>;
+
+		/**
+		 * Publish a package only when its exact version is not already on the
+		 * registry.
+		 *
+		 * @remarks
+		 * Skips when an identical version is already published (the registry
+		 * integrity hash matches `input.digest`); fails with a content-mismatch
+		 * {@link PackagePublishError} when the published version differs.
+		 * Authentication is the caller's responsibility, as for {@link publish}.
+		 *
+		 * Assumes the package name already exists on the registry: the version
+		 * lookup errors for a name that has never been published, so a brand-new
+		 * package's first publish must be routed through a separate path by the
+		 * caller, not through `publishIdempotent`.
+		 *
+		 * @deprecated The fused probe-then-publish dispatch hardcoded the
+		 *   wrong registry (the npm default) and could not recover from a
+		 *   partial publish across multiple registries. New callers should
+		 *   compose {@link pack}, {@link NpmRegistry.getPublishedIntegrity},
+		 *   and {@link publishTarball} themselves. This method is kept for
+		 *   the migration window; removal lands in a follow-up.
+		 */
+		readonly publishIdempotent: (
+			input: IdempotentPublishInput,
+		) => Effect.Effect<IdempotentPublishResult, PackagePublishError>;
+
+		/**
+		 * Simulate publishing a package via `npm publish --dry-run` — confirms the
+		 * registry would accept it (auth, reachability, version conflict) without
+		 * publishing anything.
+		 *
+		 * @remarks
+		 * A non-zero `npm` exit (bad auth, unreachable registry, version conflict)
+		 * is reported as `ok: false` in the result, not as an error — a failed
+		 * dry-run is a valid outcome. The error channel is reserved for a
+		 * structural failure (npm could not be spawned, or its `--json` output
+		 * could not be parsed).
+		 */
+		readonly dryRun: (
+			packageDir: string,
+			options?: {
+				readonly registry?: string;
+				readonly tag?: string;
+				readonly access?: "public" | "restricted";
+				readonly provenance?: boolean;
+			},
+		) => Effect.Effect<DryRunResult, PackagePublishError>;
 	}
 >() {}

--- a/src/services/PackagePublish.ts
+++ b/src/services/PackagePublish.ts
@@ -54,6 +54,14 @@ export interface RegistryTarget {
 	readonly token: string;
 	readonly tag?: string;
 	readonly access?: "public" | "restricted";
+	/**
+	 * Package manager whose bundled `npm` executor runs the publish. Matches the
+	 * `packageManager` option on {@link PackagePublish.publish} — non-`npm`
+	 * dispatchers (`pnpm dlx npm`, `yarn npm`, `bun x npm`) fetch a fresh npm so
+	 * the OIDC trusted-publisher exchange works on runners pinned to an older
+	 * bundled npm. Defaults to bare `npm`.
+	 */
+	readonly packageManager?: "npm" | "pnpm" | "yarn" | "bun";
 }
 
 /**

--- a/src/services/PullRequest.ts
+++ b/src/services/PullRequest.ts
@@ -3,6 +3,16 @@ import { Context } from "effect";
 import type { PullRequestError } from "../errors/PullRequestError.js";
 
 /**
+ * A file changed in a pull request.
+ *
+ * @public
+ */
+export interface PullRequestFile {
+	readonly filename: string;
+	readonly status: string;
+}
+
+/**
  * Information about a pull request.
  *
  * @public
@@ -17,6 +27,14 @@ export interface PullRequestInfo {
 	readonly base: string;
 	readonly draft: boolean;
 	readonly merged: boolean;
+	/** ISO-8601 merge timestamp; `null` when not merged, absent from test fixtures that do not set it. */
+	readonly mergedAt?: string | null;
+	/** The PR description body; `null` when empty. */
+	readonly body?: string | null;
+	/** SHA of the merge commit; `null` when not merged. */
+	readonly mergeCommitSha?: string | null;
+	/** The base branch's commit SHA. */
+	readonly baseSha?: string;
 }
 
 /**
@@ -52,6 +70,12 @@ export class PullRequest extends Context.Tag("github-action-effects/PullRequest"
 		readonly list: (
 			options?: PullRequestListOptions,
 		) => Effect.Effect<ReadonlyArray<PullRequestInfo>, PullRequestError>;
+
+		/** List the files changed in a pull request. */
+		readonly listFiles: (number: number) => Effect.Effect<Array<PullRequestFile>, PullRequestError>;
+
+		/** List pull requests associated with a commit SHA. */
+		readonly listAssociatedWithCommit: (sha: string) => Effect.Effect<Array<PullRequestInfo>, PullRequestError>;
 
 		/** Create a new PR. */
 		readonly create: (options: {

--- a/src/services/Sbom.test.ts
+++ b/src/services/Sbom.test.ts
@@ -1,0 +1,248 @@
+/**
+ * Step-5 tests for the Sbom service.
+ *
+ * @remarks
+ * Pure builder + serializer tests against `SbomLive`. The key edge case
+ * — in-flight sibling packages overriding registry-derived versions —
+ * is exercised explicitly so it doesn't regress.
+ */
+
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { FileSystem } from "@effect/platform";
+import { NodeFileSystem } from "@effect/platform-node";
+import { Effect, Layer } from "effect";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { Sbom, SbomLive } from "../testing.js";
+
+const layer = Layer.merge(SbomLive, NodeFileSystem.layer);
+const run = <A, E>(effect: Effect.Effect<A, E, Sbom | FileSystem.FileSystem>): Promise<A> =>
+	Effect.runPromise(Effect.provide(effect, layer));
+
+describe("Sbom service — step 5: CycloneDX BOM construction", () => {
+	let tmp: string;
+
+	beforeEach(() => {
+		tmp = mkdtempSync(join(tmpdir(), "attest-sbom-"));
+	});
+
+	afterEach(() => {
+		rmSync(tmp, { recursive: true, force: true });
+	});
+
+	describe("generate + serializeJson", () => {
+		it("produces a CycloneDX 1.5 BOM with the root component and dependencies", async () => {
+			const json = await run(
+				Effect.gen(function* () {
+					const sbom = yield* Sbom;
+					const bom = yield* sbom.generate({
+						rootName: "@savvy-web/example",
+						rootVersion: "1.0.0",
+						rootLicense: "MIT",
+						rootDescription: "Example package",
+						dependencies: [
+							{ name: "lodash", version: "4.17.21", license: "MIT" },
+							{ name: "effect", version: "3.14.0" },
+						],
+					});
+					return yield* sbom.serializeJson(bom);
+				}),
+			);
+
+			const parsed = JSON.parse(json) as Record<string, unknown>;
+			expect(parsed.bomFormat).toBe("CycloneDX");
+			expect(parsed.specVersion).toBe("1.5");
+
+			const meta = parsed.metadata as { component: { name: string; version: string } };
+			expect(meta.component.name).toBe("@savvy-web/example");
+			expect(meta.component.version).toBe("1.0.0");
+
+			const components = parsed.components as Array<{ name: string; version: string; purl: string }>;
+			expect(components).toHaveLength(2);
+			expect(components.map((c) => c.name).sort()).toEqual(["effect", "lodash"]);
+			expect(components.find((c) => c.name === "lodash")?.purl).toBe("pkg:npm/lodash@4.17.21");
+		});
+
+		it("overrides a dependency version when an in-flight sibling is provided", async () => {
+			const json = await run(
+				Effect.gen(function* () {
+					const sbom = yield* Sbom;
+					const bom = yield* sbom.generate({
+						rootName: "@savvy-web/package-1",
+						rootVersion: "1.0.1",
+						dependencies: [
+							// Registry-derived version of the sibling: stale, the
+							// builder put 1.0.0 here but the in-flight version is
+							// 1.0.0 as well — same name, different version takes
+							// the in-flight value.
+							{ name: "@savvy-web/package-2", version: "0.9.0" },
+							{ name: "lodash", version: "4.17.21" },
+						],
+						inFlightPackages: [{ name: "@savvy-web/package-2", version: "1.0.0", license: "MIT" }],
+					});
+					return yield* sbom.serializeJson(bom);
+				}),
+			);
+
+			const parsed = JSON.parse(json) as Record<string, unknown>;
+			const components = parsed.components as Array<{
+				name: string;
+				version: string;
+				purl: string;
+				licenses?: Array<{ license: { name?: string; id?: string } }>;
+			}>;
+
+			const sibling = components.find((c) => c.name === "@savvy-web/package-2");
+			expect(sibling).toBeDefined();
+			expect(sibling?.version).toBe("1.0.0");
+			expect(sibling?.purl).toBe("pkg:npm/%40savvy-web%2Fpackage-2@1.0.0");
+		});
+
+		it("adds in-flight packages that are not already in dependencies", async () => {
+			const json = await run(
+				Effect.gen(function* () {
+					const sbom = yield* Sbom;
+					const bom = yield* sbom.generate({
+						rootName: "root",
+						rootVersion: "1.0.0",
+						dependencies: [{ name: "lodash", version: "4.17.21" }],
+						inFlightPackages: [{ name: "@savvy-web/brand-new", version: "1.0.0" }],
+					});
+					return yield* sbom.serializeJson(bom);
+				}),
+			);
+			const parsed = JSON.parse(json) as { components: Array<{ name: string }> };
+			expect(parsed.components.map((c) => c.name).sort()).toEqual(["@savvy-web/brand-new", "lodash"]);
+		});
+
+		it("carries NTIA supplier and author metadata when provided", async () => {
+			const before = Date.now();
+			const json = await run(
+				Effect.gen(function* () {
+					const sbom = yield* Sbom;
+					const bom = yield* sbom.generate({
+						rootName: "@savvy-web/example",
+						rootVersion: "1.0.0",
+						supplier: {
+							name: "Savvy Web Systems",
+							url: ["https://savvyweb.systems"],
+							contact: [{ name: "Release Bot", email: "release@savvyweb.systems" }],
+						},
+						authors: [{ name: "C. Spencer Beggs", email: "spencer@beggs.codes" }],
+						dependencies: [],
+					});
+
+					// Assert on the in-memory BOM model directly.
+					expect(bom.metadata.supplier?.name).toBe("Savvy Web Systems");
+					expect(bom.metadata.timestamp).toBeInstanceOf(Date);
+					const authorNames = Array.from(bom.metadata.authors).map((a) => a.name);
+					expect(authorNames).toContain("C. Spencer Beggs");
+
+					return yield* sbom.serializeJson(bom);
+				}),
+			);
+			const after = Date.now();
+
+			const parsed = JSON.parse(json) as {
+				metadata: {
+					timestamp: string;
+					supplier?: { name?: string; url?: ReadonlyArray<string> };
+					authors?: Array<{ name?: string; email?: string }>;
+				};
+			};
+
+			expect(parsed.metadata.supplier?.name).toBe("Savvy Web Systems");
+			expect(parsed.metadata.supplier?.url).toContain("https://savvyweb.systems");
+
+			expect(parsed.metadata.authors).toBeDefined();
+			const author = parsed.metadata.authors?.find((a) => a.name === "C. Spencer Beggs");
+			expect(author).toBeDefined();
+			expect(author?.email).toBe("spencer@beggs.codes");
+
+			const ts = Date.parse(parsed.metadata.timestamp);
+			expect(ts).toBeGreaterThanOrEqual(before);
+			expect(ts).toBeLessThanOrEqual(after + 1000);
+		});
+
+		it("accepts a supplier with only a name (no url or contact)", async () => {
+			const json = await run(
+				Effect.gen(function* () {
+					const sbom = yield* Sbom;
+					const bom = yield* sbom.generate({
+						rootName: "root",
+						rootVersion: "1.0.0",
+						supplier: { name: "Savvy Web Systems" },
+						dependencies: [],
+					});
+					return yield* sbom.serializeJson(bom);
+				}),
+			);
+			const parsed = JSON.parse(json) as {
+				metadata: { supplier?: { name?: string; url?: unknown; contact?: unknown } };
+			};
+			expect(parsed.metadata.supplier?.name).toBe("Savvy Web Systems");
+			expect(parsed.metadata.supplier?.url).toBeUndefined();
+			expect(parsed.metadata.supplier?.contact).toBeUndefined();
+		});
+
+		it("omits supplier and authors metadata when not provided", async () => {
+			const json = await run(
+				Effect.gen(function* () {
+					const sbom = yield* Sbom;
+					const bom = yield* sbom.generate({
+						rootName: "root",
+						rootVersion: "1.0.0",
+						dependencies: [],
+					});
+					return yield* sbom.serializeJson(bom);
+				}),
+			);
+			const parsed = JSON.parse(json) as { metadata: Record<string, unknown> };
+			expect(parsed.metadata.supplier).toBeUndefined();
+			expect(parsed.metadata.authors).toBeUndefined();
+		});
+
+		it("includes a metadata timestamp", async () => {
+			const before = Date.now();
+			const json = await run(
+				Effect.gen(function* () {
+					const sbom = yield* Sbom;
+					const bom = yield* sbom.generate({
+						rootName: "root",
+						rootVersion: "1.0.0",
+						dependencies: [],
+					});
+					return yield* sbom.serializeJson(bom);
+				}),
+			);
+			const after = Date.now();
+			const parsed = JSON.parse(json) as { metadata: { timestamp: string } };
+			const ts = Date.parse(parsed.metadata.timestamp);
+			expect(ts).toBeGreaterThanOrEqual(before);
+			expect(ts).toBeLessThanOrEqual(after + 1000);
+		});
+	});
+
+	describe("save", () => {
+		it("writes the serialized BOM to disk", async () => {
+			const outPath = join(tmp, "sbom.json");
+			await run(
+				Effect.gen(function* () {
+					const sbom = yield* Sbom;
+					const bom = yield* sbom.generate({
+						rootName: "root",
+						rootVersion: "1.0.0",
+						dependencies: [{ name: "lodash", version: "4.17.21" }],
+					});
+					yield* sbom.save(bom, outPath);
+				}),
+			);
+			const onDisk = readFileSync(outPath, "utf-8");
+			const parsed = JSON.parse(onDisk);
+			expect(parsed.bomFormat).toBe("CycloneDX");
+			expect(parsed.specVersion).toBe("1.5");
+			expect(onDisk).toMatch(/^\{\n {2}/); // pretty-printed with 2-space indent
+		});
+	});
+});

--- a/src/services/Sbom.ts
+++ b/src/services/Sbom.ts
@@ -1,0 +1,139 @@
+import type * as CdxLibrary from "@cyclonedx/cyclonedx-library";
+import type { FileSystem } from "@effect/platform";
+import type { Effect } from "effect";
+import { Context } from "effect";
+import type { SbomError } from "../errors/SbomError.js";
+
+/**
+ * A dependency that should appear as a component in the BOM.
+ *
+ * @public
+ */
+export interface ResolvedDependency {
+	readonly name: string;
+	readonly version: string;
+	readonly license?: string;
+	readonly description?: string;
+}
+
+/**
+ * A sibling package being released in the same wave as the root —
+ * not yet on the registry, so any registry-based dependency resolver
+ * cannot see it. The Sbom service uses this list to synthesize the
+ * component entry the registry would otherwise provide.
+ *
+ * @public
+ */
+export interface InFlightPackage {
+	readonly name: string;
+	readonly version: string;
+	readonly license?: string;
+}
+
+/**
+ * A point of contact for a supplier organization.
+ *
+ * @public
+ */
+export interface SbomContact {
+	readonly name?: string;
+	readonly email?: string;
+	readonly phone?: string;
+}
+
+/**
+ * The organization that supplied the root component. Maps to the
+ * CycloneDX `metadata.supplier` field, which the NTIA SBOM "minimum
+ * elements" require for compliance.
+ *
+ * @public
+ */
+export interface SbomSupplier {
+	/** Supplier organization name. Required for NTIA compliance. */
+	readonly name: string;
+	/** Optional supplier URL(s). */
+	readonly url?: ReadonlyArray<string>;
+	/** Optional supplier point(s) of contact. */
+	readonly contact?: ReadonlyArray<SbomContact>;
+}
+
+/**
+ * An author of the SBOM document itself. Maps to a CycloneDX
+ * `metadata.authors` entry — the NTIA "author of SBOM data" element,
+ * distinct from the {@link SbomInput.rootAuthor} that describes the
+ * author of the root *component*.
+ *
+ * @public
+ */
+export interface SbomAuthor {
+	readonly name?: string;
+	readonly email?: string;
+	readonly phone?: string;
+}
+
+/**
+ * Input for {@link Sbom.generate}.
+ *
+ * @public
+ */
+export interface SbomInput {
+	/** Name of the root package the BOM describes. */
+	readonly rootName: string;
+	/** Version of the root package. */
+	readonly rootVersion: string;
+	/** Optional root-level metadata. */
+	readonly rootLicense?: string;
+	readonly rootDescription?: string;
+	readonly rootAuthor?: string;
+	/**
+	 * Supplier of the root component. Threaded onto `metadata.supplier`
+	 * of the emitted BOM — required by the NTIA SBOM minimum elements.
+	 */
+	readonly supplier?: SbomSupplier;
+	/**
+	 * Authors of the SBOM document. Threaded onto `metadata.authors` of
+	 * the emitted BOM — the NTIA "author of SBOM data" element. This is
+	 * distinct from {@link rootAuthor}, which describes the author of
+	 * the root component rather than of the SBOM itself.
+	 */
+	readonly authors?: ReadonlyArray<SbomAuthor>;
+	/**
+	 * Resolved direct dependencies (post-relink) of the root package.
+	 * Workspace references should already be replaced with concrete
+	 * versions before being passed in.
+	 */
+	readonly dependencies: ReadonlyArray<ResolvedDependency>;
+	/**
+	 * Packages being released alongside the root that aren't on the
+	 * registry yet. If any of these names also appear in
+	 * {@link dependencies}, the in-flight version wins.
+	 */
+	readonly inFlightPackages?: ReadonlyArray<InFlightPackage>;
+}
+
+/**
+ * CycloneDX BOM model. Re-exported so callers don't need to depend on
+ * `@cyclonedx/cyclonedx-library` directly.
+ *
+ * @public
+ */
+export type CycloneDXBom = CdxLibrary.Models.Bom;
+
+/**
+ * Sbom service surface.
+ *
+ * @public
+ */
+export class Sbom extends Context.Tag("github-action-effects/Sbom")<
+	Sbom,
+	{
+		/** Build an in-memory CycloneDX 1.5 BOM from the resolved dependency graph. */
+		readonly generate: (input: SbomInput) => Effect.Effect<CycloneDXBom, SbomError>;
+
+		/** Serialize a BOM to JSON. The result is the canonical CycloneDX JSON form. */
+		readonly serializeJson: (bom: CycloneDXBom) => Effect.Effect<string, SbomError>;
+
+		/** Write a BOM to disk as pretty-printed JSON. */
+		readonly save: (bom: CycloneDXBom, path: string) => Effect.Effect<void, SbomError, FileSystem.FileSystem>;
+	}
+>() {}

--- a/src/services/SigstoreSigner.ts
+++ b/src/services/SigstoreSigner.ts
@@ -1,0 +1,50 @@
+import type { Effect } from "effect";
+import { Context } from "effect";
+import type { SigstoreSignerError } from "../errors/SigstoreSignerError.js";
+import type { InTotoStatement, SigstoreBundle } from "../schemas/Attestation.js";
+import type { OidcTokenIssuer } from "./OidcTokenIssuer.js";
+
+/**
+ * DSSE payload type for in-toto statements per the GitHub attestations spec.
+ *
+ * @public
+ */
+export const IN_TOTO_PAYLOAD_TYPE = "application/vnd.in-toto+json" as const;
+
+/**
+ * OIDC audience expected by the Sigstore public-good Fulcio instance.
+ *
+ * @public
+ */
+export const SIGSTORE_OIDC_AUDIENCE = "sigstore" as const;
+
+/**
+ * Sigstore signer service surface.
+ *
+ * @public
+ */
+export class SigstoreSigner extends Context.Tag("github-action-effects/SigstoreSigner")<
+	SigstoreSigner,
+	{
+		/**
+		 * Build a Sigstore DSSE bundle from an in-toto statement.
+		 *
+		 * @remarks
+		 * The bundle is the structure GitHub accepts via
+		 * `POST /repos/{owner}/{repo}/attestations`.
+		 */
+		readonly signStatement: (
+			statement: InTotoStatement,
+		) => Effect.Effect<SigstoreBundle, SigstoreSignerError, OidcTokenIssuer>;
+	}
+>() {}
+
+/**
+ * Configuration knobs for the Live SigstoreSigner.
+ *
+ * @public
+ */
+export interface SigstoreSignerConfig {
+	readonly fulcioBaseURL?: string;
+	readonly rekorBaseURL?: string;
+}

--- a/src/testing.ts
+++ b/src/testing.ts
@@ -14,6 +14,7 @@ export { ActionEnvironmentError } from "./errors/ActionEnvironmentError.js";
 export { ActionInputError } from "./errors/ActionInputError.js";
 export { ActionOutputError } from "./errors/ActionOutputError.js";
 export { ActionStateError } from "./errors/ActionStateError.js";
+export { AttestError } from "./errors/AttestError.js";
 export { ChangesetError } from "./errors/ChangesetError.js";
 export { CheckRunError } from "./errors/CheckRunError.js";
 export { CommandRunnerError } from "./errors/CommandRunnerError.js";
@@ -21,19 +22,26 @@ export { ConfigLoaderError } from "./errors/ConfigLoaderError.js";
 export { GitBranchError } from "./errors/GitBranchError.js";
 export { GitCommitError } from "./errors/GitCommitError.js";
 export { GitHubAppError } from "./errors/GitHubAppError.js";
+export { GitHubArtifactMetadataError } from "./errors/GitHubArtifactMetadataError.js";
 export { GitHubClientError } from "./errors/GitHubClientError.js";
+export { GitHubCommitError } from "./errors/GitHubCommitError.js";
+export { GitHubContentError } from "./errors/GitHubContentError.js";
 export { GitHubGraphQLError } from "./errors/GitHubGraphQLError.js";
 export { GitHubIssueError } from "./errors/GitHubIssueError.js";
 export { GitHubReleaseError } from "./errors/GitHubReleaseError.js";
 export { GitTagError } from "./errors/GitTagError.js";
 export { NpmRegistryError } from "./errors/NpmRegistryError.js";
+export { OidcTokenError } from "./errors/OidcTokenError.js";
 export { PackageManagerError } from "./errors/PackageManagerError.js";
 export { PackagePublishError } from "./errors/PackagePublishError.js";
 export { PullRequestCommentError } from "./errors/PullRequestCommentError.js";
 export { PullRequestError } from "./errors/PullRequestError.js";
 export { RateLimitError } from "./errors/RateLimitError.js";
 export { RuntimeEnvironmentError } from "./errors/RuntimeEnvironmentError.js";
+export { SbomError } from "./errors/SbomError.js";
 export { SemverResolverError } from "./errors/SemverResolverError.js";
+export { SigstoreSignerError } from "./errors/SigstoreSignerError.js";
+export { SlsaError } from "./errors/SlsaError.js";
 export { TokenPermissionError } from "./errors/TokenPermissionError.js";
 export { ToolInstallerError } from "./errors/ToolInstallerError.js";
 export { WorkflowDispatchError } from "./errors/WorkflowDispatchError.js";
@@ -53,6 +61,9 @@ export { ActionOutputsTest } from "./layers/ActionOutputsTest.js";
 export { ActionStateLive } from "./layers/ActionStateLive.js";
 export type { ActionStateTestState } from "./layers/ActionStateTest.js";
 export { ActionStateTest } from "./layers/ActionStateTest.js";
+export { AttestLive } from "./layers/AttestLive.js";
+export type { AttestTestState } from "./layers/AttestTest.js";
+export { AttestTest, AttestTestFullLayer, makeAttestTestState } from "./layers/AttestTest.js";
 export { ChangesetAnalyzerLive } from "./layers/ChangesetAnalyzerLive.js";
 export type { ChangesetAnalyzerTestState } from "./layers/ChangesetAnalyzerTest.js";
 export { ChangesetAnalyzerTest } from "./layers/ChangesetAnalyzerTest.js";
@@ -77,8 +88,17 @@ export { GitCommitTest } from "./layers/GitCommitTest.js";
 export { GitHubAppLive } from "./layers/GitHubAppLive.js";
 export type { GitHubAppTestState } from "./layers/GitHubAppTest.js";
 export { GitHubAppTest } from "./layers/GitHubAppTest.js";
+export { GitHubArtifactMetadataLive } from "./layers/GitHubArtifactMetadataLive.js";
+export type { GitHubArtifactMetadataTestState } from "./layers/GitHubArtifactMetadataTest.js";
+export { GitHubArtifactMetadataTest } from "./layers/GitHubArtifactMetadataTest.js";
 export type { GitHubClientTestState, RestResponse } from "./layers/GitHubClientTest.js";
 export { GitHubClientTest } from "./layers/GitHubClientTest.js";
+export { GitHubCommitLive } from "./layers/GitHubCommitLive.js";
+export type { GitHubCommitTestState } from "./layers/GitHubCommitTest.js";
+export { GitHubCommitTest } from "./layers/GitHubCommitTest.js";
+export { GitHubContentLive } from "./layers/GitHubContentLive.js";
+export type { GitHubContentTestState } from "./layers/GitHubContentTest.js";
+export { GitHubContentTest } from "./layers/GitHubContentTest.js";
 export { GitHubGraphQLLive } from "./layers/GitHubGraphQLLive.js";
 export type { GitHubGraphQLTestState } from "./layers/GitHubGraphQLTest.js";
 export { GitHubGraphQLTest } from "./layers/GitHubGraphQLTest.js";
@@ -94,6 +114,8 @@ export { GitTagTest } from "./layers/GitTagTest.js";
 export { NpmRegistryLive } from "./layers/NpmRegistryLive.js";
 export type { NpmRegistryTestState } from "./layers/NpmRegistryTest.js";
 export { NpmRegistryTest } from "./layers/NpmRegistryTest.js";
+export { OidcTokenIssuerLive, saveToken } from "./layers/OidcTokenIssuerLive.js";
+export { OidcTokenIssuerTest } from "./layers/OidcTokenIssuerTest.js";
 export { PackageManagerAdapterLive } from "./layers/PackageManagerAdapterLive.js";
 export type { PackageManagerAdapterTestState } from "./layers/PackageManagerAdapterTest.js";
 export { PackageManagerAdapterTest } from "./layers/PackageManagerAdapterTest.js";
@@ -109,6 +131,11 @@ export { PullRequestTest } from "./layers/PullRequestTest.js";
 export { RateLimiterLive } from "./layers/RateLimiterLive.js";
 export type { RateLimiterTestState } from "./layers/RateLimiterTest.js";
 export { RateLimiterTest } from "./layers/RateLimiterTest.js";
+export { SbomLive } from "./layers/SbomLive.js";
+export type { SbomTestState } from "./layers/SbomTest.js";
+export { SbomTest, makeSbomTestState } from "./layers/SbomTest.js";
+export { SigstoreSignerLive, makeSigstoreSignerLive } from "./layers/SigstoreSignerLive.js";
+export { SigstoreSignerTest } from "./layers/SigstoreSignerTest.js";
 export { TokenPermissionCheckerLive } from "./layers/TokenPermissionCheckerLive.js";
 export type { TokenPermissionCheckerTestState } from "./layers/TokenPermissionCheckerTest.js";
 export { TokenPermissionCheckerTest } from "./layers/TokenPermissionCheckerTest.js";
@@ -125,6 +152,17 @@ export { WorkspaceDetectorTest } from "./layers/WorkspaceDetectorTest.js";
 export { ActionsConfigProvider } from "./runtime/ActionsConfigProvider.js";
 export { ActionsLogger } from "./runtime/ActionsLogger.js";
 export { ActionsRuntime } from "./runtime/ActionsRuntime.js";
+export type { AttestInput, AttestationRecord } from "./schemas/Attestation.js";
+export {
+	CYCLONEDX_BOM,
+	IN_TOTO_STATEMENT_V1,
+	InTotoStatement,
+	InTotoSubject,
+	SIGSTORE_BUNDLE_V0_3_MEDIA_TYPE,
+	SLSA_PROVENANCE_V1,
+	SPDX_V2_3,
+	SigstoreBundle,
+} from "./schemas/Attestation.js";
 // -- Schemas --
 export type {
 	BumpType as BumpTypeType,
@@ -173,8 +211,16 @@ export { ActionEnvironment } from "./services/ActionEnvironment.js";
 export { ActionLogger } from "./services/ActionLogger.js";
 export { ActionOutputs } from "./services/ActionOutputs.js";
 export { ActionState } from "./services/ActionState.js";
+export type { AttestationListEntry, ProvenanceAttestationInput, SbomAttestationInput } from "./services/Attest.js";
+export { Attest } from "./services/Attest.js";
 export { ChangesetAnalyzer } from "./services/ChangesetAnalyzer.js";
-export type { AnnotationLevel, CheckRunAnnotation, CheckRunConclusion, CheckRunOutput } from "./services/CheckRun.js";
+export type {
+	AnnotationLevel,
+	CheckRunAnnotation,
+	CheckRunConclusion,
+	CheckRunData,
+	CheckRunOutput,
+} from "./services/CheckRun.js";
 export { CheckRun } from "./services/CheckRun.js";
 export type { ExecOptions, ExecOutput } from "./services/CommandRunner.js";
 export { CommandRunner } from "./services/CommandRunner.js";
@@ -184,7 +230,12 @@ export { GitBranch } from "./services/GitBranch.js";
 export { GitCommit } from "./services/GitCommit.js";
 export type { BotIdentity, InstallationToken as InstallationTokenType } from "./services/GitHubApp.js";
 export { GitHubApp, InstallationToken } from "./services/GitHubApp.js";
+export type { StorageRecordInput } from "./services/GitHubArtifactMetadata.js";
+export { GitHubArtifactMetadata } from "./services/GitHubArtifactMetadata.js";
 export { GitHubClient } from "./services/GitHubClient.js";
+export type { CommitComparison, CommitDetail, CommitFile, CommitSummary } from "./services/GitHubCommit.js";
+export { GitHubCommit } from "./services/GitHubCommit.js";
+export { GitHubContent } from "./services/GitHubContent.js";
 export { GitHubGraphQL } from "./services/GitHubGraphQL.js";
 export type { IssueData } from "./services/GitHubIssue.js";
 export { GitHubIssue } from "./services/GitHubIssue.js";
@@ -195,15 +246,25 @@ export { GitTag } from "./services/GitTag.js";
 export { NpmRegistry } from "./services/NpmRegistry.js";
 export type { AppAuth } from "./services/OctokitAuthApp.js";
 export { OctokitAuthApp } from "./services/OctokitAuthApp.js";
+export { OidcTokenIssuer } from "./services/OidcTokenIssuer.js";
 export type { InstallOptions } from "./services/PackageManagerAdapter.js";
 export { PackageManagerAdapter } from "./services/PackageManagerAdapter.js";
-export type { PackResult, RegistryTarget } from "./services/PackagePublish.js";
+export type {
+	IdempotentPublishInput,
+	IdempotentPublishResult,
+	PackResult,
+	RegistryTarget,
+} from "./services/PackagePublish.js";
 export { PackagePublish } from "./services/PackagePublish.js";
-export type { PullRequestInfo, PullRequestListOptions } from "./services/PullRequest.js";
+export type { PullRequestFile, PullRequestInfo, PullRequestListOptions } from "./services/PullRequest.js";
 export { PullRequest } from "./services/PullRequest.js";
 export type { CommentRecord } from "./services/PullRequestComment.js";
 export { PullRequestComment } from "./services/PullRequestComment.js";
 export { RateLimiter } from "./services/RateLimiter.js";
+export type { CycloneDXBom, InFlightPackage, ResolvedDependency, SbomInput } from "./services/Sbom.js";
+export { Sbom } from "./services/Sbom.js";
+export type { SigstoreSignerConfig } from "./services/SigstoreSigner.js";
+export { IN_TOTO_PAYLOAD_TYPE, SIGSTORE_OIDC_AUDIENCE, SigstoreSigner } from "./services/SigstoreSigner.js";
 export { TokenPermissionChecker } from "./services/TokenPermissionChecker.js";
 export { ToolInstaller } from "./services/ToolInstaller.js";
 export type { PollOptions, WorkflowRunStatus } from "./services/WorkflowDispatch.js";
@@ -213,6 +274,9 @@ export { AutoMerge } from "./utils/AutoMerge.js";
 export type { AccumulateResult } from "./utils/ErrorAccumulator.js";
 export { ErrorAccumulator } from "./utils/ErrorAccumulator.js";
 export { GithubMarkdown } from "./utils/GithubMarkdown.js";
+export { buildStatement, npmPurl, serializeStatement, subject } from "./utils/intoto.js";
 export type { Report } from "./utils/ReportBuilder.js";
 export { ReportBuilder } from "./utils/ReportBuilder.js";
 export { SemverResolver } from "./utils/SemverResolver.js";
+export type { OidcClaims } from "./utils/slsa.js";
+export { GITHUB_BUILD_TYPE, buildSLSAProvenancePredicate, decodeJwtClaims } from "./utils/slsa.js";

--- a/src/utils/RegistryClassifier.test.ts
+++ b/src/utils/RegistryClassifier.test.ts
@@ -1,0 +1,214 @@
+import { describe, expect, it } from "vitest";
+import {
+	generatePackageViewUrl,
+	getRegistryDisplayName,
+	getRegistryType,
+	isCustomRegistry,
+	isGitHubPackagesRegistry,
+	isJsrRegistry,
+	isNpmRegistry,
+} from "./RegistryClassifier.js";
+
+describe("RegistryClassifier", () => {
+	describe("isNpmRegistry", () => {
+		it("returns true for registry.npmjs.org", () => {
+			expect(isNpmRegistry("https://registry.npmjs.org/")).toBe(true);
+		});
+
+		it("returns true for registry.npmjs.org without trailing slash", () => {
+			expect(isNpmRegistry("https://registry.npmjs.org")).toBe(true);
+		});
+
+		it("returns true for subdomains of npmjs.org", () => {
+			expect(isNpmRegistry("https://subdomain.npmjs.org/")).toBe(true);
+		});
+
+		it("returns false for evil-npmjs.org (security check)", () => {
+			expect(isNpmRegistry("https://evil-npmjs.org/")).toBe(false);
+		});
+
+		it("returns false for npmjs.org.evil.com (security check)", () => {
+			expect(isNpmRegistry("https://npmjs.org.evil.com/")).toBe(false);
+		});
+
+		it("returns false for path containing npmjs.org (security check)", () => {
+			expect(isNpmRegistry("https://evil.com/npmjs.org")).toBe(false);
+		});
+
+		it("returns false for GitHub Packages", () => {
+			expect(isNpmRegistry("https://npm.pkg.github.com/")).toBe(false);
+		});
+
+		it("returns false for null", () => {
+			expect(isNpmRegistry(null)).toBe(false);
+		});
+
+		it("returns false for undefined", () => {
+			expect(isNpmRegistry(undefined)).toBe(false);
+		});
+
+		it("returns false for invalid URL", () => {
+			expect(isNpmRegistry("not-a-url")).toBe(false);
+		});
+	});
+
+	describe("isGitHubPackagesRegistry", () => {
+		it("returns true for npm.pkg.github.com", () => {
+			expect(isGitHubPackagesRegistry("https://npm.pkg.github.com/")).toBe(true);
+		});
+
+		it("returns true for subdomains of pkg.github.com", () => {
+			expect(isGitHubPackagesRegistry("https://npm.pkg.github.com")).toBe(true);
+		});
+
+		it("returns false for evil-pkg.github.com (security check)", () => {
+			expect(isGitHubPackagesRegistry("https://evil-pkg.github.com/")).toBe(false);
+		});
+
+		it("returns false for pkg.github.com.evil.com (security check)", () => {
+			expect(isGitHubPackagesRegistry("https://pkg.github.com.evil.com/")).toBe(false);
+		});
+
+		it("returns false for npm registry", () => {
+			expect(isGitHubPackagesRegistry("https://registry.npmjs.org/")).toBe(false);
+		});
+
+		it("returns false for null", () => {
+			expect(isGitHubPackagesRegistry(null)).toBe(false);
+		});
+	});
+
+	describe("isJsrRegistry", () => {
+		it("returns true for jsr.io", () => {
+			expect(isJsrRegistry("https://jsr.io/")).toBe(true);
+		});
+
+		it("returns true for subdomains of jsr.io", () => {
+			expect(isJsrRegistry("https://registry.jsr.io/")).toBe(true);
+		});
+
+		it("returns false for evil-jsr.io (security check)", () => {
+			expect(isJsrRegistry("https://evil-jsr.io/")).toBe(false);
+		});
+
+		it("returns false for null", () => {
+			expect(isJsrRegistry(null)).toBe(false);
+		});
+	});
+
+	describe("isCustomRegistry", () => {
+		it("returns true for custom registries", () => {
+			expect(isCustomRegistry("https://my-registry.example.com/")).toBe(true);
+		});
+
+		it("returns false for npm registry", () => {
+			expect(isCustomRegistry("https://registry.npmjs.org/")).toBe(false);
+		});
+
+		it("returns false for GitHub Packages", () => {
+			expect(isCustomRegistry("https://npm.pkg.github.com/")).toBe(false);
+		});
+
+		it("returns false for JSR", () => {
+			expect(isCustomRegistry("https://jsr.io/")).toBe(false);
+		});
+
+		it("returns false for null", () => {
+			expect(isCustomRegistry(null)).toBe(false);
+		});
+
+		it("returns false for undefined", () => {
+			expect(isCustomRegistry(undefined)).toBe(false);
+		});
+	});
+
+	describe("getRegistryType", () => {
+		it("returns npm for npm registry", () => {
+			expect(getRegistryType("https://registry.npmjs.org/")).toBe("npm");
+		});
+
+		it("returns github-packages for GitHub Packages", () => {
+			expect(getRegistryType("https://npm.pkg.github.com/")).toBe("github-packages");
+		});
+
+		it("returns jsr for JSR", () => {
+			expect(getRegistryType("https://jsr.io/")).toBe("jsr");
+		});
+
+		it("returns custom for custom registries", () => {
+			expect(getRegistryType("https://my-registry.example.com/")).toBe("custom");
+		});
+
+		it("returns custom for null", () => {
+			expect(getRegistryType(null)).toBe("custom");
+		});
+	});
+
+	describe("getRegistryDisplayName", () => {
+		it("returns npm for npm registry", () => {
+			expect(getRegistryDisplayName("https://registry.npmjs.org/")).toBe("npm");
+		});
+
+		it("returns GitHub Packages for GitHub Packages", () => {
+			expect(getRegistryDisplayName("https://npm.pkg.github.com/")).toBe("GitHub Packages");
+		});
+
+		it("returns jsr.io for JSR", () => {
+			expect(getRegistryDisplayName("https://jsr.io/")).toBe("jsr.io");
+		});
+
+		it("returns hostname for custom registries", () => {
+			expect(getRegistryDisplayName("https://my-registry.example.com/")).toBe("my-registry.example.com");
+		});
+
+		it("returns jsr.io for null (default registry)", () => {
+			expect(getRegistryDisplayName(null)).toBe("jsr.io");
+		});
+
+		it("returns jsr.io for undefined", () => {
+			expect(getRegistryDisplayName(undefined)).toBe("jsr.io");
+		});
+
+		it("returns original string for invalid URL", () => {
+			expect(getRegistryDisplayName("not-a-url")).toBe("not-a-url");
+		});
+	});
+
+	describe("generatePackageViewUrl", () => {
+		it("returns npm package URL for npm registry", () => {
+			expect(generatePackageViewUrl("https://registry.npmjs.org/", "@test/package")).toBe(
+				"https://www.npmjs.com/package/@test/package",
+			);
+		});
+
+		it("returns GitHub packages URL for GitHub Packages", () => {
+			expect(generatePackageViewUrl("https://npm.pkg.github.com/", "@savvy-web/package")).toBe(
+				"https://github.com/savvy-web/packages",
+			);
+		});
+
+		it("returns undefined for unscoped package on GitHub Packages", () => {
+			expect(generatePackageViewUrl("https://npm.pkg.github.com/", "unscoped-package")).toBeUndefined();
+		});
+
+		it("returns undefined for JSR registry", () => {
+			expect(generatePackageViewUrl("https://jsr.io/", "@scope/pkg")).toBeUndefined();
+		});
+
+		it("returns undefined for custom registries", () => {
+			expect(generatePackageViewUrl("https://my-registry.example.com/", "@test/package")).toBeUndefined();
+		});
+
+		it("returns undefined for null registry", () => {
+			expect(generatePackageViewUrl(null, "@test/package")).toBeUndefined();
+		});
+
+		it("returns undefined for null package name", () => {
+			expect(generatePackageViewUrl("https://registry.npmjs.org/", null)).toBeUndefined();
+		});
+
+		it("returns undefined for undefined package name", () => {
+			expect(generatePackageViewUrl("https://registry.npmjs.org/", undefined)).toBeUndefined();
+		});
+	});
+});

--- a/src/utils/RegistryClassifier.test.ts
+++ b/src/utils/RegistryClassifier.test.ts
@@ -139,8 +139,12 @@ describe("RegistryClassifier", () => {
 			expect(getRegistryType("https://my-registry.example.com/")).toBe("custom");
 		});
 
-		it("returns custom for null", () => {
-			expect(getRegistryType(null)).toBe("custom");
+		it("returns npm for null (absent registry defaults to npm)", () => {
+			expect(getRegistryType(null)).toBe("npm");
+		});
+
+		it("returns npm for undefined (absent registry defaults to npm)", () => {
+			expect(getRegistryType(undefined)).toBe("npm");
 		});
 	});
 
@@ -161,12 +165,12 @@ describe("RegistryClassifier", () => {
 			expect(getRegistryDisplayName("https://my-registry.example.com/")).toBe("my-registry.example.com");
 		});
 
-		it("returns jsr.io for null (default registry)", () => {
-			expect(getRegistryDisplayName(null)).toBe("jsr.io");
+		it("returns npm for null (absent registry defaults to npm)", () => {
+			expect(getRegistryDisplayName(null)).toBe("npm");
 		});
 
-		it("returns jsr.io for undefined", () => {
-			expect(getRegistryDisplayName(undefined)).toBe("jsr.io");
+		it("returns npm for undefined (absent registry defaults to npm)", () => {
+			expect(getRegistryDisplayName(undefined)).toBe("npm");
 		});
 
 		it("returns original string for invalid URL", () => {

--- a/src/utils/RegistryClassifier.ts
+++ b/src/utils/RegistryClassifier.ts
@@ -110,12 +110,16 @@ export function isCustomRegistry(registry: string | null | undefined): boolean {
 /**
  * Detect the type of a registry from its URL
  *
- * @param registry - Registry URL to check
- * @returns The registry type
+ * @param registry - Registry URL, or null/undefined when no registry is
+ *   configured.
+ * @returns The registry type. Returns `"npm"` when `registry` is null or
+ *   undefined: an absent registry resolves to the public npm registry
+ *   (`registry.npmjs.org`), which is this library's publishing default.
  *
  * @public
  */
 export function getRegistryType(registry: string | null | undefined): RegistryType {
+	if (!registry) return "npm";
 	if (isNpmRegistry(registry)) return "npm";
 	if (isGitHubPackagesRegistry(registry)) return "github-packages";
 	if (isJsrRegistry(registry)) return "jsr";
@@ -128,13 +132,14 @@ export function getRegistryType(registry: string | null | undefined): RegistryTy
  * @param registry - Registry URL, or null/undefined when no registry is
  *   configured.
  * @returns Human-readable registry name (e.g. "npm", "GitHub Packages", or the
- *   hostname for custom registries). Returns `"jsr.io"` when `registry` is null
- *   or undefined, because JSR is the default registry.
+ *   hostname for custom registries). Returns `"npm"` when `registry` is null or
+ *   undefined, matching {@link getRegistryType}: an absent registry resolves to
+ *   the public npm registry (`registry.npmjs.org`), this library's default.
  *
  * @public
  */
 export function getRegistryDisplayName(registry: string | null | undefined): string {
-	if (!registry) return "jsr.io";
+	if (!registry) return "npm";
 	if (isNpmRegistry(registry)) return "npm";
 	if (isGitHubPackagesRegistry(registry)) return "GitHub Packages";
 	if (isJsrRegistry(registry)) return "jsr.io";

--- a/src/utils/RegistryClassifier.ts
+++ b/src/utils/RegistryClassifier.ts
@@ -1,0 +1,174 @@
+/**
+ * Registry detection and display utilities
+ *
+ * @remarks
+ * This module provides URL-safe registry detection that properly parses URLs
+ * before checking hostnames. Using substring matching on URLs is a security
+ * issue (CWE-20) as it can be bypassed with malicious URLs like:
+ * - `http://evil-npmjs.org` (prefix)
+ * - `http://npmjs.org.evil.com` (suffix)
+ * - `http://evil.com/npmjs.org` (path component)
+ *
+ * All functions in this module parse URLs and check the hostname properly.
+ */
+
+/**
+ * Known registry types
+ *
+ * @public
+ */
+export type RegistryType = "npm" | "github-packages" | "jsr" | "custom";
+
+/**
+ * Parse a URL and extract the hostname safely
+ *
+ * @param url - URL string to parse
+ * @returns Lowercase hostname or null if invalid
+ *
+ * @internal
+ */
+function getHostname(url: string | null | undefined): string | null {
+	if (!url) return null;
+	try {
+		return new URL(url).hostname.toLowerCase();
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Check if a hostname matches a known registry domain
+ *
+ * @remarks
+ * Uses exact match or subdomain match to ensure security:
+ * - `registry.npmjs.org` matches `npmjs.org`
+ * - `npm.pkg.github.com` matches `pkg.github.com`
+ * - `evil-npmjs.org` does NOT match `npmjs.org`
+ *
+ * @param hostname - Parsed hostname to check
+ * @param domain - Domain to match against (e.g., "npmjs.org")
+ * @returns true if hostname matches the domain
+ *
+ * @internal
+ */
+function matchesDomain(hostname: string | null, domain: string): boolean {
+	if (!hostname) return false;
+	const normalizedDomain = domain.toLowerCase();
+	// Exact match or subdomain match (hostname ends with .domain)
+	return hostname === normalizedDomain || hostname.endsWith(`.${normalizedDomain}`);
+}
+
+/**
+ * Check if a registry URL is the npm public registry
+ *
+ * @param registry - Registry URL to check
+ * @returns true if this is the npm public registry (registry.npmjs.org or subdomain)
+ *
+ * @public
+ */
+export function isNpmRegistry(registry: string | null | undefined): boolean {
+	return matchesDomain(getHostname(registry), "npmjs.org");
+}
+
+/**
+ * Check if a registry URL is GitHub Packages
+ *
+ * @param registry - Registry URL to check
+ * @returns true if this is GitHub Packages (npm.pkg.github.com or subdomain)
+ *
+ * @public
+ */
+export function isGitHubPackagesRegistry(registry: string | null | undefined): boolean {
+	return matchesDomain(getHostname(registry), "pkg.github.com");
+}
+
+/**
+ * Check if a registry URL is JSR
+ *
+ * @param registry - Registry URL to check
+ * @returns true if this is JSR (jsr.io or subdomain)
+ *
+ * @public
+ */
+export function isJsrRegistry(registry: string | null | undefined): boolean {
+	return matchesDomain(getHostname(registry), "jsr.io");
+}
+
+/**
+ * Check if a registry URL is a custom (non-standard) registry
+ *
+ * @param registry - Registry URL to check
+ * @returns true if this is not npm, GitHub Packages, or JSR
+ *
+ * @public
+ */
+export function isCustomRegistry(registry: string | null | undefined): boolean {
+	if (!registry) return false;
+	return !isNpmRegistry(registry) && !isGitHubPackagesRegistry(registry) && !isJsrRegistry(registry);
+}
+
+/**
+ * Detect the type of a registry from its URL
+ *
+ * @param registry - Registry URL to check
+ * @returns The registry type
+ *
+ * @public
+ */
+export function getRegistryType(registry: string | null | undefined): RegistryType {
+	if (isNpmRegistry(registry)) return "npm";
+	if (isGitHubPackagesRegistry(registry)) return "github-packages";
+	if (isJsrRegistry(registry)) return "jsr";
+	return "custom";
+}
+
+/**
+ * Get a human-readable display name for a registry URL.
+ *
+ * @param registry - Registry URL, or null/undefined when no registry is
+ *   configured.
+ * @returns Human-readable registry name (e.g. "npm", "GitHub Packages", or the
+ *   hostname for custom registries). Returns `"jsr.io"` when `registry` is null
+ *   or undefined, because JSR is the default registry.
+ *
+ * @public
+ */
+export function getRegistryDisplayName(registry: string | null | undefined): string {
+	if (!registry) return "jsr.io";
+	if (isNpmRegistry(registry)) return "npm";
+	if (isGitHubPackagesRegistry(registry)) return "GitHub Packages";
+	if (isJsrRegistry(registry)) return "jsr.io";
+
+	// For custom registries, return the hostname
+	const hostname = getHostname(registry);
+	return hostname || registry;
+}
+
+/**
+ * Generate a URL to view the published package on its registry
+ *
+ * @param registry - Registry URL
+ * @param packageName - Name of the package (including scope if any)
+ * @returns URL to view the package, or undefined if not supported
+ *
+ * @public
+ */
+export function generatePackageViewUrl(
+	registry: string | null | undefined,
+	packageName: string | null | undefined,
+): string | undefined {
+	if (!packageName || !registry) return undefined;
+
+	if (isNpmRegistry(registry)) {
+		return `https://www.npmjs.com/package/${packageName}`;
+	}
+
+	if (isGitHubPackagesRegistry(registry)) {
+		// GitHub Packages URL format: github.com/{owner}/packages
+		const scope = packageName.startsWith("@") ? packageName.split("/")[0].slice(1) : undefined;
+		return scope ? `https://github.com/${scope}/packages` : undefined;
+	}
+
+	// Custom registries have no standard URL format
+	return undefined;
+}

--- a/src/utils/ReportBuilder.test.ts
+++ b/src/utils/ReportBuilder.test.ts
@@ -104,6 +104,7 @@ describe("ReportBuilder", () => {
 				id: 99,
 				name: "test",
 				headSha: "abc",
+				htmlUrl: "https://github.com/test/checks/99",
 				status: "in_progress",
 				outputs: [],
 			});

--- a/src/utils/intoto.ts
+++ b/src/utils/intoto.ts
@@ -1,0 +1,65 @@
+/**
+ * Pure constructors for in-toto statements.
+ *
+ * @remarks
+ * No I/O, no Effect dependencies — these are plain functions so callers
+ * can build statements deterministically and inspect them (or hash them,
+ * or feed them straight into a DSSE envelope) without needing the rest
+ * of the Attest service plumbing.
+ */
+
+import type { AttestInput } from "../schemas/Attestation.js";
+import { IN_TOTO_STATEMENT_V1, InTotoStatement, InTotoSubject } from "../schemas/Attestation.js";
+
+/**
+ * Build a {@link InTotoStatement} from a list of subjects and a typed
+ * predicate.
+ *
+ * @example
+ * ```ts
+ * const stmt = buildStatement({
+ *   subjects: [{ name: "pkg:npm/@scope/pkg@1.0.0", digest: { sha256: "..." } }],
+ *   predicateType: SLSA_PROVENANCE_V1,
+ *   predicate: { buildDefinition: ..., runDetails: ... },
+ * })
+ * ```
+ *
+ * @public
+ */
+export const buildStatement = (input: AttestInput): InTotoStatement => {
+	return new InTotoStatement({
+		_type: IN_TOTO_STATEMENT_V1,
+		subject: [...input.subjects],
+		predicateType: input.predicateType,
+		predicate: input.predicate,
+	});
+};
+
+/**
+ * Build a single-subject {@link InTotoSubject} from a name and sha256
+ * digest. Convenience for the common case of attesting one artifact.
+ *
+ * @param name - PURL or other identifier (e.g. `pkg:npm/@scope/pkg@1.0.0`).
+ * @param sha256 - 64-char lowercase hex SHA-256 digest of the artifact.
+ *
+ * @public
+ */
+export const subject = (name: string, sha256: string): InTotoSubject =>
+	new InTotoSubject({ name, digest: { sha256: sha256.replace(/^sha256:/i, "") } });
+
+/**
+ * Serialize a statement to canonical JSON for hashing / DSSE-wrapping.
+ *
+ * @remarks
+ * No special canonicalization beyond `JSON.stringify` with two-space
+ * indentation — the DSSE Pre-Authentication Encoding handles
+ * canonicalization separately. This is the form we write to disk for
+ * local inspection (`Attest.save`) and what gets fed into the DSSE
+ * envelope's payload field.
+ *
+ * @public
+ */
+export const serializeStatement = (statement: InTotoStatement): string => JSON.stringify(statement, null, 2);
+
+/** PURL helper for npm packages. */
+export const npmPurl = (name: string, version: string): string => `pkg:npm/${name}@${version}`;

--- a/src/utils/slsa.test.ts
+++ b/src/utils/slsa.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Step-8a tests for the Attest service: SLSA predicate helpers.
+ *
+ * @remarks
+ * Pure functions, no Effect plumbing beyond `runPromise`/`runSync`.
+ * The shape of the predicate is asserted against the snapshot
+ * `@actions/attest` produces so verifiers can't tell the two paths
+ * apart.
+ */
+
+import { Effect } from "effect";
+import { describe, expect, it } from "vitest";
+import type { OidcClaims } from "../testing.js";
+import { GITHUB_BUILD_TYPE, buildSLSAProvenancePredicate, decodeJwtClaims } from "../testing.js";
+
+const base64UrlEncode = (obj: unknown): string =>
+	Buffer.from(JSON.stringify(obj), "utf-8")
+		.toString("base64")
+		.replace(/=+$/, "")
+		.replace(/\+/g, "-")
+		.replace(/\//g, "_");
+
+const fakeJwt = (payload: Record<string, unknown>): string => {
+	const header = base64UrlEncode({ alg: "RS256", typ: "JWT" });
+	const body = base64UrlEncode(payload);
+	return `${header}.${body}.signature-not-verified`;
+};
+
+const fullClaims: OidcClaims = {
+	iss: "https://token.actions.githubusercontent.com",
+	ref: "refs/heads/main",
+	sha: "deadbeef".repeat(5),
+	repository: "savvy-web/silk-integration",
+	event_name: "push",
+	job_workflow_ref: "savvy-web/workflow-release-action/.github/workflows/release.yml@refs/heads/main",
+	workflow_ref: "savvy-web/silk-integration/.github/workflows/release.yml@refs/heads/main",
+	repository_id: "123456",
+	repository_owner_id: "654321",
+	runner_environment: "github-hosted",
+	run_id: "987654",
+	run_attempt: "1",
+};
+
+describe("decodeJwtClaims — step 8a", () => {
+	it("extracts the payload from a valid 3-segment JWT", async () => {
+		const token = fakeJwt(fullClaims);
+		const decoded = await Effect.runPromise(decodeJwtClaims(token));
+		expect(decoded.repository).toBe("savvy-web/silk-integration");
+		expect(decoded.run_id).toBe("987654");
+	});
+
+	it("fails with `decode` reason on a malformed JWT", async () => {
+		const exit = await Effect.runPromiseExit(decodeJwtClaims("not-a-jwt"));
+		expect(exit._tag).toBe("Failure");
+		if (exit._tag === "Failure") {
+			expect(JSON.stringify(exit.cause)).toContain('"reason":"decode"');
+		}
+	});
+
+	it("fails with `claims` reason when required claims are missing", async () => {
+		const { run_id: _, ...partial } = fullClaims;
+		void _;
+		const token = fakeJwt(partial);
+
+		const exit = await Effect.runPromiseExit(decodeJwtClaims(token));
+		expect(exit._tag).toBe("Failure");
+		if (exit._tag === "Failure") {
+			const cause = JSON.stringify(exit.cause);
+			expect(cause).toContain('"reason":"claims"');
+			expect(cause).toContain("run_id");
+		}
+	});
+});
+
+describe("buildSLSAProvenancePredicate — step 8a", () => {
+	it("produces a SLSA v1 predicate with the GitHub workflow build type", async () => {
+		const predicate = (await Effect.runPromise(
+			buildSLSAProvenancePredicate(fullClaims, { GITHUB_SERVER_URL: "https://github.com" }),
+		)) as {
+			buildDefinition: {
+				buildType: string;
+				externalParameters: { workflow: { ref: string; repository: string; path: string } };
+				internalParameters: { github: { event_name: string } };
+				resolvedDependencies: Array<{ uri: string; digest: { gitCommit: string } }>;
+			};
+			runDetails: {
+				builder: { id: string };
+				metadata: { invocationId: string };
+			};
+		};
+
+		expect(predicate.buildDefinition.buildType).toBe(GITHUB_BUILD_TYPE);
+		expect(predicate.buildDefinition.externalParameters.workflow).toEqual({
+			ref: "refs/heads/main",
+			repository: "https://github.com/savvy-web/silk-integration",
+			path: ".github/workflows/release.yml",
+		});
+		expect(predicate.buildDefinition.internalParameters.github.event_name).toBe("push");
+		expect(predicate.buildDefinition.resolvedDependencies[0]).toEqual({
+			uri: "git+https://github.com/savvy-web/silk-integration@refs/heads/main",
+			digest: { gitCommit: "deadbeef".repeat(5) },
+		});
+		expect(predicate.runDetails.builder.id).toBe(
+			"https://github.com/savvy-web/workflow-release-action/.github/workflows/release.yml@refs/heads/main",
+		);
+		expect(predicate.runDetails.metadata.invocationId).toBe(
+			"https://github.com/savvy-web/silk-integration/actions/runs/987654/attempts/1",
+		);
+	});
+
+	it("defaults GITHUB_SERVER_URL to https://github.com", async () => {
+		const predicate = (await Effect.runPromise(buildSLSAProvenancePredicate(fullClaims, {}))) as {
+			buildDefinition: { externalParameters: { workflow: { repository: string } } };
+		};
+		expect(predicate.buildDefinition.externalParameters.workflow.repository).toBe(
+			"https://github.com/savvy-web/silk-integration",
+		);
+	});
+
+	it("honors GITHUB_SERVER_URL for GHES deployments", async () => {
+		const predicate = (await Effect.runPromise(
+			buildSLSAProvenancePredicate(fullClaims, { GITHUB_SERVER_URL: "https://github.example.com" }),
+		)) as {
+			buildDefinition: { externalParameters: { workflow: { repository: string } } };
+			runDetails: { builder: { id: string } };
+		};
+		expect(predicate.buildDefinition.externalParameters.workflow.repository).toBe(
+			"https://github.example.com/savvy-web/silk-integration",
+		);
+		expect(predicate.runDetails.builder.id).toBe(
+			"https://github.example.com/savvy-web/workflow-release-action/.github/workflows/release.yml@refs/heads/main",
+		);
+	});
+
+	it("end-to-end: decode + build round-trip", async () => {
+		const token = fakeJwt(fullClaims);
+		const predicate = await Effect.runPromise(
+			Effect.gen(function* () {
+				const claims = yield* decodeJwtClaims(token);
+				return yield* buildSLSAProvenancePredicate(claims, { GITHUB_SERVER_URL: "https://github.com" });
+			}),
+		);
+		expect(predicate).toMatchObject({ buildDefinition: { buildType: GITHUB_BUILD_TYPE } });
+	});
+});

--- a/src/utils/slsa.ts
+++ b/src/utils/slsa.ts
@@ -1,0 +1,169 @@
+/**
+ * SLSA Provenance v1 predicate construction for the GitHub Actions
+ * `workflow/v1` build type.
+ *
+ * @remarks
+ * Two pure helpers:
+ *
+ * - {@link decodeJwtClaims} — extracts the payload from a runner-issued
+ *   OIDC JWT. We do _not_ re-verify the JWT here: the token already
+ *   came from the runner's token-service endpoint over TLS, and we
+ *   only use the claims to populate the predicate (not for trust
+ *   decisions). Re-verifying would require fetching JWKS over the
+ *   network, which makes the helper non-pure.
+ * - {@link buildSLSAProvenancePredicate} — assembles a SLSA v1
+ *   predicate from the JWT claims + the current runner environment,
+ *   shaped to match what `@actions/attest`'s `attestProvenance`
+ *   produces.
+ */
+
+import { Effect } from "effect";
+import { SlsaError } from "../errors/SlsaError.js";
+
+/** GitHub Actions `workflow/v1` build type. */
+export const GITHUB_BUILD_TYPE = "https://actions.github.io/buildtypes/workflow/v1" as const;
+
+/**
+ * Subset of GitHub Actions OIDC claims used to construct an SLSA
+ * provenance predicate.
+ *
+ * @public
+ */
+export interface OidcClaims {
+	readonly iss: string;
+	readonly ref: string;
+	readonly sha: string;
+	readonly repository: string;
+	readonly event_name: string;
+	readonly job_workflow_ref: string;
+	readonly workflow_ref: string;
+	readonly repository_id: string;
+	readonly repository_owner_id: string;
+	readonly runner_environment: string;
+	readonly run_id: string;
+	readonly run_attempt: string;
+	readonly [k: string]: unknown;
+}
+
+const REQUIRED_CLAIMS = [
+	"iss",
+	"ref",
+	"sha",
+	"repository",
+	"event_name",
+	"job_workflow_ref",
+	"workflow_ref",
+	"repository_id",
+	"repository_owner_id",
+	"runner_environment",
+	"run_id",
+	"run_attempt",
+] as const;
+
+const base64UrlDecode = (segment: string): string => {
+	const padded = segment
+		.replace(/-/g, "+")
+		.replace(/_/g, "/")
+		.padEnd(Math.ceil(segment.length / 4) * 4, "=");
+	return Buffer.from(padded, "base64").toString("utf-8");
+};
+
+/**
+ * Decode a JWT payload without verifying its signature.
+ *
+ * @remarks
+ * Intended only for extracting claims from a token the runner just
+ * issued to us — do not call this on user-supplied tokens.
+ *
+ * @public
+ */
+export const decodeJwtClaims = (token: string): Effect.Effect<OidcClaims, SlsaError> =>
+	Effect.try({
+		try: () => {
+			const parts = token.split(".");
+			if (parts.length !== 3) {
+				throw new Error(`Expected a 3-segment JWT, got ${parts.length}`);
+			}
+			const decoded = base64UrlDecode(parts[1]);
+			const payload = JSON.parse(decoded) as Record<string, unknown>;
+			const missing = REQUIRED_CLAIMS.filter((c) => !(c in payload));
+			if (missing.length > 0) {
+				throw new Error(`OIDC token is missing required claims: ${missing.join(", ")}`);
+			}
+			return payload as unknown as OidcClaims;
+		},
+		catch: (cause) =>
+			new SlsaError({
+				reason: cause instanceof Error && cause.message.startsWith("OIDC token is missing") ? "claims" : "decode",
+				message: cause instanceof Error ? cause.message : String(cause),
+				cause,
+			}),
+	});
+
+/**
+ * Build a SLSA Provenance v1 predicate from OIDC claims + the current
+ * runner environment.
+ *
+ * @remarks
+ * Matches the shape `@actions/attest`'s `attestProvenance` produces so
+ * downstream verifiers see the same `buildDefinition` /
+ * `runDetails` structure regardless of which path generated the
+ * attestation.
+ *
+ * @param claims - OIDC claims (use {@link decodeJwtClaims} to extract).
+ * @param env - Runner environment overrides; defaults to `process.env`.
+ *
+ * @public
+ */
+export const buildSLSAProvenancePredicate = (
+	claims: OidcClaims,
+	env: Readonly<Record<string, string | undefined>> = process.env,
+): Effect.Effect<Record<string, unknown>, SlsaError> =>
+	Effect.try({
+		try: () => {
+			const serverURL = env.GITHUB_SERVER_URL ?? "https://github.com";
+			// Split path and ref from `owner/repo/.github/workflows/main.yml@main`.
+			const [workflowPath] = claims.workflow_ref.replace(`${claims.repository}/`, "").split("@");
+
+			return {
+				buildDefinition: {
+					buildType: GITHUB_BUILD_TYPE,
+					externalParameters: {
+						workflow: {
+							ref: claims.ref,
+							repository: `${serverURL}/${claims.repository}`,
+							path: workflowPath,
+						},
+					},
+					internalParameters: {
+						github: {
+							event_name: claims.event_name,
+							repository_id: claims.repository_id,
+							repository_owner_id: claims.repository_owner_id,
+							runner_environment: claims.runner_environment,
+						},
+					},
+					resolvedDependencies: [
+						{
+							uri: `git+${serverURL}/${claims.repository}@${claims.ref}`,
+							digest: { gitCommit: claims.sha },
+						},
+					],
+				},
+				runDetails: {
+					builder: {
+						id: `${serverURL}/${claims.job_workflow_ref}`,
+					},
+					metadata: {
+						invocationId: `${serverURL}/${claims.repository}/actions/runs/${claims.run_id}/attempts/${claims.run_attempt}`,
+					},
+				},
+			};
+		},
+		catch: (cause) =>
+			new SlsaError({
+				reason: "env",
+				message: `Failed to build SLSA provenance predicate: ${cause instanceof Error ? cause.message : String(cause)}`,
+				cause,
+			}),
+	});


### PR DESCRIPTION
## Summary

Ports `workflow-release-action`'s imperative Phase-2/3 publish chain to Effect primitives, validated end-to-end against `savvy-web/github-action-builder` over a long debugging arc. The library gains the self-recovering publish primitives, step-buffered logging, per-registry version probing, and the attestation idempotency the consumer's orchestration needs.

## What's in this branch

- New `Step` module — `withStep` / `success` / `collapse` / `groupStep` for one-summary-line-per-step logging with debug buffered and spilled on failure.
- `Attest.listForSubject` (idempotent attestation reuse) + `Attest.sbom({ bomDocument })` (attest a pre-built CycloneDX BOM verbatim).
- `PackagePublish` redesign: `pack` returns sha512 integrity + sha256 hex + sizes; new `publishTarball`; `packageManager` dispatch (fixes OIDC trusted publishing on Node 24 runners); verbose + streaming npm output; `publishIdempotent` deprecated.
- `NpmRegistry` per-target probe: `getVersions`/`getPackageInfo` registry override + new `getPublishedIntegrity`.
- `Sbom.generate` supplier + author metadata for NTIA compliance.
- Bug fixes: GitTag annotated-tag resolution, stderr-tail error truncation, `message` getters on `NpmRegistryError`/`PackagePublishError`, `dryRun` object-form parsing, Octokit deprecation-warning suppression.

Full detail in `.changeset/upstream-port-publish-chain.md` (minor release).

## Validation

`@savvy-web/github-action-builder@0.7.1` published to both npm and GitHub Packages through this chain, with self-healing recovery across partial-publish failures, attestation reuse on re-runs, and the clean step-buffered log output. `release.yml` switched to the `@dev` reusable workflow to consume the matching `workflow-release-action` behaviour.

## Test status

`pnpm typecheck`, `pnpm test` (1020 passing), `pnpm build` all green.

Signed-off-by: C. Spencer Beggs <spencer@beggs.codes>
