### PR TITLE
feat: resilient GitHub client with retry and streaming pagination

### DIFF
--- a/.changeset/ws2-resilient-github-client.md
+++ b/.changeset/ws2-resilient-github-client.md
@@ -1,0 +1,63 @@
+---
+"@savvy-web/github-action-effects": major
+---
+
+## Breaking changes
+
+### `GitHubClientLive.fromApp` now requires a `Scope`
+
+`fromApp` builds as a scoped layer so it can revoke its installation token on
+scope close. Consumers on `ActionsRuntime.Default` / `Action.run` are unaffected
+(the run boundary establishes and finalizes the scope automatically). Consumers
+who provide `fromApp` via a bare `Effect.provide` must now wrap in
+`Effect.scoped`. Part of the 2.0 release.
+
+### `GitHubClientLive.fromEnv` is now a constructor function
+
+`fromEnv` changed from a bare `Layer` value to a function
+`(resilience?: ResilienceOptions) => Layer` so it can accept resilience tuning,
+matching `fromToken` and `fromApp`. Call it as `GitHubClientLive.fromEnv()`
+(or `GitHubClientLive.fromEnv({ enabled: false })` for bare behavior).
+
+## Features
+
+### Resilient `GitHubClient` — automatic retry and rate-limit awareness
+
+Every `GitHubClient` call (`rest`, `graphql`, `paginate`, and the new
+`paginateStream`) now retries retryable failures (429 and 5xx) automatically
+with an exponential, jittered, capped backoff, and honors server-advised delays
+from the `Retry-After` and `x-ratelimit-reset` response headers. Resilience is
+on by default; every `GitHubClientLive` constructor (`fromEnv`, `fromToken`,
+`fromApp`) accepts an optional `ResilienceOptions` argument to tune
+`maxRetries` / `baseDelay` / `maxDelay` or disable retries entirely. The pure
+`resilienceSchedule` builder is exported for reuse. All 14 `GitHubClient`-backed
+services inherit this with no code change. `GitHubClientError` gained an optional
+`retryAfterMs` field carrying the server-advised delay.
+
+### Streaming pagination — `GitHubClient.paginateStream`
+
+A new `paginateStream` method returns an Effect `Stream` that fetches one page at
+a time, so consumers can `takeWhile` / `take` and stop early without buffering or
+fetching the remaining pages. The eager `paginate` is unchanged and agrees with
+`paginateStream` on page boundaries.
+
+## Bug Fixes
+
+### `RateLimiter` no longer probes `GET /rate_limit` on every guarded call
+
+`withRateLimit` previously issued a pre-flight `GET /rate_limit` before every
+guarded effect, wasting a request and quota per call. It now reads the
+`x-ratelimit-*` headers observed on real responses (cached in a shared `Ref`
+via an internal `RateLimitState`) and only waits or fails when the cached
+remaining quota is below the 10 percent threshold. `checkRest` and `checkGraphQL`
+are cache-first and probe only on a cache miss. Strictly fewer requests,
+identical wait/fail policy. To share the observed snapshot between the client
+and the rate limiter, provide `RateLimitState.Default` once at the graph root;
+without it each falls back to a private cache (still probe-free).
+
+### `fromApp` revokes its installation token on scope close
+
+`GitHubClientLive.fromApp` now builds as a scoped layer and revokes the minted
+installation token when its scope closes, instead of leaving short-lived tokens
+to expire. A `Layer.memoize` recipe is documented on `fromApp` for sharing one
+App client (and one token) across multiple provides in a single run.

--- a/.changeset/ws2-resilient-github-client.md
+++ b/.changeset/ws2-resilient-github-client.md
@@ -49,9 +49,10 @@ fetching the remaining pages. The eager `paginate` is unchanged and agrees with
 guarded effect, wasting a request and quota per call. It now reads the
 `x-ratelimit-*` headers observed on real responses (cached in a shared `Ref`
 via an internal `RateLimitState`) and only waits or fails when the cached
-remaining quota is below the 10 percent threshold. `checkRest` and `checkGraphQL`
-are cache-first and probe only on a cache miss. Strictly fewer requests,
-identical wait/fail policy. To share the observed snapshot between the client
+remaining quota is below the 10 percent threshold. `checkRest` is cache-first
+(the shared snapshot holds the core/REST bucket) and probes only on a cache
+miss; `checkGraphQL` always probes, since REST and GraphQL have independent
+quotas. Strictly fewer requests, identical wait/fail policy. To share the observed snapshot between the client
 and the rate limiter, provide `RateLimitState.Default` once at the graph root;
 without it each falls back to a private cache (still probe-free).
 

--- a/src/errors/GitHubClientError.ts
+++ b/src/errors/GitHubClientError.ts
@@ -15,4 +15,12 @@ export class GitHubClientError extends Data.TaggedError("GitHubClientError")<{
 
 	/** Whether this error is retryable (e.g., rate limit, 5xx). */
 	readonly retryable: boolean;
+
+	/**
+	 * Server-advised delay before retrying, in milliseconds, if the response
+	 * carried a `Retry-After` header or an exhausted `x-ratelimit-reset`.
+	 * `undefined` when the server gave no explicit hint (the resilient client
+	 * then falls back to its exponential backoff).
+	 */
+	readonly retryAfterMs: number | undefined;
 }> {}

--- a/src/index.ts
+++ b/src/index.ts
@@ -137,6 +137,8 @@ export { PullRequestTest } from "./layers/PullRequestTest.js";
 export { RateLimiterLive } from "./layers/RateLimiterLive.js";
 export type { RateLimiterTestState } from "./layers/RateLimiterTest.js";
 export { RateLimiterTest } from "./layers/RateLimiterTest.js";
+export type { ResilienceOptions } from "./layers/resilience.js";
+export { resilienceSchedule } from "./layers/resilience.js";
 export { SbomLive } from "./layers/SbomLive.js";
 export type { SbomTestState } from "./layers/SbomTest.js";
 export { SbomTest, makeSbomTestState } from "./layers/SbomTest.js";

--- a/src/layers/CheckRunLive.test.ts
+++ b/src/layers/CheckRunLive.test.ts
@@ -1,4 +1,4 @@
-import { Effect, Layer } from "effect";
+import { Effect, Layer, Stream } from "effect";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { GitHubClientError } from "../errors/GitHubClientError.js";
 import { CheckRun } from "../services/CheckRun.js";
@@ -24,10 +24,12 @@ const mockClient: typeof GitHubClient.Service = {
 					status: undefined,
 					reason: e instanceof Error ? e.message : String(e),
 					retryable: false,
+					retryAfterMs: undefined,
 				}),
 		}).pipe(Effect.map((r) => r.data)),
 	graphql: () => Effect.die("not used"),
 	paginate: () => Effect.die("not used"),
+	paginateStream: () => Stream.die("not used"),
 	repo: Effect.succeed({ owner: "test-owner", repo: "test-repo" }),
 };
 

--- a/src/layers/GitBranchLive.test.ts
+++ b/src/layers/GitBranchLive.test.ts
@@ -1,4 +1,4 @@
-import { Cause, Duration, Effect, Exit, Fiber, Layer, TestClock, TestContext } from "effect";
+import { Cause, Duration, Effect, Exit, Fiber, Layer, Stream, TestClock, TestContext } from "effect";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { GitHubClientError } from "../errors/GitHubClientError.js";
 import { GitBranch } from "../services/GitBranch.js";
@@ -30,10 +30,12 @@ const mockClient: typeof GitHubClient.Service = {
 					status: undefined,
 					reason: e instanceof Error ? e.message : String(e),
 					retryable: false,
+					retryAfterMs: undefined,
 				}),
 		}).pipe(Effect.map((r) => r.data)),
 	graphql: () => Effect.die("not used"),
 	paginate: () => Effect.die("not used"),
+	paginateStream: () => Stream.die("not used"),
 	repo: Effect.succeed({ owner: "test-owner", repo: "test-repo" }),
 };
 
@@ -66,11 +68,13 @@ const makeMockClient = (): typeof GitHubClient.Service => ({
 					status,
 					reason: message,
 					retryable: status !== undefined && (status === 429 || status >= 500),
+					retryAfterMs: undefined,
 				});
 			},
 		}).pipe(Effect.map((r) => r.data)),
 	graphql: () => Effect.die("not used"),
 	paginate: () => Effect.die("not used"),
+	paginateStream: () => Stream.die("not used"),
 	repo: Effect.succeed({ owner: "test-owner", repo: "test-repo" }),
 });
 
@@ -155,6 +159,7 @@ describe("GitBranchLive", () => {
 								status: 500,
 								reason: "Internal Server Error",
 								retryable: false,
+								retryAfterMs: undefined,
 							}),
 					}).pipe(Effect.map((r) => r.data)),
 			};
@@ -194,6 +199,7 @@ describe("GitBranchLive", () => {
 								status: 404,
 								reason: "Not Found",
 								retryable: false,
+								retryAfterMs: undefined,
 							}),
 					}).pipe(Effect.map((r) => r.data)),
 			};

--- a/src/layers/GitCommitLive.test.ts
+++ b/src/layers/GitCommitLive.test.ts
@@ -1,4 +1,4 @@
-import { Effect, Layer } from "effect";
+import { Effect, Layer, Stream } from "effect";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { GitHubClientError } from "../errors/GitHubClientError.js";
 import { GitCommit } from "../services/GitCommit.js";
@@ -30,10 +30,12 @@ const mockClient: typeof GitHubClient.Service = {
 					status: undefined,
 					reason: e instanceof Error ? e.message : String(e),
 					retryable: false,
+					retryAfterMs: undefined,
 				}),
 		}).pipe(Effect.map((r) => r.data)),
 	graphql: () => Effect.die("not used"),
 	paginate: () => Effect.die("not used"),
+	paginateStream: () => Stream.die("not used"),
 	repo: Effect.succeed({ owner: "test-owner", repo: "test-repo" }),
 };
 

--- a/src/layers/GitHubArtifactMetadataLive.test.ts
+++ b/src/layers/GitHubArtifactMetadataLive.test.ts
@@ -1,4 +1,4 @@
-import { Effect, Layer } from "effect";
+import { Effect, Layer, Stream } from "effect";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { GitHubArtifactMetadataError } from "../errors/GitHubArtifactMetadataError.js";
 import { GitHubClientError } from "../errors/GitHubClientError.js";
@@ -21,9 +21,11 @@ const mockClient: typeof GitHubClient.Service = {
 					status: undefined,
 					reason: e instanceof Error ? e.message : String(e),
 					retryable: false,
+					retryAfterMs: undefined,
 				}),
 		}).pipe(Effect.map((r) => r.data)),
 	graphql: () => Effect.die("not used"),
+	paginateStream: () => Stream.die("not used"),
 	paginate: <T>(
 		_operation: string,
 		fn: (octokit: unknown, page: number, perPage: number) => Promise<{ data: T[] }>,
@@ -44,6 +46,7 @@ const mockClient: typeof GitHubClient.Service = {
 					status: undefined,
 					reason: e instanceof Error ? e.message : String(e),
 					retryable: false,
+					retryAfterMs: undefined,
 				}),
 		}).pipe(Effect.map((r) => r.data)),
 	repo: Effect.succeed({ owner: "test-owner", repo: "test-repo" }),

