### PR TITLE
fix: accept null in WebhookPayload IssueRef and Repository string fields

### DIFF
--- a/.changeset/webhook-payload-null-fields.md
+++ b/.changeset/webhook-payload-null-fields.md
@@ -1,0 +1,7 @@
+---
+"@savvy-web/github-action-effects": patch
+---
+
+## Bug Fixes
+
+- Accept `null` in `WebhookPayload`'s `IssueRef.body`, `IssueRef.html_url`, `Repository.full_name`, and `Repository.html_url` fields. GitHub webhook payloads carry these as `null` (not absent) when the issue or PR has no description, or when an event payload omits the rendered URL. Previously decoding any such payload through `ActionEnvironment.payload` failed with `ActionEnvironmentError: Event payload did not match the expected shape: WebhookPayload — Expected string, actual null`.

--- a/.github/workflows/pnpm-update.yml
+++ b/.github/workflows/pnpm-update.yml
@@ -39,7 +39,7 @@ jobs:
           fetch-depth: 0
       - name: Setup Runtime
         id: runtime
-        uses: savvy-web/workflow-runtime-action@main
+        uses: savvy-web/silk-runtime-action@v1
       - name: Update Config Dependencies
         id: update
         uses: savvy-web/pnpm-config-dependency-action@v1

--- a/src/schemas/EventPayload.test.ts
+++ b/src/schemas/EventPayload.test.ts
@@ -14,6 +14,24 @@ describe("WebhookPayload", () => {
 		expect(result.repository?.owner.login).toBe("owner");
 	});
 