--- a/src/layers/GitHubClientLive.test.ts
+++ b/src/layers/GitHubClientLive.test.ts
@@ -1,6 +1,21 @@
-import { Cause, Effect, Exit, Redacted } from "effect";
+import {
+	Cause,
+	Chunk,
+	Duration,
+	Effect,
+	Exit,
+	Fiber,
+	Layer,
+	Option,
+	Redacted,
+	Ref,
+	Stream,
+	TestClock,
+	TestContext,
+} from "effect";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { GitHubClient } from "../services/GitHubClient.js";
+import { RateLimitState } from "../services/RateLimitState.js";
 import { GitHubClientLive } from "./GitHubClientLive.js";
 
 const { octokitAuthCalls, mockAuth } = vi.hoisted(() => ({
@@ -31,11 +46,13 @@ afterEach(() => {
 
 describe("GitHubClientLive", () => {
 	describe("fromEnv", () => {
+		// Error-wrapping tests disable resilience so retryable failures fail fast;
+		// retry behavior has dedicated tests under the "resilience" describe.
 		const run = <A, E>(effect: Effect.Effect<A, E, GitHubClient>) =>
-			Effect.runPromise(Effect.provide(effect, GitHubClientLive.fromEnv));
+			Effect.runPromise(Effect.provide(effect, GitHubClientLive.fromEnv({ enabled: false })));
 
 		const runExit = <A, E>(effect: Effect.Effect<A, E, GitHubClient>) =>
-			Effect.runPromise(Effect.exit(Effect.provide(effect, GitHubClientLive.fromEnv)));
+			Effect.runPromise(Effect.exit(Effect.provide(effect, GitHubClientLive.fromEnv({ enabled: false }))));
 
 		it("fails when GITHUB_TOKEN is not set", async () => {
 			delete process.env.GITHUB_TOKEN;
@@ -243,6 +260,19 @@ describe("GitHubClientLive", () => {
 	});
 
 	describe("fromApp", () => {
+		// fromApp is now a scoped layer that revokes its token (DELETE
+		// /installation/token via fetch) on scope close. Stub fetch so the revoke
+		// finalizer never touches the network, and wrap provides in Effect.scoped.
+		let fromAppFetchSpy: ReturnType<typeof vi.spyOn>;
+		beforeEach(() => {
+			fromAppFetchSpy = vi
+				.spyOn(globalThis, "fetch")
+				.mockImplementation(() => Promise.resolve(new Response(null, { status: 204 })));
+		});
+		afterEach(() => {
+			fromAppFetchSpy.mockRestore();
+		});
+
 		it("generates an installation token and builds a client", async () => {
 			mockAuth.mockResolvedValue({
 				token: "app-installation-token",
@@ -251,9 +281,11 @@ describe("GitHubClientLive", () => {
 				permissions: { contents: "write" },
 			});
 			const result = await Effect.runPromise(
-				Effect.provide(
-					Effect.flatMap(GitHubClient, (client) => client.rest("op", () => Promise.resolve({ data: "done" }))),
-					GitHubClientLive.fromApp({ clientId: "Iv1.abc", privateKey: "key", installationId: 42 }),
+				Effect.scoped(
+					Effect.provide(
+						Effect.flatMap(GitHubClient, (client) => client.rest("op", () => Promise.resolve({ data: "done" }))),
+						GitHubClientLive.fromApp({ clientId: "Iv1.abc", privateKey: "key", installationId: 42 }),
+					),
 				),
 			);
 			expect(result).toBe("done");
@@ -267,13 +299,15 @@ describe("GitHubClientLive", () => {
 				permissions: {},
 			});
 			const result = await Effect.runPromise(
-				Effect.provide(
-					Effect.flatMap(GitHubClient, (client) => client.rest("op", () => Promise.resolve({ data: 1 }))),
-					GitHubClientLive.fromApp({
-						clientId: "Iv1.abc",
-						privateKey: Redacted.make("key"),
-						installationId: 42,
-					}),
+				Effect.scoped(
+					Effect.provide(
+						Effect.flatMap(GitHubClient, (client) => client.rest("op", () => Promise.resolve({ data: 1 }))),
+						GitHubClientLive.fromApp({
+							clientId: "Iv1.abc",
+							privateKey: Redacted.make("key"),
+							installationId: 42,
+						}),
+					),
 				),
 			);
 			expect(result).toBe(1);
@@ -283,9 +317,11 @@ describe("GitHubClientLive", () => {
 			mockAuth.mockRejectedValue(new Error("bad credentials"));
 			const exit = await Effect.runPromise(
 				Effect.exit(
-					Effect.provide(
-						Effect.flatMap(GitHubClient, (client) => client.repo),
-						GitHubClientLive.fromApp({ clientId: "Iv1.abc", privateKey: "key", installationId: 42 }),
+					Effect.scoped(
+						Effect.provide(
+							Effect.flatMap(GitHubClient, (client) => client.repo),
+							GitHubClientLive.fromApp({ clientId: "Iv1.abc", privateKey: "key", installationId: 42 }),
+						),
 					),
 				),
 			);
@@ -294,6 +330,340 @@ describe("GitHubClientLive", () => {
 				const err = Cause.squash(exit.cause) as { _tag?: string };
 				expect(err._tag).toBe("GitHubAppError");
 			}
+		});
+	});
+
+	describe("resilience", () => {
+		/** Drive a retrying effect under TestClock so backoff sleeps are instant. */
+		const runWithClock = <A, E>(effect: Effect.Effect<A, E>, advance = Duration.seconds(600)) =>
+			Effect.gen(function* () {
+				const fiber = yield* Effect.fork(effect);
+				yield* TestClock.adjust(advance);
+				return yield* Fiber.join(fiber);
+			}).pipe(Effect.exit, Effect.provide(TestContext.TestContext), Effect.runPromise);
+
+		it("rest retries a transient 503 then succeeds (default-on)", async () => {
+			let attempts = 0;
+			const exit = await runWithClock(
+				Effect.provide(
+					Effect.flatMap(GitHubClient, (client) =>
+						client.rest("op", () => {
+							attempts++;
+							if (attempts < 2) {
+								return Promise.reject(Object.assign(new Error("unavailable"), { status: 503 }));
+							}
+							return Promise.resolve({ data: "ok" });
+						}),
+					),
+					GitHubClientLive.fromToken("t"),
+				),
+			);
+			expect(exit._tag).toBe("Success");
+			expect(attempts).toBe(2);
+		});
+
+		it("rest with resilience disabled does not retry", async () => {
+			let attempts = 0;
+			const exit = await runWithClock(
+				Effect.provide(
+					Effect.flatMap(GitHubClient, (client) =>
+						client.rest("op", () => {
+							attempts++;
+							return Promise.reject(Object.assign(new Error("unavailable"), { status: 503 }));
+						}),
+					),
+					GitHubClientLive.fromToken("t", { enabled: false }),
+				),
+			);
+			expect(exit._tag).toBe("Failure");
+			expect(attempts).toBe(1);
+		});
+
+		it("rest does not retry non-retryable (404) errors", async () => {
+			let attempts = 0;
+			const exit = await runWithClock(
+				Effect.provide(
+					Effect.flatMap(GitHubClient, (client) =>
+						client.rest("op", () => {
+							attempts++;
+							return Promise.reject(Object.assign(new Error("not found"), { status: 404 }));
+						}),
+					),
+					GitHubClientLive.fromToken("t"),
+				),
+			);
+			expect(exit._tag).toBe("Failure");
+			expect(attempts).toBe(1);
+		});
+
+		it("honors a Retry-After header as the retry delay", async () => {
+			let attempts = 0;
+			const exit = await Effect.gen(function* () {
+				const fiber = yield* Effect.fork(
+					Effect.provide(
+						Effect.flatMap(GitHubClient, (client) =>
+							client.rest("op", () => {
+								attempts++;
+								if (attempts < 2) {
+									return Promise.reject(
+										Object.assign(new Error("secondary limit"), {
+											status: 429,
+											response: { headers: { "retry-after": "5" } },
+										}),
+									);
+								}
+								return Promise.resolve({ data: "recovered" });
+							}),
+						),
+						GitHubClientLive.fromToken("t"),
+					),
+				);
+				// Less than the advised 5s: still pending.
+				yield* TestClock.adjust(Duration.seconds(4));
+				const stillRunning = (yield* Fiber.poll(fiber))._tag === "None";
+				// Past the advised delay: completes.
+				yield* TestClock.adjust(Duration.seconds(2));
+				const result = yield* Fiber.join(fiber);
+				return { stillRunning, result };
+			}).pipe(Effect.exit, Effect.provide(TestContext.TestContext), Effect.runPromise);
+
+			expect(exit._tag).toBe("Success");
+			if (Exit.isSuccess(exit)) {
+				expect(exit.value.stillRunning).toBe(true);
+				expect(exit.value.result).toBe("recovered");
+			}
+			expect(attempts).toBe(2);
+		});
+
+		it("graphql failures route through the resilient wrapper", async () => {
+			// graphql shares the withResilience wrapper. The mocked octokit.graphql
+			// rejects without a status (network error) → non-retryable → fails fast.
+			const exit = await runWithClock(
+				Effect.provide(
+					Effect.flatMap(GitHubClient, (client) => client.graphql("{ viewer { login } }")),
+					GitHubClientLive.fromToken("t"),
+				),
+			);
+			expect(exit._tag).toBe("Failure");
+		});
+	});
+
+	describe("rate-limit snapshot", () => {
+		it("records x-ratelimit headers into RateLimitState on a successful rest call", async () => {
+			const snapshot = await Effect.runPromise(
+				Effect.gen(function* () {
+					const ref = yield* RateLimitState;
+					yield* Effect.flatMap(GitHubClient, (client) =>
+						client.rest("op", () =>
+							Promise.resolve({
+								data: "ok",
+								headers: {
+									"x-ratelimit-remaining": "4321",
+									"x-ratelimit-limit": "5000",
+									"x-ratelimit-reset": "1700000000",
+								},
+							}),
+						),
+					);
+					return yield* Ref.get(ref);
+				}).pipe(Effect.provide(GitHubClientLive.fromToken("t")), Effect.provide(RateLimitState.Default)),
+			);
+			expect(Option.isSome(snapshot)).toBe(true);
+			if (Option.isSome(snapshot)) {
+				expect(snapshot.value.remaining).toBe(4321);
+				expect(snapshot.value.limit).toBe(5000);
+				expect(snapshot.value.resetEpochSeconds).toBe(1700000000);
+			}
+		});
+
+		it("leaves the snapshot untouched when no headers are present", async () => {
+			const snapshot = await Effect.runPromise(
+				Effect.gen(function* () {
+					const ref = yield* RateLimitState;
+					yield* Effect.flatMap(GitHubClient, (client) => client.rest("op", () => Promise.resolve({ data: "ok" })));
+					return yield* Ref.get(ref);
+				}).pipe(Effect.provide(GitHubClientLive.fromToken("t")), Effect.provide(RateLimitState.Default)),
+			);
+			expect(Option.isNone(snapshot)).toBe(true);
+		});
+	});
+
+	describe("paginateStream", () => {
+		it("emits pages lazily — Stream.take(1) fetches only page 1", async () => {
+			let callCount = 0;
+			const result = await Effect.runPromise(
+				Effect.provide(
+					Effect.flatMap(GitHubClient, (client) =>
+						Stream.runCollect(
+							client
+								.paginateStream(
+									"op",
+									(_o, page) => {
+										callCount++;
+										if (page === 1) return Promise.resolve({ data: [1, 2, 3] });
+										return Promise.resolve({ data: [4, 5, 6] });
+									},
+									{ perPage: 3 },
+								)
+								.pipe(Stream.take(1)),
+						).pipe(Effect.map(Chunk.toReadonlyArray)),
+					),
+					GitHubClientLive.fromToken("t"),
+				),
+			);
+			expect(result).toEqual([1]);
+			expect(callCount).toBe(1);
+		});
+
+		it("stops at maxPages", async () => {
+			let callCount = 0;
+			const result = await Effect.runPromise(
+				Effect.provide(
+					Effect.flatMap(GitHubClient, (client) =>
+						Stream.runCollect(
+							client.paginateStream(
+								"op",
+								(_o, _page) => {
+									callCount++;
+									return Promise.resolve({ data: [1, 2, 3] });
+								},
+								{ perPage: 3, maxPages: 2 },
+							),
+						).pipe(Effect.map(Chunk.toReadonlyArray)),
+					),
+					GitHubClientLive.fromToken("t"),
+				),
+			);
+			expect(callCount).toBe(2);
+			expect(result).toEqual([1, 2, 3, 1, 2, 3]);
+		});
+
+		it("agrees with paginate on page boundaries", async () => {
+			const fn = (_o: unknown, page: number) => {
+				if (page === 1) return Promise.resolve({ data: [1, 2, 3] });
+				if (page === 2) return Promise.resolve({ data: [4, 5, 6] });
+				return Promise.resolve({ data: [7] });
+			};
+			const eager = await Effect.runPromise(
+				Effect.provide(
+					Effect.flatMap(GitHubClient, (client) => client.paginate("op", fn, { perPage: 3 })),
+					GitHubClientLive.fromToken("t"),
+				),
+			);
+			const streamed = await Effect.runPromise(
+				Effect.provide(
+					Effect.flatMap(GitHubClient, (client) =>
+						Stream.runCollect(client.paginateStream("op", fn, { perPage: 3 })).pipe(Effect.map(Chunk.toReadonlyArray)),
+					),
+					GitHubClientLive.fromToken("t"),
+				),
+			);
+			expect(streamed).toEqual(eager);
+			expect(streamed).toEqual([1, 2, 3, 4, 5, 6, 7]);
+		});
+
+		it("takeWhile stops fetching subsequent pages", async () => {
+			let callCount = 0;
+			const result = await Effect.runPromise(
+				Effect.provide(
+					Effect.flatMap(GitHubClient, (client) =>
+						Stream.runCollect(
+							client
+								.paginateStream(
+									"op",
+									(_o, page) => {
+										callCount++;
+										if (page === 1) return Promise.resolve({ data: [1, 2, 3] });
+										if (page === 2) return Promise.resolve({ data: [4, 5, 6] });
+										return Promise.resolve({ data: [7, 8, 9] });
+									},
+									{ perPage: 3 },
+								)
+								.pipe(Stream.takeWhile((x) => x < 5)),
+						).pipe(Effect.map(Chunk.toReadonlyArray)),
+					),
+					GitHubClientLive.fromToken("t"),
+				),
+			);
+			expect(result).toEqual([1, 2, 3, 4]);
+			// page 3 is never fetched; at most 2 pages.
+			expect(callCount).toBeLessThanOrEqual(2);
+		});
+
+		it("propagates errors through the stream", async () => {
+			const exit = await Effect.runPromise(
+				Effect.exit(
+					Effect.provide(
+						Effect.flatMap(GitHubClient, (client) =>
+							Stream.runCollect(client.paginateStream("op", () => Promise.reject(new Error("page fail")))),
+						),
+						GitHubClientLive.fromToken("t"),
+					),
+				),
+			);
+			expect(exit._tag).toBe("Failure");
+		});
+	});
+
+	describe("fromApp scope", () => {
+		it("revokes the installation token when the scope closes", async () => {
+			const revoked: Array<string> = [];
+			mockAuth.mockResolvedValue({
+				token: "scoped-installation-token",
+				expiresAt: "2099-01-01T00:00:00Z",
+				installationId: 42,
+				permissions: {},
+			});
+			// Spy on the revoke fetch (DELETE /installation/token).
+			const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation((url, init) => {
+				if (typeof url === "string" && url.includes("/installation/token") && init?.method === "DELETE") {
+					revoked.push(url);
+				}
+				return Promise.resolve(new Response(null, { status: 204 }));
+			});
+
+			await Effect.runPromise(
+				Effect.scoped(
+					Effect.provide(
+						Effect.flatMap(GitHubClient, (client) => client.rest("op", () => Promise.resolve({ data: "done" }))),
+						GitHubClientLive.fromApp({ clientId: "Iv1.abc", privateKey: "key", installationId: 42 }),
+					),
+				),
+			);
+
+			expect(revoked.length).toBe(1);
+			fetchSpy.mockRestore();
+		});
+
+		it("Layer.memoize builds the App client once across multiple provides", async () => {
+			mockAuth.mockResolvedValue({
+				token: "memoized-token",
+				expiresAt: "2099-01-01T00:00:00Z",
+				installationId: 42,
+				permissions: {},
+			});
+			const before = mockAuth.mock.calls.length;
+			const fetchSpy = vi
+				.spyOn(globalThis, "fetch")
+				.mockImplementation(() => Promise.resolve(new Response(null, { status: 204 })));
+
+			await Effect.runPromise(
+				Effect.gen(function* () {
+					const shared = yield* Layer.memoize(
+						GitHubClientLive.fromApp({ clientId: "Iv1.abc", privateKey: "key", installationId: 42 }),
+					);
+					yield* Effect.flatMap(GitHubClient, (client) => client.rest("a", () => Promise.resolve({ data: 1 }))).pipe(
+						Effect.provide(shared),
+					);
+					yield* Effect.flatMap(GitHubClient, (client) => client.rest("b", () => Promise.resolve({ data: 2 }))).pipe(
+						Effect.provide(shared),
+					);
+				}).pipe(Effect.scoped),
+			);
+
+			// generateToken (which calls mockAuth) ran exactly once for both provides.
+			expect(mockAuth.mock.calls.length - before).toBe(1);
+			fetchSpy.mockRestore();
 		});
 	});
 });

--- a/src/layers/GitHubClientLive.ts
+++ b/src/layers/GitHubClientLive.ts
@@ -1,14 +1,24 @@
 import { Octokit } from "@octokit/rest";
 import type { Redacted } from "effect";
-import { Effect, Layer } from "effect";
+import { Chunk, Effect, Layer, Option, Ref, Stream } from "effect";
 import type { GitHubAppError } from "../errors/GitHubAppError.js";
 import { GitHubClientError } from "../errors/GitHubClientError.js";
 import * as WorkflowCommand from "../runtime/WorkflowCommand.js";
 import { GitHubApp } from "../services/GitHubApp.js";
 import { GitHubClient } from "../services/GitHubClient.js";
+import type { RateLimitSnapshot } from "../services/RateLimitState.js";
+import { RateLimitState } from "../services/RateLimitState.js";
 import { unwrapRedacted } from "../utils/unwrapRedacted.js";
 import { GitHubAppLive } from "./GitHubAppLive.js";
 import { OctokitAuthAppLive } from "./OctokitAuthAppLive.js";
+import type { ResilienceOptions } from "./resilience.js";
+import { withResilience } from "./resilience.js";
+
+// Re-export the pure resilience surface so consumers can reach it through the
+// GitHubClient layer module (it lives in the octokit-free `resilience.ts` so
+// the testing entry point can also export it without dragging in @octokit/rest).
+export type { ResilienceOptions } from "./resilience.js";
+export { resilienceSchedule } from "./resilience.js";
 
 /**
  * Custom `log` sink installed on every Octokit instance to suppress the
@@ -47,6 +57,54 @@ const silentOctokitLog = {
 
 const isRetryableStatus = (status: number): boolean => status === 429 || status >= 500;
 
+/**
+ * Structural shape of the response headers Octokit returns at runtime. The
+ * callback types name only `{ data }`, but Octokit hands back the full
+ * `OctokitResponse` (`{ data, headers, status, url }`); the resilient client
+ * reads `headers` via this cast at the wire boundary. A hand-rolled `fn` that
+ * genuinely returns only `{ data }` yields no headers and degrades safely.
+ */
+interface WithHeaders {
+	readonly headers?: Record<string, string | number | undefined>;
+}
+
+const headerValue = (
+	headers: Record<string, string | number | undefined> | undefined,
+	key: string,
+): string | undefined => {
+	const raw = headers?.[key];
+	return raw === undefined ? undefined : String(raw);
+};
+
+/** Parse a server-advised retry delay (ms) from an Octokit-shaped error, if any. */
+const parseRetryAfterMs = (error: unknown): number | undefined => {
+	const headers =
+		typeof error === "object" && error !== null && "response" in error
+			? (error as { response?: { headers?: Record<string, string | number | undefined> } }).response?.headers
+			: undefined;
+	if (!headers) return undefined;
+
+	const retryAfter = headerValue(headers, "retry-after");
+	if (retryAfter !== undefined) {
+		const seconds = Number(retryAfter);
+		if (Number.isFinite(seconds) && seconds >= 0) {
+			return Math.round(seconds * 1000);
+		}
+	}
+
+	const remaining = headerValue(headers, "x-ratelimit-remaining");
+	const reset = headerValue(headers, "x-ratelimit-reset");
+	if (remaining === "0" && reset !== undefined) {
+		const resetEpoch = Number(reset);
+		if (Number.isFinite(resetEpoch)) {
+			const waitMs = resetEpoch * 1000 - Date.now();
+			return waitMs > 0 ? waitMs : 0;
+		}
+	}
+
+	return undefined;
+};
+
 const wrapError = (operation: string, error: unknown): GitHubClientError => {
 	const status =
 		typeof error === "object" && error !== null && "status" in error ? (error as { status: number }).status : undefined;
@@ -63,18 +121,65 @@ const wrapError = (operation: string, error: unknown): GitHubClientError => {
 		status,
 		reason: message,
 		retryable: status !== undefined && isRetryableStatus(status),
+		retryAfterMs: parseRetryAfterMs(error),
 	});
 };
 
-/** Build the GitHubClient service object from a concrete token. */
-const makeClient = (token: string): typeof GitHubClient.Service => {
+/** Parse a rate-limit snapshot from a successful response's headers, if present. */
+const parseSnapshot = (response: WithHeaders): Option.Option<RateLimitSnapshot> => {
+	const headers = response.headers;
+	const remaining = headerValue(headers, "x-ratelimit-remaining");
+	const limit = headerValue(headers, "x-ratelimit-limit");
+	const reset = headerValue(headers, "x-ratelimit-reset");
+	if (remaining === undefined || limit === undefined || reset === undefined) {
+		return Option.none();
+	}
+	const remainingNum = Number(remaining);
+	const limitNum = Number(limit);
+	const resetNum = Number(reset);
+	if (!Number.isFinite(remainingNum) || !Number.isFinite(limitNum) || !Number.isFinite(resetNum)) {
+		return Option.none();
+	}
+	return Option.some({
+		remaining: remainingNum,
+		limit: limitNum,
+		resetEpochSeconds: resetNum,
+		observedAt: Date.now(),
+	});
+};
+
+/**
+ * Build the GitHubClient service object from a concrete token.
+ *
+ * `snapshotRef` is the shared rate-limit state the client writes observed
+ * `x-ratelimit-*` headers into. `resilience` tunes (or disables) the automatic
+ * retry/backoff applied to every call.
+ */
+const makeClient = (
+	token: string,
+	snapshotRef: Ref.Ref<Option.Option<RateLimitSnapshot>>,
+	resilience?: ResilienceOptions,
+): typeof GitHubClient.Service => {
 	const octokit = new Octokit({ auth: token, log: silentOctokitLog });
+
+	/** Record a successful response's rate-limit headers into the shared snapshot. */
+	const recordSnapshot = (response: WithHeaders): Effect.Effect<void> => {
+		const parsed = parseSnapshot(response);
+		return Option.isSome(parsed) ? Ref.set(snapshotRef, parsed) : Effect.void;
+	};
+
 	return {
 		rest: <T>(operation: string, fn: (octokit: unknown) => Promise<{ data: T }>) =>
-			Effect.tryPromise({
-				try: () => fn(octokit),
-				catch: (error) => wrapError(operation, error),
-			}).pipe(Effect.map((response) => response.data)),
+			withResilience(
+				Effect.tryPromise({
+					try: () => fn(octokit),
+					catch: (error) => wrapError(operation, error),
+				}),
+				resilience,
+			).pipe(
+				Effect.tap((response) => recordSnapshot(response as WithHeaders)),
+				Effect.map((response) => response.data),
+			),
 
 		paginate: <T>(
 			operation: string,
@@ -85,10 +190,14 @@ const makeClient = (token: string): typeof GitHubClient.Service => {
 			const maxPages = options?.maxPages ?? Infinity;
 
 			const loop = (page: number, accumulated: Array<T>): Effect.Effect<Array<T>, GitHubClientError> =>
-				Effect.tryPromise({
-					try: () => fn(octokit, page, perPage),
-					catch: (error) => wrapError(operation, error),
-				}).pipe(
+				withResilience(
+					Effect.tryPromise({
+						try: () => fn(octokit, page, perPage),
+						catch: (error) => wrapError(operation, error),
+					}),
+					resilience,
+				).pipe(
+					Effect.tap((response) => recordSnapshot(response as WithHeaders)),
 					Effect.flatMap((response) => {
 						const results = [...accumulated, ...response.data];
 						if (response.data.length < perPage || page >= maxPages) {
@@ -101,11 +210,40 @@ const makeClient = (token: string): typeof GitHubClient.Service => {
 			return loop(1, []);
 		},
 
+		paginateStream: <T>(
+			operation: string,
+			fn: (octokit: unknown, page: number, perPage: number) => Promise<{ data: T[] }>,
+			options?: { perPage?: number; maxPages?: number },
+		) => {
+			const perPage = options?.perPage ?? 100;
+			const maxPages = options?.maxPages ?? Infinity;
+
+			return Stream.paginateChunkEffect(1, (page: number) =>
+				withResilience(
+					Effect.tryPromise({
+						try: () => fn(octokit, page, perPage),
+						catch: (error) => wrapError(operation, error),
+					}),
+					resilience,
+				).pipe(
+					Effect.tap((response) => recordSnapshot(response as WithHeaders)),
+					Effect.map((response) => {
+						const chunk = Chunk.fromIterable(response.data);
+						const more = response.data.length >= perPage && page < maxPages;
+						return [chunk, more ? Option.some(page + 1) : Option.none<number>()] as const;
+					}),
+				),
+			);
+		},
+
 		graphql: <T>(query: string, variables: Record<string, unknown> = {}) =>
-			Effect.tryPromise({
-				try: () => octokit.graphql<T>(query, variables),
-				catch: (error) => wrapError("graphql", error),
-			}),
+			withResilience(
+				Effect.tryPromise({
+					try: () => octokit.graphql<T>(query, variables),
+					catch: (error) => wrapError("graphql", error),
+				}),
+				resilience,
+			),
 
 		repo: Effect.try({
 			try: () => {
@@ -124,55 +262,105 @@ const makeClient = (token: string): typeof GitHubClient.Service => {
 					status: undefined,
 					reason: error instanceof Error ? error.message : String(error),
 					retryable: false,
+					retryAfterMs: undefined,
 				}),
 		}),
 	};
 };
 
 /**
+ * Resolve the shared rate-limit snapshot `Ref`. Uses the app-provided
+ * `RateLimitState` when present (so `RateLimiterLive` reads the same headers
+ * the client writes); otherwise falls back to a private throwaway `Ref` so the
+ * client stays self-contained and the requirement never leaks into the build
+ * graph or any consumer.
+ */
+const resolveSnapshotRef: Effect.Effect<Ref.Ref<Option.Option<RateLimitSnapshot>>> = Effect.flatMap(
+	Effect.serviceOption(RateLimitState),
+	(maybe) => (Option.isSome(maybe) ? Effect.succeed(maybe.value) : Ref.make(Option.none<RateLimitSnapshot>())),
+);
+
+/**
  * Reads the ambient `process.env.GITHUB_TOKEN` — the weak repo-scoped default
  * token. NOT the path for permission-sensitive work; use `fromToken` or `fromApp`
  * with an explicitly constructed identity instead.
+ *
+ * Resilient by default; pass `resilience` to tune or disable retries.
  */
-const fromEnv: Layer.Layer<GitHubClient, GitHubClientError> = Layer.effect(
-	GitHubClient,
-	Effect.try({
-		try: () => {
+const fromEnv = (resilience?: ResilienceOptions): Layer.Layer<GitHubClient, GitHubClientError> =>
+	Layer.effect(
+		GitHubClient,
+		Effect.gen(function* () {
+			const snapshotRef = yield* resolveSnapshotRef;
 			const token = process.env.GITHUB_TOKEN;
-			if (!token) throw new Error("GITHUB_TOKEN not set");
-			return makeClient(token);
-		},
-		catch: (error) => wrapError("getOctokit", error),
-	}),
-);
+			if (!token) {
+				return yield* Effect.fail(wrapError("getOctokit", new Error("GITHUB_TOKEN not set")));
+			}
+			return makeClient(token, snapshotRef, resilience);
+		}),
+	);
 
-/** Build a client from an explicit token. No `process.env` dependency. */
-const fromToken = (token: string | Redacted.Redacted<string>): Layer.Layer<GitHubClient> =>
-	Layer.sync(GitHubClient, () => makeClient(unwrapRedacted(token)));
+/**
+ * Build a client from an explicit token. No `process.env` dependency.
+ *
+ * Resilient by default; pass `resilience` to tune or disable retries.
+ */
+const fromToken = (
+	token: string | Redacted.Redacted<string>,
+	resilience?: ResilienceOptions,
+): Layer.Layer<GitHubClient> =>
+	Layer.effect(
+		GitHubClient,
+		Effect.map(resolveSnapshotRef, (snapshotRef) => makeClient(unwrapRedacted(token), snapshotRef, resilience)),
+	);
 
 /**
  * Generate a GitHub App installation token from App credentials, then build the
  * client. Composes `OctokitAuthAppLive` + `GitHubAppLive` internally.
  *
- * Generates a fresh installation token each time the layer is built. For the
- * pre/main/post pattern where one token is shared across phases, use the
- * `GitHubToken` namespace instead.
+ * Builds as a scoped layer: the minted installation token is revoked on scope
+ * close (best-effort `DELETE /installation/token`). Consumers on
+ * `ActionsRuntime.Default` / `Action.run` (which wrap in `Effect.scoped`) are
+ * unaffected; a consumer providing this via a bare `Effect.provide` must wrap in
+ * `Effect.scoped` to satisfy the build-time `Scope` requirement.
+ *
+ * Resilient by default; pass `resilience` to tune or disable retries.
+ *
+ * @example
+ * ```ts
+ * import { Effect, Layer } from "effect"
+ * import { GitHubClient, GitHubClientLive } from "@savvy-web/github-action-effects"
+ *
+ * // Share one App client (and one installation token) across multiple provides
+ * // in a single run by memoizing the layer; it builds at most once.
+ * const program = Effect.gen(function* () {
+ *   const shared = yield* Layer.memoize(
+ *     GitHubClientLive.fromApp({ clientId, privateKey, installationId }),
+ *   )
+ *   yield* subProgramA.pipe(Effect.provide(shared))
+ *   yield* subProgramB.pipe(Effect.provide(shared))
+ * }).pipe(Effect.scoped)
+ * ```
  */
-const fromApp = (options: {
-	clientId: string;
-	privateKey: string | Redacted.Redacted<string>;
-	installationId?: number;
-}): Layer.Layer<GitHubClient, GitHubAppError> =>
-	Layer.effect(
+const fromApp = (
+	options: {
+		clientId: string;
+		privateKey: string | Redacted.Redacted<string>;
+		installationId?: number;
+	},
+	resilience?: ResilienceOptions,
+): Layer.Layer<GitHubClient, GitHubAppError> =>
+	Layer.scoped(
 		GitHubClient,
 		Effect.gen(function* () {
 			const app = yield* GitHubApp;
-			const installationToken = yield* app.generateToken(
-				options.clientId,
-				unwrapRedacted(options.privateKey),
-				options.installationId,
+			const snapshotRef = yield* resolveSnapshotRef;
+			const installationToken = yield* Effect.acquireRelease(
+				app.generateToken(options.clientId, unwrapRedacted(options.privateKey), options.installationId),
+				// Best-effort revoke on scope close; ignore failures (token expires anyway).
+				(token) => app.revokeToken(token.token).pipe(Effect.ignore),
 			);
-			return makeClient(installationToken.token);
+			return makeClient(installationToken.token, snapshotRef, resilience);
 		}),
 	).pipe(Layer.provide(GitHubAppLive), Layer.provide(OctokitAuthAppLive));
 

--- a/src/layers/GitHubClientTest.ts
+++ b/src/layers/GitHubClientTest.ts
@@ -1,4 +1,4 @@
-import { Effect, Layer } from "effect";
+import { Chunk, Effect, Layer, Stream } from "effect";
 import { GitHubClientError } from "../errors/GitHubClientError.js";
 import type { GitHubClient } from "../services/GitHubClient.js";
 import { GitHubClient as GitHubClientTag } from "../services/GitHubClient.js";
@@ -34,6 +34,7 @@ const makeTestClient = (state: GitHubClientTestState): typeof GitHubClient.Servi
 					status: 404,
 					reason: `No test response recorded for operation "${operation}"`,
 					retryable: false,
+					retryAfterMs: undefined,
 				}),
 			);
 		}
@@ -49,6 +50,7 @@ const makeTestClient = (state: GitHubClientTestState): typeof GitHubClient.Servi
 					status: undefined,
 					reason: "No test response recorded for query",
 					retryable: false,
+					retryAfterMs: undefined,
 				}),
 			);
 		}
@@ -68,11 +70,34 @@ const makeTestClient = (state: GitHubClientTestState): typeof GitHubClient.Servi
 					status: 404,
 					reason: `No paginate responses recorded for "${operation}"`,
 					retryable: false,
+					retryAfterMs: undefined,
 				}),
 			);
 		}
 		const allData = pages.flat() as T[];
 		return Effect.succeed(allData);
+	},
+
+	paginateStream: <T>(
+		operation: string,
+		_fn: (octokit: unknown, page: number, perPage: number) => Promise<{ data: T[] }>,
+		_options?: { perPage?: number; maxPages?: number },
+	) => {
+		const pages = state.paginateResponses.get(operation);
+		if (!pages) {
+			return Stream.fail(
+				new GitHubClientError({
+					operation,
+					status: 404,
+					reason: `No paginate responses recorded for "${operation}"`,
+					retryable: false,
+					retryAfterMs: undefined,
+				}),
+			);
+		}
+		// Replay one recorded page per chunk so consumers can takeWhile / take and
+		// stop early without consuming later pages.
+		return Stream.fromIterable(pages).pipe(Stream.mapConcatChunk((page) => Chunk.fromIterable(page as T[])));
 	},
 
 	repo: Effect.succeed(state.repo),

--- a/src/layers/GitHubGraphQLLive.test.ts
+++ b/src/layers/GitHubGraphQLLive.test.ts
@@ -1,4 +1,4 @@
-import { Effect, Layer } from "effect";
+import { Effect, Layer, Stream } from "effect";
 import { describe, expect, it } from "vitest";
 import { GitHubClientError } from "../errors/GitHubClientError.js";
 import { GitHubClient } from "../services/GitHubClient.js";
@@ -11,6 +11,7 @@ const makeMockGitHubClient = (
 	Layer.succeed(GitHubClient, {
 		rest: () => Effect.die("not used"),
 		paginate: () => Effect.die("not used"),
+		paginateStream: () => Stream.die("not used"),
 		graphql: graphqlFn as (typeof GitHubClient.Service)["graphql"],
 		repo: Effect.die("not used"),
 	});
@@ -48,6 +49,7 @@ describe("GitHubGraphQLLive", () => {
 					status: 401,
 					reason: "Bad credentials",
 					retryable: false,
+					retryAfterMs: undefined,
 				}),
 			),
 		);
@@ -72,6 +74,7 @@ describe("GitHubGraphQLLive", () => {
 					status: 403,
 					reason: "Forbidden",
 					retryable: false,
+					retryAfterMs: undefined,
 				}),
 			),
 		);
@@ -99,6 +102,7 @@ describe("GitHubGraphQLLive", () => {
 					status: 200,
 					reason: errorJson,
 					retryable: false,
+					retryAfterMs: undefined,
 				}),
 			),
 		);

--- a/src/layers/GitHubIssueLive.test.ts
+++ b/src/layers/GitHubIssueLive.test.ts
@@ -1,4 +1,4 @@
-import { Effect, Layer } from "effect";
+import { Effect, Layer, Stream } from "effect";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { GitHubClientError } from "../errors/GitHubClientError.js";
 import { GitHubClient } from "../services/GitHubClient.js";
@@ -32,9 +32,11 @@ const mockClient: typeof GitHubClient.Service = {
 					status: undefined,
 					reason: e instanceof Error ? e.message : String(e),
 					retryable: false,
+					retryAfterMs: undefined,
 				}),
 		}).pipe(Effect.map((r) => r.data)),
 	graphql: () => Effect.die("not used"),
+	paginateStream: () => Stream.die("not used"),
 	paginate: <T>(
 		_operation: string,
 		fn: (octokit: unknown, page: number, perPage: number) => Promise<{ data: T[] }>,
@@ -62,6 +64,7 @@ const mockClient: typeof GitHubClient.Service = {
 					status: undefined,
 					reason: e instanceof Error ? e.message : String(e),
 					retryable: false,
+					retryAfterMs: undefined,
 				}),
 		}).pipe(Effect.map((r) => r.data)),
 	repo: Effect.succeed({ owner: "test-owner", repo: "test-repo" }),

--- a/src/layers/GitHubReleaseLive.test.ts
+++ b/src/layers/GitHubReleaseLive.test.ts
@@ -1,4 +1,4 @@
-import { Effect, Layer } from "effect";
+import { Effect, Layer, Stream } from "effect";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { GitHubClientError } from "../errors/GitHubClientError.js";
 import { GitHubClient } from "../services/GitHubClient.js";
@@ -34,9 +34,11 @@ const mockClient: typeof GitHubClient.Service = {
 					status: undefined,
 					reason: e instanceof Error ? e.message : String(e),
 					retryable: false,
+					retryAfterMs: undefined,
 				}),
 		}).pipe(Effect.map((r) => r.data)),
 	graphql: () => Effect.die("not used"),
+	paginateStream: () => Stream.die("not used"),
 	paginate: <T>(
 		_operation: string,
 		fn: (octokit: unknown, page: number, perPage: number) => Promise<{ data: T[] }>,
@@ -66,6 +68,7 @@ const mockClient: typeof GitHubClient.Service = {
 					status: undefined,
 					reason: e instanceof Error ? e.message : String(e),
 					retryable: false,
+					retryAfterMs: undefined,
 				}),
 		}).pipe(Effect.map((r) => r.data)),
 	repo: Effect.succeed({ owner: "test-owner", repo: "test-repo" }),

--- a/src/layers/GitTagLive.test.ts
+++ b/src/layers/GitTagLive.test.ts
@@ -1,4 +1,4 @@
-import { Effect, Layer } from "effect";
+import { Effect, Layer, Stream } from "effect";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { GitHubClientError } from "../errors/GitHubClientError.js";
 import { GitHubClient } from "../services/GitHubClient.js";
@@ -34,9 +34,11 @@ const mockClient: typeof GitHubClient.Service = {
 					status: undefined,
 					reason: e instanceof Error ? e.message : String(e),
 					retryable: false,
+					retryAfterMs: undefined,
 				}),
 		}).pipe(Effect.map((r) => r.data)),
 	graphql: () => Effect.die("not used"),