+	it("decodes a pull_request with null body and null html_url", () => {
+		const result = decode({
+			pull_request: { number: 7, body: null, html_url: null },
+		});
+		expect(result.pull_request?.number).toBe(7);
+		expect(result.pull_request?.body).toBeNull();
+		expect(result.pull_request?.html_url).toBeNull();
+	});
+
+	it("decodes a repository with null full_name and null html_url", () => {
+		const result = decode({
+			repository: { name: "repo", full_name: null, html_url: null, owner: { login: "owner" } },
+		});
+		expect(result.repository?.name).toBe("repo");
+		expect(result.repository?.full_name).toBeNull();
+		expect(result.repository?.html_url).toBeNull();
+	});
+
 	it("decodes an issues payload", () => {
 		const result = decode({ issue: { number: 12 } });
 		expect(result.issue?.number).toBe(12);

--- a/src/schemas/EventPayload.ts
+++ b/src/schemas/EventPayload.ts
@@ -7,20 +7,25 @@ import { Schema } from "effect";
  */
 const Repository = Schema.Struct({
 	name: Schema.String,
-	full_name: Schema.optional(Schema.String),
+	full_name: Schema.optional(Schema.NullOr(Schema.String)),
 	owner: Schema.Struct({ login: Schema.String }),
-	html_url: Schema.optional(Schema.String),
+	html_url: Schema.optional(Schema.NullOr(Schema.String)),
 });
 
 /**
  * An issue / pull-request reference on a webhook payload (typed subset).
  *
+ * @remarks
+ * `body` and `html_url` accept `null` because GitHub webhook payloads carry
+ * those fields as `null` (not absent) when the issue or PR has no description,
+ * or for events whose payload omits the rendered URL.
+ *
  * @internal
  */
 const IssueRef = Schema.Struct({
 	number: Schema.Number,
-	html_url: Schema.optional(Schema.String),
-	body: Schema.optional(Schema.String),
+	html_url: Schema.optional(Schema.NullOr(Schema.String)),
+	body: Schema.optional(Schema.NullOr(Schema.String)),
 });
 
 /**

--- a/src/services/Attest.test.ts
+++ b/src/services/Attest.test.ts
@@ -48,7 +48,7 @@ const noopOidcLayer: Layer.Layer<OidcTokenIssuer> = Layer.succeed(OidcTokenIssue
 
 const makeGitHubClientLayer = (
 	restResponse: { data: unknown } | undefined,
-	repo = { owner: "savvy-web", repo: "workflow-release-action" },
+	repo = { owner: "savvy-web", repo: "silk-release-action" },
 ): Layer.Layer<GitHubClient> =>
 	GitHubClientTest.layer({
 		restResponses: restResponse ? new Map([["repos.createAttestation", restResponse]]) : new Map(),

--- a/src/services/Attest.wrappers.test.ts
+++ b/src/services/Attest.wrappers.test.ts
@@ -112,7 +112,7 @@ describe("Attest.provenance — step 6", () => {
 
 		const slsaPredicate = {
 			buildDefinition: {
-				buildType: "https://github.com/savvy-web/workflow-release-action/release/v1",
+				buildType: "https://github.com/savvy-web/silk-release-action/release/v1",
 				externalParameters: { workflow: { ref: "refs/heads/main" } },
 			},
 			runDetails: {

--- a/src/utils/slsa.test.ts
+++ b/src/utils/slsa.test.ts
@@ -32,7 +32,7 @@ const fullClaims: OidcClaims = {
 	sha: "deadbeef".repeat(5),
 	repository: "savvy-web/silk-integration",
 	event_name: "push",
-	job_workflow_ref: "savvy-web/workflow-release-action/.github/workflows/release.yml@refs/heads/main",
+	job_workflow_ref: "savvy-web/silk-release-action/.github/workflows/release.yml@refs/heads/main",
 	workflow_ref: "savvy-web/silk-integration/.github/workflows/release.yml@refs/heads/main",
 	repository_id: "123456",
 	repository_owner_id: "654321",
@@ -101,7 +101,7 @@ describe("buildSLSAProvenancePredicate — step 8a", () => {
 			digest: { gitCommit: "deadbeef".repeat(5) },
 		});
 		expect(predicate.runDetails.builder.id).toBe(
-			"https://github.com/savvy-web/workflow-release-action/.github/workflows/release.yml@refs/heads/main",
+			"https://github.com/savvy-web/silk-release-action/.github/workflows/release.yml@refs/heads/main",
 		);
 		expect(predicate.runDetails.metadata.invocationId).toBe(
 			"https://github.com/savvy-web/silk-integration/actions/runs/987654/attempts/1",
@@ -128,7 +128,7 @@ describe("buildSLSAProvenancePredicate — step 8a", () => {
 			"https://github.example.com/savvy-web/silk-integration",
 		);
 		expect(predicate.runDetails.builder.id).toBe(
-			"https://github.example.com/savvy-web/workflow-release-action/.github/workflows/release.yml@refs/heads/main",
+			"https://github.example.com/savvy-web/silk-release-action/.github/workflows/release.yml@refs/heads/main",
 		);
 	});
 


### PR DESCRIPTION
## Summary

`ActionEnvironment.payload` failed to decode real `pull_request` events because the `WebhookPayload` schema declared `IssueRef.body`, `IssueRef.html_url`, `Repository.full_name`, and `Repository.html_url` as `Schema.optional(Schema.String)` — string-or-undefined. GitHub webhook payloads carry these fields as `null` (not absent) when the issue or PR has no description, or when the event payload omits the rendered URL.

Switch the four affected optional fields to `Schema.optional(Schema.NullOr(Schema.String))`.

## Repro

Job that exposed it: https://github.com/savvy-web/rslib-builder/actions/runs/26596426144/job/78380850728

Calling `savvy-web/silk-router-action@v1` (which uses `@savvy-web/github-action-effects` ^2.0.0) on a pull_request event with `pull_request.body = null` triggered:

```
[ActionEnvironmentError] Event payload did not match the expected shape: WebhookPayload
└─ ["pull_request"]
   └─ { readonly number: number; readonly html_url?: string | undefined; readonly body?: string | undefined } | undefined
      ├─ { readonly number: number; readonly html_url?: string | undefined; readonly body?: string | undefined }
      │  └─ ["body"]
      │     └─ string | undefined
      │        ├─ Expected string, actual null
      │        └─ Expected undefined, actual null
```

## Test plan

- [x] New tests in `src/schemas/EventPayload.test.ts` cover both the `pull_request` and `repository` paths.
- [x] `pnpm test` — 1244 tests pass.
- [x] `pnpm typecheck` passes.
- [x] `pnpm lint` clean.
- [x] `pnpm ci:build` succeeds.

## Changeset

`patch` in `.changeset/webhook-payload-null-fields.md`.

Signed-off-by: C. Spencer Beggs <spencer@savvyweb.systems>