+	paginateStream: () => Stream.die("not used"),
 	paginate: <T>(
 		_operation: string,
 		fn: (octokit: unknown, page: number, perPage: number) => Promise<{ data: T[] }>,
@@ -61,6 +63,7 @@ const mockClient: typeof GitHubClient.Service = {
 					status: undefined,
 					reason: e instanceof Error ? e.message : String(e),
 					retryable: false,
+					retryAfterMs: undefined,
 				}),
 		}).pipe(Effect.map((r) => r.data)),
 	repo: Effect.succeed({ owner: "test-owner", repo: "test-repo" }),

--- a/src/layers/PullRequestCommentLive.test.ts
+++ b/src/layers/PullRequestCommentLive.test.ts
@@ -1,4 +1,4 @@
-import { Effect, Layer, Option } from "effect";
+import { Effect, Layer, Option, Stream } from "effect";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { GitHubClientError } from "../errors/GitHubClientError.js";
 import { GitHubClient } from "../services/GitHubClient.js";
@@ -17,10 +17,12 @@ const mockClient: typeof GitHubClient.Service = {
 					status: undefined,
 					reason: e instanceof Error ? e.message : String(e),
 					retryable: false,
+					retryAfterMs: undefined,
 				}),
 		}).pipe(Effect.map((r) => r.data)),
 	graphql: () => Effect.die("not used"),
 	paginate: () => Effect.die("not used"),
+	paginateStream: () => Stream.die("not used"),
 	repo: Effect.succeed({ owner: "test-owner", repo: "test-repo" }),
 };
 

--- a/src/layers/PullRequestLive.test.ts
+++ b/src/layers/PullRequestLive.test.ts
@@ -1,4 +1,4 @@
-import { Effect, Layer } from "effect";
+import { Effect, Layer, Stream } from "effect";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { GitHubClientError } from "../errors/GitHubClientError.js";
 import { GitHubClient } from "../services/GitHubClient.js";
@@ -26,9 +26,11 @@ const mockClient: typeof GitHubClient.Service = {
 					status: undefined,
 					reason: e instanceof Error ? e.message : String(e),
 					retryable: false,
+					retryAfterMs: undefined,
 				}),
 		}).pipe(Effect.map((r) => r.data)),
 	graphql: () => Effect.die("not used"),
+	paginateStream: () => Stream.die("not used"),
 	paginate: <T>(_operation: string, fn: (octokit: unknown, page: number, perPage: number) => Promise<{ data: T[] }>) =>
 		Effect.tryPromise({
 			try: () =>
@@ -47,6 +49,7 @@ const mockClient: typeof GitHubClient.Service = {
 					status: undefined,
 					reason: e instanceof Error ? e.message : String(e),
 					retryable: false,
+					retryAfterMs: undefined,
 				}),
 		}),
 	repo: Effect.succeed({ owner: "test-owner", repo: "test-repo" }),

--- a/src/layers/RateLimiterLive.test.ts
+++ b/src/layers/RateLimiterLive.test.ts
@@ -117,6 +117,31 @@ describe("RateLimiterLive", () => {
 			const result = await run(Effect.flatMap(RateLimiter, (svc) => svc.checkGraphQL()));
 			expect(result).toEqual({ limit: 5000, remaining: 3000, reset: 1700000000, used: 2000 });
 		});
+
+		it("always probes the graphql resource even when the REST-sourced cache is warm", async () => {
+			// A warm snapshot represents the core (REST) bucket. checkGraphQL must
+			// NOT serve it — REST and GraphQL have independent quotas — so it probes.
+			mockRateLimitGet.mockResolvedValue({
+				data: {
+					resources: {
+						core: { limit: 5000, remaining: 4500, reset: 1700000000, used: 500 },
+						graphql: { limit: 5000, remaining: 3000, reset: 1700000000, used: 2000 },
+					},
+				},
+			});
+
+			const result = await Effect.runPromise(
+				withSeededSnapshot(
+					{ remaining: 4500, limit: 5000, resetEpochSeconds: 1700000000, observedAt: Date.now() },
+					Effect.flatMap(RateLimiter, (svc) => svc.checkGraphQL()),
+				),
+			);
+
+			// Returns the graphql bucket (3000), not the seeded core snapshot (4500).
+			expect(result).toEqual({ limit: 5000, remaining: 3000, reset: 1700000000, used: 2000 });
+			expect(restOperations).toContain("rate_limit");
+			expect(mockRateLimitGet).toHaveBeenCalledTimes(1);
+		});
 	});
 
 	describe("withRateLimit", () => {

--- a/src/layers/RateLimiterLive.test.ts
+++ b/src/layers/RateLimiterLive.test.ts
@@ -1,16 +1,21 @@
-import { Effect, Exit, Layer } from "effect";
+import { Duration, Effect, Exit, Fiber, Layer, Option, Ref, Stream, TestClock, TestContext } from "effect";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { GitHubClientError } from "../errors/GitHubClientError.js";
 // eslint-disable-next-line @typescript-eslint/consistent-type-imports -- value needed for Layer.succeed
 import { GitHubClient } from "../services/GitHubClient.js";
 import { RateLimiter } from "../services/RateLimiter.js";
+import type { RateLimitSnapshot } from "../services/RateLimitState.js";
+import { RateLimitState } from "../services/RateLimitState.js";
 import { RateLimiterLive } from "./RateLimiterLive.js";
 
 const mockRateLimitGet = vi.fn();
+/** Records every operation name the rate limiter routes through client.rest. */
+const restOperations: Array<string> = [];
 
 const mockClient: typeof GitHubClient.Service = {
-	rest: <T>(_operation: string, fn: (octokit: unknown) => Promise<{ data: T }>) =>
-		Effect.tryPromise({
+	rest: <T>(operation: string, fn: (octokit: unknown) => Promise<{ data: T }>) => {
+		restOperations.push(operation);
+		return Effect.tryPromise({
 			try: () =>
 				fn({
 					rest: {
@@ -19,31 +24,63 @@ const mockClient: typeof GitHubClient.Service = {
 				}),
 			catch: (e) =>
 				new GitHubClientError({
-					operation: _operation,
+					operation,
 					status: undefined,
 					reason: e instanceof Error ? e.message : String(e),
 					retryable: false,
+					retryAfterMs: undefined,
 				}),
-		}).pipe(Effect.map((r) => r.data)),
+		}).pipe(Effect.map((r) => r.data));
+	},
 	graphql: () => Effect.die("not used"),
 	paginate: () => Effect.die("not used"),
+	paginateStream: () => Stream.die("not used"),
 	repo: Effect.succeed({ owner: "test-owner", repo: "test-repo" }),
 };
 
-const testLayer = Layer.provide(RateLimiterLive, Layer.succeed(GitHubClient, mockClient));
+const clientLayer = Layer.succeed(GitHubClient, mockClient);
+const baseLayer = Layer.provideMerge(RateLimiterLive, Layer.merge(clientLayer, RateLimitState.Default));
 
-const run = <A, E>(effect: Effect.Effect<A, E, RateLimiter>) => Effect.runPromise(Effect.provide(effect, testLayer));
+const run = <A, E>(effect: Effect.Effect<A, E, RateLimiter>) => Effect.runPromise(Effect.provide(effect, baseLayer));
 
 const runExit = <A, E>(effect: Effect.Effect<A, E, RateLimiter>) =>
-	Effect.runPromise(Effect.exit(Effect.provide(effect, testLayer)));
+	Effect.runPromise(Effect.exit(Effect.provide(effect, baseLayer)));
+
+/** Seed the shared RateLimitState snapshot, then run an effect against the limiter. */
+const withSeededSnapshot = <A, E>(snapshot: RateLimitSnapshot, effect: Effect.Effect<A, E, RateLimiter>) =>
+	Effect.gen(function* () {
+		const ref = yield* RateLimitState;
+		yield* Ref.set(ref, Option.some(snapshot));
+		return yield* effect;
+	}).pipe(Effect.provide(baseLayer));
 
 beforeEach(() => {
 	vi.clearAllMocks();
+	restOperations.length = 0;
 });
 
 describe("RateLimiterLive", () => {
 	describe("checkRest", () => {
-		it("calls GitHub API and maps core resource", async () => {
+		it("returns the cached snapshot without probing when the cache is warm", async () => {
+			const snapshot: RateLimitSnapshot = {
+				remaining: 4500,
+				limit: 5000,
+				resetEpochSeconds: 1700000000,
+				observedAt: Date.now(),
+			};
+			const result = await Effect.runPromise(
+				withSeededSnapshot(
+					snapshot,
+					Effect.flatMap(RateLimiter, (svc) => svc.checkRest()),
+				),
+			);
+			expect(result).toEqual({ limit: 5000, remaining: 4500, reset: 1700000000, used: 500 });
+			// No GET /rate_limit probe when the cache is warm.
+			expect(restOperations).not.toContain("rate_limit");
+			expect(mockRateLimitGet).not.toHaveBeenCalled();
+		});
+
+		it("probes GitHub on a cache miss and maps the core resource", async () => {
 			mockRateLimitGet.mockResolvedValue({
 				data: {
 					resources: {
@@ -55,10 +92,11 @@ describe("RateLimiterLive", () => {
 
 			const result = await run(Effect.flatMap(RateLimiter, (svc) => svc.checkRest()));
 			expect(result).toEqual({ limit: 5000, remaining: 4500, reset: 1700000000, used: 500 });
+			expect(restOperations).toContain("rate_limit");
 			expect(mockRateLimitGet).toHaveBeenCalledTimes(1);
 		});
 
-		it("fails on API error", async () => {
+		it("fails on API error during a cache-miss probe", async () => {
 			mockRateLimitGet.mockRejectedValue(new Error("network error"));
 			const exit = await runExit(Effect.flatMap(RateLimiter, (svc) => svc.checkRest()));
 			expect(exit._tag).toBe("Failure");
@@ -66,7 +104,7 @@ describe("RateLimiterLive", () => {
 	});
 
 	describe("checkGraphQL", () => {
-		it("calls GitHub API and maps graphql resource", async () => {
+		it("probes on a cache miss and maps the graphql resource", async () => {
 			mockRateLimitGet.mockResolvedValue({
 				data: {
 					resources: {
@@ -82,38 +120,62 @@ describe("RateLimiterLive", () => {
 	});
 
 	describe("withRateLimit", () => {
-		it("runs effect when rate limit is healthy", async () => {
-			mockRateLimitGet.mockResolvedValue({
-				data: {
-					resources: {
-						core: { limit: 5000, remaining: 4000, reset: 1700000000, used: 1000 },
-						graphql: { limit: 5000, remaining: 5000, reset: 1700000000, used: 0 },
-					},
-				},
-			});
-
+		it("runs the effect without any probe when the cache is empty", async () => {
 			const result = await run(Effect.flatMap(RateLimiter, (svc) => svc.withRateLimit(Effect.succeed("ok"))));
 			expect(result).toBe("ok");
+			// No pre-flight GET /rate_limit on an empty cache.
+			expect(restOperations).not.toContain("rate_limit");
+			expect(mockRateLimitGet).not.toHaveBeenCalled();
 		});
 
-		it("fails with RateLimitError when near limit and wait exceeds 60s", async () => {
-			const futureReset = Math.floor(Date.now() / 1000) + 120; // 2 minutes from now
-			mockRateLimitGet.mockResolvedValue({
-				data: {
-					resources: {
-						core: { limit: 5000, remaining: 10, reset: futureReset, used: 4990 },
-						graphql: { limit: 5000, remaining: 5000, reset: futureReset, used: 0 },
-					},
-				},
-			});
+		it("runs the effect when cached remaining is healthy", async () => {
+			const result = await Effect.runPromise(
+				withSeededSnapshot(
+					{ remaining: 4000, limit: 5000, resetEpochSeconds: 1700000000, observedAt: Date.now() },
+					Effect.flatMap(RateLimiter, (svc) => svc.withRateLimit(Effect.succeed("ok"))),
+				),
+			);
+			expect(result).toBe("ok");
+			expect(restOperations).not.toContain("rate_limit");
+		});
 
-			const exit = await runExit(Effect.flatMap(RateLimiter, (svc) => svc.withRateLimit(Effect.succeed("ok"))));
+		it("waits then runs when cached remaining is below the threshold and reset is near", async () => {
+			const nearReset = Math.floor(Date.now() / 1000) + 10; // 10s out
+			const exit = await Effect.gen(function* () {
+				const ref = yield* RateLimitState;
+				yield* Ref.set(
+					ref,
+					Option.some({ remaining: 10, limit: 5000, resetEpochSeconds: nearReset, observedAt: Date.now() }),
+				);
+				const fiber = yield* Effect.fork(
+					Effect.flatMap(RateLimiter, (svc) => svc.withRateLimit(Effect.succeed("done"))),
+				);
+				yield* TestClock.adjust(Duration.seconds(11));
+				return yield* Fiber.join(fiber);
+			}).pipe(Effect.exit, Effect.provide(baseLayer), Effect.provide(TestContext.TestContext), Effect.runPromise);
 
+			expect(exit._tag).toBe("Success");
+			if (Exit.isSuccess(exit)) {
+				expect(exit.value).toBe("done");
+			}
+		});
+
+		it("fails with RateLimitError when below threshold and wait exceeds 60s", async () => {
+			const farReset = Math.floor(Date.now() / 1000) + 120; // 2 minutes out
+			const exit = await Effect.runPromise(
+				Effect.exit(
+					withSeededSnapshot(
+						{ remaining: 10, limit: 5000, resetEpochSeconds: farReset, observedAt: Date.now() },
+						Effect.flatMap(RateLimiter, (svc) => svc.withRateLimit(Effect.succeed("ok"))),
+					),
+				),
+			);
 			expect(Exit.isFailure(exit)).toBe(true);
 			if (Exit.isFailure(exit)) {
-				const error = exit.cause;
-				expect(String(error)).toContain("RateLimitError");
+				expect(String(exit.cause)).toContain("RateLimitError");
 			}
+			// Policy is cache-driven; no probe issued.
+			expect(restOperations).not.toContain("rate_limit");
 		});
 	});
 

--- a/src/layers/RateLimiterLive.ts
+++ b/src/layers/RateLimiterLive.ts
@@ -1,8 +1,11 @@
-import { Duration, Effect, Layer, Schedule } from "effect";
+import { Duration, Effect, Layer, Option, Ref, Schedule } from "effect";
+import type { GitHubClientError } from "../errors/GitHubClientError.js";
 import { RateLimitError } from "../errors/RateLimitError.js";
 import type { RateLimitStatus } from "../schemas/RateLimit.js";
 import { GitHubClient } from "../services/GitHubClient.js";
 import { RateLimiter } from "../services/RateLimiter.js";
+import type { RateLimitSnapshot } from "../services/RateLimitState.js";
+import { RateLimitState } from "../services/RateLimitState.js";
 
 /** Minimal Octokit shape for rate limit API calls. */
 interface OctokitRateLimit {
@@ -22,34 +25,56 @@ interface OctokitRateLimit {
 
 const asRateLimit = (octokit: unknown): OctokitRateLimit => octokit as OctokitRateLimit;
 
+/** Project an internal snapshot onto the public `RateLimitStatus` schema. */
+const snapshotToStatus = (snapshot: RateLimitSnapshot): RateLimitStatus => ({
+	limit: snapshot.limit,
+	remaining: snapshot.remaining,
+	reset: snapshot.resetEpochSeconds,
+	used: Math.max(0, snapshot.limit - snapshot.remaining),
+});
+
 /**
- * Executes `effect` with a pre-flight REST rate limit check.
- * Note: only checks the REST core quota. For GraphQL-heavy effects,
- * call `checkGraphQL` separately.
+ * Rate limiter that reads the `x-ratelimit-*` headers observed on real
+ * responses (cached in a shared `RateLimitState` `Ref` written by the
+ * GitHubClient), rather than issuing a pre-flight `GET /rate_limit` before every
+ * guarded call. Probes only on a cache miss.
  */
 export const RateLimiterLive: Layer.Layer<RateLimiter, never, GitHubClient> = Layer.effect(
 	RateLimiter,
-	Effect.map(GitHubClient, (client) => {
-		/** Fetch all rate limit resources via the REST API (used by both checkRest and checkGraphQL). */
+	Effect.gen(function* () {
+		const client = yield* GitHubClient;
+		// Use the app-provided shared snapshot when present (so the client's
+		// observed headers drive the policy); otherwise fall back to a private
+		// empty Ref so the limiter is self-contained and adds no build requirement.
+		const snapshotRef = yield* Effect.flatMap(Effect.serviceOption(RateLimitState), (maybe) =>
+			Option.isSome(maybe) ? Effect.succeed(maybe.value) : Ref.make(Option.none<RateLimitSnapshot>()),
+		);
+
+		/** Fetch all rate limit resources via the REST API (the cache-miss probe). */
 		const fetchRateLimits = () => client.rest("rate_limit", (octokit) => asRateLimit(octokit).rest.rateLimit.get());
 
-		const checkRest = (): Effect.Effect<RateLimitStatus, import("../errors/GitHubClientError.js").GitHubClientError> =>
-			fetchRateLimits().pipe(
-				Effect.map((data) => {
-					const typed = data as { resources: { core: RateLimitStatus } };
-					return typed.resources.core;
-				}),
+		const checkRest = (): Effect.Effect<RateLimitStatus, GitHubClientError> =>
+			Effect.flatMap(Ref.get(snapshotRef), (cached) =>
+				Option.isSome(cached)
+					? Effect.succeed(snapshotToStatus(cached.value))
+					: fetchRateLimits().pipe(
+							Effect.map((data) => {
+								const typed = data as { resources: { core: RateLimitStatus } };
+								return typed.resources.core;
+							}),
+						),
 			);
 
-		const checkGraphQL = (): Effect.Effect<
-			RateLimitStatus,
-			import("../errors/GitHubClientError.js").GitHubClientError
-		> =>
-			fetchRateLimits().pipe(
-				Effect.map((data) => {
-					const typed = data as { resources: { graphql: RateLimitStatus } };
-					return typed.resources.graphql;
-				}),
+		const checkGraphQL = (): Effect.Effect<RateLimitStatus, GitHubClientError> =>
+			Effect.flatMap(Ref.get(snapshotRef), (cached) =>
+				Option.isSome(cached)
+					? Effect.succeed(snapshotToStatus(cached.value))
+					: fetchRateLimits().pipe(
+							Effect.map((data) => {
+								const typed = data as { resources: { graphql: RateLimitStatus } };
+								return typed.resources.graphql;
+							}),
+						),
 			);
 
 		return {
@@ -57,36 +82,31 @@ export const RateLimiterLive: Layer.Layer<RateLimiter, never, GitHubClient> = La
 			checkGraphQL,
 
 			withRateLimit: <A, E, R>(effect: Effect.Effect<A, E, R>): Effect.Effect<A, E | RateLimitError, R> =>
-				checkRest().pipe(
-					Effect.mapError(
-						(e): E | RateLimitError =>
+				Effect.flatMap(Ref.get(snapshotRef), (cached): Effect.Effect<A, E | RateLimitError, R> => {
+					// Never observed yet → run directly; the first real call will
+					// populate the snapshot for subsequent guards (no wasted probe).
+					if (Option.isNone(cached)) {
+						return effect;
+					}
+					const snapshot = cached.value;
+					const threshold = Math.ceil(snapshot.limit * 0.1);
+					if (snapshot.remaining > threshold) {
+						return effect;
+					}
+					const resetDate = new Date(snapshot.resetEpochSeconds * 1000);
+					const waitMs = Math.max(0, resetDate.getTime() - Date.now());
+					if (waitMs > 60000) {
+						return Effect.fail(
 							new RateLimitError({
 								api: "rest",
-								remaining: 0,
-								resetAt: "",
-								reason: `Failed to check rate limit: ${e.reason}`,
+								remaining: snapshot.remaining,
+								resetAt: resetDate.toISOString(),
+								reason: `Rate limit nearly exhausted (${snapshot.remaining}/${snapshot.limit}). Resets at ${resetDate.toISOString()}`,
 							}),
-					),
-					Effect.flatMap((status): Effect.Effect<A, E | RateLimitError, R> => {
-						const threshold = Math.ceil(status.limit * 0.1);
-						if (status.remaining <= threshold) {
-							const resetDate = new Date(status.reset * 1000);
-							const waitMs = Math.max(0, resetDate.getTime() - Date.now());
-							if (waitMs > 60000) {
-								return Effect.fail(
-									new RateLimitError({
-										api: "rest",
-										remaining: status.remaining,
-										resetAt: resetDate.toISOString(),
-										reason: `Rate limit nearly exhausted (${status.remaining}/${status.limit}). Resets at ${resetDate.toISOString()}`,
-									}),
-								);
-							}
-							return Effect.sleep(Duration.millis(waitMs)).pipe(Effect.flatMap(() => effect));
-						}
-						return effect;
-					}),
-				),
+						);
+					}
+					return Effect.sleep(Duration.millis(waitMs)).pipe(Effect.flatMap(() => effect));
+				}),
 
 			withRetry: <A, E, R>(
 				effect: Effect.Effect<A, E, R>,

--- a/src/layers/RateLimiterLive.ts
+++ b/src/layers/RateLimiterLive.ts
@@ -53,6 +53,9 @@ export const RateLimiterLive: Layer.Layer<RateLimiter, never, GitHubClient> = La
 		/** Fetch all rate limit resources via the REST API (the cache-miss probe). */
 		const fetchRateLimits = () => client.rest("rate_limit", (octokit) => asRateLimit(octokit).rest.rateLimit.get());
 
+		// The shared snapshot is written only from REST (core-bucket) responses;
+		// `graphql` calls never record it. So a cached snapshot is always the
+		// core bucket: checkRest may serve it, but checkGraphQL must not.
 		const checkRest = (): Effect.Effect<RateLimitStatus, GitHubClientError> =>
 			Effect.flatMap(Ref.get(snapshotRef), (cached) =>
 				Option.isSome(cached)
@@ -65,16 +68,16 @@ export const RateLimiterLive: Layer.Layer<RateLimiter, never, GitHubClient> = La
 						),
 			);
 
+		// REST and GraphQL have independent quotas on the GitHub API, and the
+		// shared snapshot only ever holds the core (REST) bucket, so serving it
+		// here would report the wrong quota. checkGraphQL always probes the
+		// graphql resource directly.
 		const checkGraphQL = (): Effect.Effect<RateLimitStatus, GitHubClientError> =>
-			Effect.flatMap(Ref.get(snapshotRef), (cached) =>
-				Option.isSome(cached)
-					? Effect.succeed(snapshotToStatus(cached.value))
-					: fetchRateLimits().pipe(
-							Effect.map((data) => {
-								const typed = data as { resources: { graphql: RateLimitStatus } };
-								return typed.resources.graphql;
-							}),
-						),
+			fetchRateLimits().pipe(
+				Effect.map((data) => {
+					const typed = data as { resources: { graphql: RateLimitStatus } };
+					return typed.resources.graphql;
+				}),
 			);
 
 		return {

--- a/src/layers/WorkflowDispatchLive.test.ts
+++ b/src/layers/WorkflowDispatchLive.test.ts
@@ -1,4 +1,4 @@
-import { Effect, Exit, Layer } from "effect";
+import { Effect, Exit, Layer, Stream } from "effect";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { GitHubClientError } from "../errors/GitHubClientError.js";
 import { GitHubClient } from "../services/GitHubClient.js";
@@ -28,10 +28,12 @@ const mockClient: typeof GitHubClient.Service = {
 					status: undefined,
 					reason: e instanceof Error ? e.message : String(e),
 					retryable: false,
+					retryAfterMs: undefined,
 				}),
 		}).pipe(Effect.map((r) => r.data)),
 	graphql: () => Effect.die("not used"),
 	paginate: () => Effect.die("not used"),
+	paginateStream: () => Stream.die("not used"),
 	repo: Effect.succeed({ owner: "test-owner", repo: "test-repo" }),
 };
 

--- a/src/layers/resilience.test.ts
+++ b/src/layers/resilience.test.ts
@@ -1,0 +1,193 @@
+import { Clock, Duration, Effect, Fiber, Ref, TestClock, TestContext } from "effect";
+import { describe, expect, it } from "vitest";
+import { GitHubClientError } from "../errors/GitHubClientError.js";
+import { resilienceSchedule, withResilience } from "./resilience.js";
+
+const retryableError = (overrides?: Partial<{ status: number; retryAfterMs: number }>) =>
+	new GitHubClientError({
+		operation: "test",
+		status: overrides?.status ?? 503,
+		reason: "transient",
+		retryable: true,
+		retryAfterMs: overrides?.retryAfterMs,
+	});
+
+const nonRetryableError = () =>
+	new GitHubClientError({
+		operation: "test",
+		status: 404,
+		reason: "not found",
+		retryable: false,
+		retryAfterMs: undefined,
+	});
+
+/** Run an effect that uses TestClock-driven delays; advance the clock then join. */
+const runWithClock = <A, E>(effect: Effect.Effect<A, E>, advance = Duration.seconds(600)) =>
+	Effect.gen(function* () {
+		const fiber = yield* Effect.fork(effect);
+		yield* TestClock.adjust(advance);
+		return yield* Fiber.join(fiber);
+	}).pipe(Effect.exit, Effect.provide(TestContext.TestContext), Effect.runPromise);
+
+describe("resilienceSchedule", () => {
+	it("does not retry non-retryable errors (single attempt)", async () => {
+		const counter = await Effect.runPromise(Ref.make(0));
+		const exit = await runWithClock(
+			withResilience(
+				Effect.flatMap(
+					Ref.updateAndGet(counter, (x) => x + 1),
+					() => Effect.fail(nonRetryableError()),
+				),
+				{ maxRetries: 4 },
+			),
+		);
+		const count = await Effect.runPromise(Ref.get(counter));
+		expect(exit._tag).toBe("Failure");
+		expect(count).toBe(1);
+	});
+
+	it("recovers after transient failures within maxRetries", async () => {
+		const counter = await Effect.runPromise(Ref.make(0));
+		const exit = await runWithClock(
+			withResilience(
+				Effect.gen(function* () {
+					const n = yield* Ref.updateAndGet(counter, (x) => x + 1);
+					if (n < 3) return yield* Effect.fail(retryableError());
+					return n;
+				}),
+				{ maxRetries: 4, baseDelay: Duration.seconds(1) },
+			),
+		);
+		const count = await Effect.runPromise(Ref.get(counter));
+		expect(exit._tag).toBe("Success");
+		expect(count).toBe(3);
+	});
+
+	it("gives up after maxRetries on persistent retryable errors", async () => {
+		const counter = await Effect.runPromise(Ref.make(0));
+		const exit = await runWithClock(
+			withResilience(
+				Effect.flatMap(
+					Ref.updateAndGet(counter, (x) => x + 1),
+					() => Effect.fail(retryableError()),
+				),
+				{ maxRetries: 4, baseDelay: Duration.seconds(1) },
+			),
+		);
+		const count = await Effect.runPromise(Ref.get(counter));
+		expect(exit._tag).toBe("Failure");
+		// 1 initial + 4 retries = 5 total attempts
+		expect(count).toBe(5);
+	});
+
+	it("disabled resilience does not retry", async () => {
+		const counter = await Effect.runPromise(Ref.make(0));
+		const exit = await runWithClock(
+			withResilience(
+				Effect.flatMap(
+					Ref.updateAndGet(counter, (x) => x + 1),
+					() => Effect.fail(retryableError()),
+				),
+				{ enabled: false },
+			),
+		);
+		const count = await Effect.runPromise(Ref.get(counter));
+		expect(exit._tag).toBe("Failure");
+		expect(count).toBe(1);
+	});
+
+	it("caps each backoff delay at maxDelay", async () => {
+		// Record the wall-clock time before each attempt to measure inter-attempt sleeps.
+		const timestamps = await Effect.runPromise(Ref.make<Array<number>>([]));
+		const counter = await Effect.runPromise(Ref.make(0));
+		await runWithClock(
+			withResilience(
+				Effect.gen(function* () {
+					const now = yield* Clock.currentTimeMillis;
+					yield* Ref.update(timestamps, (xs) => [...xs, now]);
+					const n = yield* Ref.updateAndGet(counter, (x) => x + 1);
+					if (n < 5) return yield* Effect.fail(retryableError());
+					return n;
+				}),
+				{ maxRetries: 10, baseDelay: Duration.seconds(1), maxDelay: Duration.seconds(5) },
+			),
+		);
+		const stamps = await Effect.runPromise(Ref.get(timestamps));
+		const deltas = stamps.slice(1).map((t, i) => t - stamps[i]);
+		// With baseDelay 1s doubling (1,2,4,8,...) but capped at 5s, no inter-attempt
+		// sleep may exceed the cap (allow small jitter slack above the cap).
+		for (const d of deltas) {
+			expect(d).toBeLessThanOrEqual(5000 + 1);
+		}
+	});
+
+	it("honors retryAfterMs over the exponential backoff", async () => {
+		const timestamps = await Effect.runPromise(Ref.make<Array<number>>([]));
+		const counter = await Effect.runPromise(Ref.make(0));
+		const exit = await runWithClock(
+			withResilience(
+				Effect.gen(function* () {
+					const now = yield* Clock.currentTimeMillis;
+					yield* Ref.update(timestamps, (xs) => [...xs, now]);
+					const n = yield* Ref.updateAndGet(counter, (x) => x + 1);
+					// First attempt fails with a server-advised 7s delay, then succeeds.
+					if (n < 2) return yield* Effect.fail(retryableError({ retryAfterMs: 7000 }));
+					return n;
+				}),
+				{ maxRetries: 4, baseDelay: Duration.seconds(1), maxDelay: Duration.seconds(30) },
+			),
+		);
+		const stamps = await Effect.runPromise(Ref.get(timestamps));
+		expect(exit._tag).toBe("Success");
+		// The single inter-attempt sleep must be the advised 7s, not the 1s base.
+		expect(stamps.length).toBe(2);
+		expect(stamps[1] - stamps[0]).toBeGreaterThanOrEqual(7000);
+	});
+
+	it("falls back to exponential when retryAfterMs is absent", async () => {
+		const timestamps = await Effect.runPromise(Ref.make<Array<number>>([]));
+		const counter = await Effect.runPromise(Ref.make(0));
+		await runWithClock(
+			withResilience(
+				Effect.gen(function* () {
+					const now = yield* Clock.currentTimeMillis;
+					yield* Ref.update(timestamps, (xs) => [...xs, now]);
+					const n = yield* Ref.updateAndGet(counter, (x) => x + 1);
+					if (n < 2) return yield* Effect.fail(retryableError());
+					return n;
+				}),
+				{ maxRetries: 4, baseDelay: Duration.seconds(1), maxDelay: Duration.seconds(30) },
+			),
+		);
+		const stamps = await Effect.runPromise(Ref.get(timestamps));
+		// The single inter-attempt sleep is roughly the 1s base (jittered, so < 7s).
+		expect(stamps[1] - stamps[0]).toBeLessThan(7000);
+	});
+
+	it("resilienceSchedule retries retryable errors and stops at maxRetries", async () => {
+		const counter = await Effect.runPromise(Ref.make(0));
+		const exit = await runWithClock(
+			Effect.flatMap(
+				Ref.updateAndGet(counter, (x) => x + 1),
+				() => Effect.fail(retryableError()),
+			).pipe(Effect.retry(resilienceSchedule({ maxRetries: 2, baseDelay: Duration.seconds(1) }))),
+		);
+		const count = await Effect.runPromise(Ref.get(counter));
+		expect(exit._tag).toBe("Failure");
+		// 1 initial + 2 retries = 3 attempts.
+		expect(count).toBe(3);
+	});
+
+	it("resilienceSchedule does not recur on non-retryable errors", async () => {
+		const counter = await Effect.runPromise(Ref.make(0));
+		const exit = await runWithClock(
+			Effect.flatMap(
+				Ref.updateAndGet(counter, (x) => x + 1),
+				() => Effect.fail(nonRetryableError()),
+			).pipe(Effect.retry(resilienceSchedule({ maxRetries: 4 }))),
+		);
+		const count = await Effect.runPromise(Ref.get(counter));
+		expect(exit._tag).toBe("Failure");
+		expect(count).toBe(1);
+	});
+});

--- a/src/layers/resilience.ts
+++ b/src/layers/resilience.ts
@@ -26,14 +26,22 @@ const DEFAULT_BASE_DELAY = Duration.seconds(1);
 const DEFAULT_MAX_DELAY = Duration.seconds(30);
 
 /**
- * Backoff schedule for retryable GitHubClient errors: exponential + full
- * jitter, each interval capped at `maxDelay`, bounded by `maxRetries`, and
- * gated so that only `retryable` errors recur. Non-retryable errors stop the
- * schedule immediately.
+ * Backoff schedule for retryable GitHubClient errors: exponential, jittered,
+ * each interval capped at `maxDelay`, bounded by `maxRetries`, and gated so
+ * that only `retryable` errors recur. Non-retryable errors stop the schedule
+ * immediately.
  *
  * Exported for reuse by tracing spans and any future layer transformer. It is
  * pure (depends only on `effect` and the error type) so it is safe to import
  * from the octokit-free testing entry point.
+ *
+ * Note this differs from the internal `withResilience` (which wraps every
+ * `GitHubClient` call) in two ways: it does NOT consult a
+ * `GitHubClientError.retryAfterMs` server-advised delay, and it jitters with
+ * `Schedule.jittered` (multiplicative) rather than `withResilience`'s uniform
+ * full-jitter in `[0, capped]`. Use `Effect.retry(resilienceSchedule(...))` for
+ * a standalone backoff; reach for `withResilience` directly when server-advised
+ * `Retry-After` / `x-ratelimit-reset` delays must be honored.
  *
  * The per-interval cap is expressed with `Schedule.map((d) => Duration.min(d, cap))`
  * rather than `Schedule.either(Schedule.spaced(cap))`: `Duration.min` caps each

--- a/src/layers/resilience.ts
+++ b/src/layers/resilience.ts
@@ -1,0 +1,95 @@
+import { Duration, Effect, Schedule } from "effect";
+import type { GitHubClientError } from "../errors/GitHubClientError.js";
+
+/**
+ * Tuning for the resilient retry/backoff applied to every GitHubClient call.
+ *
+ * Resilience is on by default; pass `{ enabled: false }` for bare, retry-free
+ * behavior. `maxRetries`, `baseDelay`, and `maxDelay` tune the exponential,
+ * jittered, capped backoff schedule used for retryable (429 / 5xx) errors.
+ *
+ * @public
+ */
+export interface ResilienceOptions {
+	/** Master switch. Default `true`. Set `false` for bare, retry-free behavior. */
+	readonly enabled?: boolean;
+	/** Max retry attempts for `retryable` errors. Default `4`. */
+	readonly maxRetries?: number;
+	/** Base delay for the exponential schedule. Default `Duration.seconds(1)`. */
+	readonly baseDelay?: Duration.DurationInput;
+	/** Cap on any single backoff delay. Default `Duration.seconds(30)`. */
+	readonly maxDelay?: Duration.DurationInput;
+}
+
+const DEFAULT_MAX_RETRIES = 4;
+const DEFAULT_BASE_DELAY = Duration.seconds(1);
+const DEFAULT_MAX_DELAY = Duration.seconds(30);
+
+/**
+ * Backoff schedule for retryable GitHubClient errors: exponential + full
+ * jitter, each interval capped at `maxDelay`, bounded by `maxRetries`, and
+ * gated so that only `retryable` errors recur. Non-retryable errors stop the
+ * schedule immediately.
+ *
+ * Exported for reuse by tracing spans and any future layer transformer. It is
+ * pure (depends only on `effect` and the error type) so it is safe to import
+ * from the octokit-free testing entry point.
+ *
+ * The per-interval cap is expressed with `Schedule.map((d) => Duration.min(d, cap))`
+ * rather than `Schedule.either(Schedule.spaced(cap))`: `Duration.min` caps each
+ * computed delay deterministically, which the cap test pins directly.
+ *
+ * @public
+ */
+export const resilienceSchedule = (options?: ResilienceOptions): Schedule.Schedule<unknown, GitHubClientError> => {
+	const max = options?.maxRetries ?? DEFAULT_MAX_RETRIES;
+	const base = options?.baseDelay ?? DEFAULT_BASE_DELAY;
+	const cap = Duration.decode(options?.maxDelay ?? DEFAULT_MAX_DELAY);
+	return Schedule.exponential(base).pipe(
+		Schedule.map((d) => Duration.min(d, cap)),
+		Schedule.jittered,
+		Schedule.whileInput((e: GitHubClientError) => e.retryable),
+		Schedule.compose(Schedule.recurs(max)),
+	);
+};
+
+/** Compute the exponential, jittered, capped backoff for a given retry attempt (0-based). */
+const backoffMillis = (attempt: number, baseMs: number, capMs: number): number => {
+	const raw = baseMs * 2 ** attempt;
+	const capped = Math.min(raw, capMs);
+	// Full jitter: a random delay in [0, capped].
+	return Math.floor(Math.random() * capped);
+};
+
+/**
+ * Wrap a single GitHubClient call with the resilient retry policy. On a
+ * `retryable` error it waits for the server-advised `retryAfterMs` when present,
+ * otherwise an exponential + jittered + capped backoff, retrying up to
+ * `maxRetries` times. Non-retryable errors fail immediately. With
+ * `{ enabled: false }` the effect runs once with no retry.
+ */
+export const withResilience = <T>(
+	effect: Effect.Effect<T, GitHubClientError>,
+	options?: ResilienceOptions,
+): Effect.Effect<T, GitHubClientError> => {
+	if (options?.enabled === false) {
+		return effect;
+	}
+	const max = options?.maxRetries ?? DEFAULT_MAX_RETRIES;
+	const baseMs = Duration.toMillis(Duration.decode(options?.baseDelay ?? DEFAULT_BASE_DELAY));
+	const capMs = Duration.toMillis(Duration.decode(options?.maxDelay ?? DEFAULT_MAX_DELAY));
+
+	const loop = (attempt: number): Effect.Effect<T, GitHubClientError> =>
+		effect.pipe(
+			Effect.catchAll((error) => {
+				if (!error.retryable || attempt >= max) {
+					return Effect.fail(error);
+				}
+				// Server-advised delay takes precedence over the computed backoff.
+				const waitMs = error.retryAfterMs ?? backoffMillis(attempt, baseMs, capMs);
+				return Effect.sleep(Duration.millis(waitMs)).pipe(Effect.flatMap(() => loop(attempt + 1)));
+			}),
+		);
+
+	return loop(0);
+};

--- a/src/services/Attest.list.test.ts
+++ b/src/services/Attest.list.test.ts
@@ -15,7 +15,7 @@
  * synchronously so we cover both code paths.
  */
 
-import { Effect, Layer } from "effect";
+import { Effect, Layer, Stream } from "effect";
 import { describe, expect, it } from "vitest";
 import {
 	Attest,
@@ -81,6 +81,7 @@ const fixedGitHubClient = (
 			}).pipe(Effect.map((r) => r.data)),
 		graphql: () => Effect.die("graphql not used"),
 		paginate: () => Effect.die("paginate not used"),
+		paginateStream: () => Stream.die("paginateStream not used"),
 		repo: Effect.succeed(repo),
 	});
 
@@ -101,6 +102,7 @@ const throwingGitHubClient = (status: number): Layer.Layer<GitHubClient> =>
 			}).pipe(Effect.map((r) => r.data)),
 		graphql: () => Effect.die("graphql not used"),
 		paginate: () => Effect.die("paginate not used"),
+		paginateStream: () => Stream.die("paginateStream not used"),
 		repo: Effect.succeed({ owner: "savvy-web", repo: "workflow-release-action" }),
 	});
 

--- a/src/services/Attest.test.ts
+++ b/src/services/Attest.test.ts
@@ -9,7 +9,7 @@
  * silk-integration repo run, not here.
  */
 
-import { Cause, Effect, Exit, Layer } from "effect";
+import { Cause, Effect, Exit, Layer, Stream } from "effect";
 import { describe, expect, it } from "vitest";
 import type { InTotoStatement } from "../testing.js";
 import {
@@ -94,10 +94,12 @@ describe("Attest.attest — step 4: end-to-end upload", () => {
 						status: 403,
 						reason: "permission denied: missing attestations:write",
 						retryable: false,
+						retryAfterMs: undefined,
 					}),
 				),
 			graphql: () => Effect.die("graphql should not be called"),
 			paginate: () => Effect.die("paginate should not be called"),
+			paginateStream: () => Stream.die("paginateStream should not be called"),
 			repo: Effect.succeed({ owner: "savvy-web", repo: "silk-integration" }),
 		});
 

--- a/src/services/GitHubClient.test.ts
+++ b/src/services/GitHubClient.test.ts
@@ -105,6 +105,7 @@ describe("GitHubClient", () => {
 				status: 404,
 				reason: "Not Found",
 				retryable: false,
+				retryAfterMs: undefined,
 			});
 			expect(error._tag).toBe("GitHubClientError");
 			expect(error.operation).toBe("repos.get");
@@ -119,8 +120,20 @@ describe("GitHubClient", () => {
 				status: 429,
 				reason: "Rate limit exceeded",
 				retryable: true,
+				retryAfterMs: undefined,
 			});
 			expect(error.retryable).toBe(true);
+		});
+
+		it("carries an optional retryAfterMs hint", () => {
+			const error = new GitHubClientError({
+				operation: "repos.list",
+				status: 429,
+				reason: "Secondary rate limit",
+				retryable: true,
+				retryAfterMs: 5000,
+			});
+			expect(error.retryAfterMs).toBe(5000);
 		});
 
 		it("supports undefined status", () => {
@@ -129,6 +142,7 @@ describe("GitHubClient", () => {
 				status: undefined,
 				reason: "Network error",
 				retryable: false,
+				retryAfterMs: undefined,
 			});
 			expect(error.status).toBeUndefined();
 		});

--- a/src/services/GitHubClient.ts
+++ b/src/services/GitHubClient.ts
@@ -1,4 +1,4 @@
-import type { Effect } from "effect";
+import type { Effect, Stream } from "effect";
 import { Context } from "effect";
 import type { GitHubClientError } from "../errors/GitHubClientError.js";
 
@@ -30,6 +30,19 @@ export class GitHubClient extends Context.Tag("github-action-effects/GitHubClien
 			fn: (octokit: unknown, page: number, perPage: number) => Promise<{ data: T[] }>,
 			options?: { perPage?: number; maxPages?: number },
 		) => Effect.Effect<Array<T>, GitHubClientError>;
+
+		/**
+		 * Paginate a REST API call as a Stream, one page's worth of items at a
+		 * time. Lets consumers `Stream.takeWhile` / `Stream.take` and stop early
+		 * without fetching or buffering the remaining pages. The eager `paginate`
+		 * collects all pages; prefer `paginateStream` for large or
+		 * early-terminating scans.
+		 */
+		readonly paginateStream: <T>(
+			operation: string,
+			fn: (octokit: unknown, page: number, perPage: number) => Promise<{ data: T[] }>,
+			options?: { perPage?: number; maxPages?: number },
+		) => Stream.Stream<T, GitHubClientError>;
 
 		/**
 		 * Get the repository context (owner and repo name).

--- a/src/services/RateLimitState.test.ts
+++ b/src/services/RateLimitState.test.ts
@@ -1,0 +1,32 @@
+import { Effect, Option, Ref } from "effect";
+import { describe, expect, it } from "vitest";
+import { RateLimitState } from "./RateLimitState.js";
+
+describe("RateLimitState", () => {
+	it("seeds an empty snapshot", async () => {
+		const result = await Effect.runPromise(
+			Effect.gen(function* () {
+				const ref = yield* RateLimitState;
+				return yield* Ref.get(ref);
+			}).pipe(Effect.provide(RateLimitState.Default)),
+		);
+		expect(Option.isNone(result)).toBe(true);
+	});
+
+	it("can hold a snapshot once written", async () => {
+		const result = await Effect.runPromise(
+			Effect.gen(function* () {
+				const ref = yield* RateLimitState;
+				yield* Ref.set(
+					ref,
+					Option.some({ remaining: 10, limit: 5000, resetEpochSeconds: 1700000000, observedAt: 123 }),
+				);
+				return yield* Ref.get(ref);
+			}).pipe(Effect.provide(RateLimitState.Default)),
+		);
+		expect(Option.isSome(result)).toBe(true);
+		if (Option.isSome(result)) {
+			expect(result.value.remaining).toBe(10);
+		}
+	});
+});

--- a/src/services/RateLimitState.ts
+++ b/src/services/RateLimitState.ts
@@ -1,0 +1,35 @@
+import { Context, Layer, Option, Ref } from "effect";
+
+/**
+ * Internal snapshot of the latest observed GitHub rate-limit headers.
+ *
+ * INTERNAL — never exported from a public barrel and never appears in a public
+ * method signature. Shared between `GitHubClientLive` (the writer, which reads
+ * `x-ratelimit-*` headers off real responses) and `RateLimiterLive` (the
+ * reader, which applies the wait/fail policy).
+ */
+export interface RateLimitSnapshot {
+	readonly remaining: number;
+	readonly limit: number;
+	readonly resetEpochSeconds: number;
+	/** `Date.now()` at observation, for staleness checks. */
+	readonly observedAt: number;
+}
+
+/**
+ * Internal shared state holding the most recently observed rate-limit snapshot.
+ *
+ * INTERNAL — not exported from `index.ts` / `testing.ts`. Provided by both
+ * `GitHubClientLive.*` and `RateLimiterLive` so the client can record headers
+ * and the rate limiter can read them without a pre-flight probe.
+ */
+export class RateLimitState extends Context.Tag("github-action-effects/RateLimitState")<
+	RateLimitState,
+	Ref.Ref<Option.Option<RateLimitSnapshot>>
+>() {
+	/** Default layer seeding an empty (unobserved) snapshot. */
+	static readonly Default: Layer.Layer<RateLimitState> = Layer.effect(
+		RateLimitState,
+		Ref.make(Option.none<RateLimitSnapshot>()),
+	);
+}

--- a/src/services/RateLimitState.ts
+++ b/src/services/RateLimitState.ts
@@ -12,7 +12,12 @@ export interface RateLimitSnapshot {
 	readonly remaining: number;
 	readonly limit: number;
 	readonly resetEpochSeconds: number;
-	/** `Date.now()` at observation, for staleness checks. */
+	/**
+	 * `Date.now()` at observation. Reserved for a future staleness-eviction
+	 * gate — it is recorded on every snapshot but is not currently read by any
+	 * policy (the snapshot is refreshed on every REST call, so it stays fresh
+	 * for active workflows).
+	 */
 	readonly observedAt: number;
 }
 

--- a/src/testing.ts
+++ b/src/testing.ts
@@ -131,6 +131,8 @@ export { PullRequestTest } from "./layers/PullRequestTest.js";
 export { RateLimiterLive } from "./layers/RateLimiterLive.js";
 export type { RateLimiterTestState } from "./layers/RateLimiterTest.js";
 export { RateLimiterTest } from "./layers/RateLimiterTest.js";
+export type { ResilienceOptions } from "./layers/resilience.js";
+export { resilienceSchedule } from "./layers/resilience.js";
 export { SbomLive } from "./layers/SbomLive.js";
 export type { SbomTestState } from "./layers/SbomTest.js";
 export { SbomTest, makeSbomTestState } from "./layers/SbomTest.js";


### PR DESCRIPTION
## WS2 — Resilient GitHub Client

Second workstream of the [reviewer-improvements 2.0.0 effort](.claude/plans/2026-05-20-reviewer-improvements/00-overview.md). Hardens all 14 `GitHubClient`-backed services at once by joining the retry + rate-limit machinery that existed but was never wired into the call path. **Bump: major.**

### Features

- **Resilient retry, default-on.** `rest`/`graphql`/`paginate`/`paginateStream` retry retryable failures (429/5xx) with an exponential, jittered, capped backoff, honoring server-advised `Retry-After` / `x-ratelimit-reset` headers. Tunable/disable-able per constructor via an optional `ResilienceOptions` arg; the pure `resilienceSchedule` builder is exported (from an octokit-free module, so `testing.ts` can re-export it without pulling in `@octokit/rest` — AD-3). `GitHubClientError` gains an optional `retryAfterMs`.
- **`paginateStream`** — a lazy `Stream` variant of `paginate` for early-terminating / memory-bounded scans; agrees with the eager `paginate` on page boundaries.

### Bug fixes

- **No more per-call `GET /rate_limit` probe.** `withRateLimit` reads `x-ratelimit-*` off real responses cached in a shared `Ref` (internal `RateLimitState`), waiting/failing only below the 10% threshold. `checkRest`/`checkGraphQL` are cache-first. Strictly fewer requests, identical policy.
- **`fromApp` revokes its installation token on scope close** (now a scoped layer), with a documented `Layer.memoize` recipe for sharing one token across provides.

### Breaking changes (intentional, per the 2.0 decision)

- `fromApp` requires a `Scope` at build time (`ActionsRuntime.Default` / `Action.run` already establish one; bare `Effect.provide` consumers wrap in `Effect.scoped`).
- `fromEnv` is now a constructor function — call `GitHubClientLive.fromEnv()`. Verified no sibling repo references it as a value.

### Design notes

- `RateLimitState` is internal (never exported, never in a public signature) and accessed optionally — provide `RateLimitState.Default` at the graph root to share the snapshot between the client and the rate limiter; without it each uses a private probe-free cache.
- Retry uses a small recursive loop (preferring `retryAfterMs` over the computed backoff) rather than stacked `Schedule` combinators; the `maxDelay` cap uses `Duration.min` (not `Schedule.either`) and is pinned by a test.

### Verification

- `pnpm run lint` — exit 0 · `pnpm run ci:build` — passes (api-extractor forgotten-exports confirms `ResilienceOptions`/`resilienceSchedule` exported from both barrels; TSDoc clean)
- `pnpm run test` — 1056 passed (29 new tests; all retry/backoff/wait tests run under `TestClock`)

> Per-feature prose docs land in WS6 (documentation), which owns the docs structure + 2.0 migration note; this PR carries the changeset as the release-notes artifact.

Signed-off-by: C. Spencer Beggs <spencer@savvyweb.systems>