### PR TITLE
fix: retry 403 secondary rate limits in GitHubClient resilience

### DIFF
--- a/.changeset/gentle-rivers-burn.md
+++ b/.changeset/gentle-rivers-burn.md
@@ -1,0 +1,7 @@
+---
+"@savvy-web/github-action-effects": patch
+---
+
+## Bug Fixes
+
+`GitHubClientLive` now correctly treats GitHub secondary rate-limit responses as retryable. A 403 carrying a `Retry-After` header, or a 403 with `x-ratelimit-remaining: 0` and an `x-ratelimit-reset` timestamp, is retried with back-off rather than surfacing as a permanent failure. A bare 403 with no rate-limit signals remains non-retryable so genuine permission denials are not looped on.

--- a/.claude/design/github-action-effects/errors-and-schemas.md
+++ b/.claude/design/github-action-effects/errors-and-schemas.md
@@ -3,8 +3,8 @@ status: current
 module: github-action-effects
 category: architecture
 created: 2026-03-06
-updated: 2026-05-20
-last-synced: 2026-05-20
+updated: 2026-05-29
+last-synced: 2026-05-29
 completeness: 95
 related:
   - ./index.md
@@ -115,7 +115,7 @@ to their own domain-specific error type:
 - `GitHubArtifactMetadataError` wraps with artifact-metadata context
 - `AttestError` wraps with attestation context
 
-The `retryable` flag on `GitHubClientError` is `true` for 429 (rate limit) and 5xx status codes, enabling consumers to implement retry logic.
+The `retryable` flag on `GitHubClientError` is `true` for 429 (rate limit), any 5xx and a 403 that carries a server-advised retry signal (a `Retry-After` header, or `x-ratelimit-remaining: 0` plus `x-ratelimit-reset` — a GitHub secondary rate limit); a bare 403 (genuine permission denial) stays non-retryable. The accompanying `retryAfterMs` carries the server-advised delay when present. This enables consumers to implement retry logic.
 
 `NpmRegistryError` and `PackagePublishError` both carry a `message` getter so caught errors remain readable at the surface (e.g. in `console.error` or workflow command output) without forcing callers to destructure the tagged error. `PackagePublishError` also carries the source error as `cause` and surfaces the tail of long stderr output to aid diagnostics in CI logs. HTTP errors from `OidcTokenIssuerLive` route through `Effect.logDebug` so they appear in the step's debug buffer (visible on failure) rather than cluttering the success log.
 

--- a/.claude/design/github-action-effects/layers.md
+++ b/.claude/design/github-action-effects/layers.md
@@ -3,8 +3,8 @@ status: current
 module: github-action-effects
 category: architecture
 created: 2026-03-06
-updated: 2026-05-20
-last-synced: 2026-05-20
+updated: 2026-05-29
+last-synced: 2026-05-29
 completeness: 95
 related:
   - ./index.md
@@ -306,8 +306,11 @@ instance from `@octokit/rest`. See `src/layers/GitHubClientLive.ts`.
 
 REST calls use `Effect.tryPromise`, GraphQL uses `octokit.graphql()`.
 Pagination handles page incrementing and empty-page termination. Error mapping
-extracts HTTP status and sets the `retryable` flag for 429/5xx. Detects HTML
-error pages (GitHub "Unicorn" pages). The `repo` accessor still resolves
+extracts HTTP status and sets the `retryable` flag for 429, any 5xx and a 403
+that carries a server-advised retry signal (`Retry-After` header, or
+`x-ratelimit-remaining: 0` plus `x-ratelimit-reset` — a GitHub secondary rate
+limit); a bare 403 is a genuine permission denial and stays non-retryable.
+Detects HTML error pages (GitHub "Unicorn" pages). The `repo` accessor still resolves
 `GITHUB_REPOSITORY` at call time and fails with `GitHubClientError` regardless
 of construction mode.
 

--- a/.claude/design/github-action-effects/services.md
+++ b/.claude/design/github-action-effects/services.md
@@ -3,8 +3,8 @@ status: current
 module: github-action-effects
 category: architecture
 created: 2026-03-06
-updated: 2026-05-20
-last-synced: 2026-05-20
+updated: 2026-05-29
+last-synced: 2026-05-29
 completeness: 97
 related:
   - ./index.md
@@ -279,7 +279,7 @@ Uses `@octokit/rest` directly.
 - `paginate(operation, fn, options?)` -- Paginate a REST API call, collecting all results. Options: `{ perPage?, maxPages? }`
 - `repo` -- Get the repository context (`{ owner, repo }`) from `GITHUB_REPOSITORY` env var
 
-**Error type:** `GitHubClientError` -- includes `retryable` flag for 429/5xx
+**Error type:** `GitHubClientError` -- `retryable` flag true for 429, any 5xx and a 403 carrying a retry signal (secondary rate limit); bare 403 stays non-retryable
 
 **Construction.** The `GitHubClientLive` layer is a namespace object, not a
 plain const — the construction surface chooses the client's identity. See

--- a/.claude/design/github-action-effects/testing-strategy.md
+++ b/.claude/design/github-action-effects/testing-strategy.md
@@ -3,8 +3,8 @@ status: current
 module: github-action-effects
 category: architecture
 created: 2026-03-06
-updated: 2026-05-20
-last-synced: 2026-05-20
+updated: 2026-05-29
+last-synced: 2026-05-29
 completeness: 95
 related:
   - ./index.md
@@ -192,7 +192,7 @@ via `sha: null` entries.
 token generation + `GitHubAppError` propagation), REST callback, GraphQL query
 execution, pagination (page incrementing, empty-page termination, maxPages),
 repo context from GITHUB_REPOSITORY, error wrapping with HTTP status
-extraction, retryable flag for 429/5xx, HTML error page detection.
+extraction, retryable classification (429, 5xx, 403 secondary rate limit vs bare 403 permission denial), HTML error page detection.
 
 **GitHubToken** -- `provision` (Config defaults + override, permission check
 pass/fail, persistence), `client` (success + missing-state failure), `dispose`

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -12,7 +12,6 @@
 	"enableAllProjectMcpServers": true,
 	"enabledPlugins": {
 		"design-docs@spencerbeggs": true,
-		"vitest-agent-reporter@spencerbeggs": true,
 		"changesets@savvy-web-systems": true,
 		"commitlint@savvy-web-systems": true,
 		"lint-staged@savvy-web-systems": true,

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ pnpm-release.json
 # Claude AI files
 .claude/settings.local.json
 .claude/plans/
+.claude/cache/
 .claude/plugins-debug.log
 .playwright-mcp
 .mcp.json

--- a/docs/08-resilient-github-api.md
+++ b/docs/08-resilient-github-api.md
@@ -1,10 +1,10 @@
 # Resilient GitHub API calls
 
-The GitHub API returns 429s under rate pressure and 5xxs when something on its side hiccups. An action that does not retry those will fail a run that a single retry would have saved. `GitHubClient` retries them for you — resilience is on by default on every call — and exposes the knobs to tune or disable it. This guide covers the default retry policy, the `ResilienceOptions` you pass per constructor, the `RateLimiter` service and the streaming pagination that lets a scan stop early.
+The GitHub API returns 429s under rate pressure, 403s with a retry hint under secondary rate limits and 5xxs when something on its side hiccups. An action that does not retry those will fail a run that a single retry would have saved. `GitHubClient` retries them for you — resilience is on by default on every call — and exposes the knobs to tune or disable it. This guide covers the default retry policy, the `ResilienceOptions` you pass per constructor, the `RateLimiter` service and the streaming pagination that lets a scan stop early.
 
 ## Retry is on by default
 
-Every `GitHubClient` call — `rest`, `graphql`, `paginate`, `paginateStream` — runs through `withResilience`. On a retryable error it waits, then tries again, up to a bounded number of attempts. An error is retryable when the response status is `429` or `>= 500`; the client sets that flag when it wraps the underlying error into a `GitHubClientError`. Non-retryable errors (a `404`, a `422`, a malformed request) fail immediately — retrying them would only waste time.
+Every `GitHubClient` call — `rest`, `graphql`, `paginate`, `paginateStream` — runs through `withResilience`. On a retryable error it waits, then tries again, up to a bounded number of attempts. An error is retryable when the response status is `429`, is `>= 500`, or is a `403` that carries a server-advised retry signal — a `Retry-After` header, or `x-ratelimit-remaining: 0` plus an `x-ratelimit-reset` timestamp — which is how GitHub reports a secondary rate limit. A bare `403` with no such hint is a genuine permission failure and is not retried. The client sets the flag when it wraps the underlying error into a `GitHubClientError`. Non-retryable errors (a bare `403`, a `404`, a `422`, a malformed request) fail immediately — retrying them would only waste time.
 
 You do not opt in. `GitHubClientLive.fromEnv()` already gives you the resilient client:
 

--- a/src/layers/GitHubClientLive.test.ts
+++ b/src/layers/GitHubClientLive.test.ts
@@ -121,6 +121,50 @@ describe("GitHubClientLive", () => {
 				}
 			});
 
+			it("marks a 403 carrying Retry-After as retryable (secondary rate limit)", async () => {
+				const error = Object.assign(new Error("secondary limit"), {
+					status: 403,
+					response: { headers: { "retry-after": "5" } },
+				});
+				const exit = await runExit(
+					Effect.flatMap(GitHubClient, (client) => client.rest("test.403.retryAfter", () => Promise.reject(error))),
+				);
+				expect(exit._tag).toBe("Failure");
+				if (Exit.isFailure(exit)) {
+					const err = Cause.squash(exit.cause) as { retryable: boolean; retryAfterMs: number };
+					expect(err.retryable).toBe(true);
+					expect(err.retryAfterMs).toBe(5000);
+				}
+			});
+
+			it("marks a 403 with x-ratelimit-remaining: 0 as retryable (secondary rate limit)", async () => {
+				const reset = Math.floor(Date.now() / 1000) + 30;
+				const error = Object.assign(new Error("secondary limit"), {
+					status: 403,
+					response: { headers: { "x-ratelimit-remaining": "0", "x-ratelimit-reset": String(reset) } },
+				});
+				const exit = await runExit(
+					Effect.flatMap(GitHubClient, (client) => client.rest("test.403.ratelimit", () => Promise.reject(error))),
+				);
+				expect(exit._tag).toBe("Failure");
+				if (Exit.isFailure(exit)) {
+					const err = Cause.squash(exit.cause) as { retryable: boolean };
+					expect(err.retryable).toBe(true);
+				}
+			});
+
+			it("marks a bare 403 (permission denial) as non-retryable", async () => {
+				const error = Object.assign(new Error("forbidden"), { status: 403 });
+				const exit = await runExit(
+					Effect.flatMap(GitHubClient, (client) => client.rest("test.403.bare", () => Promise.reject(error))),
+				);
+				expect(exit._tag).toBe("Failure");
+				if (Exit.isFailure(exit)) {
+					const err = Cause.squash(exit.cause) as { retryable: boolean };
+					expect(err.retryable).toBe(false);
+				}
+			});
+
 			it("sanitizes HTML error responses", async () => {
 				const htmlError = Object.assign(new Error("<!DOCTYPE html><html><body>Unicorn!</body></html>"), {
 					status: 500,
@@ -407,6 +451,48 @@ describe("GitHubClientLive", () => {
 						client.rest("op", () => {
 							attempts++;
 							return Promise.reject(Object.assign(new Error("not found"), { status: 404 }));
+						}),
+					),
+					GitHubClientLive.fromToken(Redacted.make("t")),
+				),
+			);
+			expect(exit._tag).toBe("Failure");
+			expect(attempts).toBe(1);
+		});
+
+		it("rest retries a 403 secondary rate limit that carries Retry-After, then succeeds", async () => {
+			let attempts = 0;
+			const exit = await runWithClock(
+				Effect.provide(
+					Effect.flatMap(GitHubClient, (client) =>
+						client.rest("op", () => {
+							attempts++;
+							if (attempts < 2) {
+								return Promise.reject(
+									Object.assign(new Error("secondary limit"), {
+										status: 403,
+										response: { headers: { "retry-after": "5" } },
+									}),
+								);
+							}
+							return Promise.resolve({ data: "recovered" });
+						}),
+					),
+					GitHubClientLive.fromToken(Redacted.make("t")),
+				),
+			);
+			expect(exit._tag).toBe("Success");
+			expect(attempts).toBe(2);
+		});
+
+		it("rest does not retry a bare 403 (permission denial)", async () => {
+			let attempts = 0;
+			const exit = await runWithClock(
+				Effect.provide(
+					Effect.flatMap(GitHubClient, (client) =>
+						client.rest("op", () => {
+							attempts++;
+							return Promise.reject(Object.assign(new Error("forbidden"), { status: 403 }));
 						}),
 					),
 					GitHubClientLive.fromToken(Redacted.make("t")),

--- a/src/layers/GitHubClientLive.ts
+++ b/src/layers/GitHubClientLive.ts
@@ -55,7 +55,14 @@ const silentOctokitLog = {
 	},
 };
 
-const isRetryableStatus = (status: number): boolean => status === 429 || status >= 500;
+/**
+ * Whether a failed response should be retried. `429` and any `5xx` are always
+ * retryable. A `403` is retryable only when it carries a server-advised retry
+ * delay (GitHub secondary rate limit) — a bare `403` is a genuine permission
+ * denial and must fail fast rather than loop.
+ */
+const isRetryable = (status: number, retryAfterMs: number | undefined): boolean =>
+	status === 429 || status >= 500 || (status === 403 && retryAfterMs !== undefined);
 
 /**
  * Structural shape of the response headers Octokit returns at runtime. The
@@ -116,12 +123,13 @@ const wrapError = (operation: string, error: unknown): GitHubClientError => {
 			status !== undefined ? `GitHub API returned ${status} (server error)` : "GitHub API returned an HTML error page";
 	}
 
+	const retryAfterMs = parseRetryAfterMs(error);
 	return new GitHubClientError({
 		operation,
 		status,
 		reason: message,
-		retryable: status !== undefined && isRetryableStatus(status),
-		retryAfterMs: parseRetryAfterMs(error),
+		retryable: status !== undefined && isRetryable(status, retryAfterMs),
+		retryAfterMs,
 	});
 };
 


### PR DESCRIPTION
## Summary

`GitHubClient`'s resilience layer previously classified only `429` and `>= 500` responses as retryable. GitHub **secondary rate limits** frequently surface as **`403`** with a `Retry-After` header, so those responses failed immediately instead of backing off.

A `403` is now treated as retryable **only when** it carries a server-advised retry signal — a `Retry-After` header, or `x-ratelimit-remaining: 0` plus `x-ratelimit-reset`. A bare `403` (genuine permission denial) stays non-retryable so we don't loop on real auth failures. `429` / `5xx` behavior is unchanged. The fix reuses the existing `parseRetryAfterMs` / `withResilience` backoff machinery.

## Changes

- `src/layers/GitHubClientLive.ts` — replace status-only `isRetryableStatus` with `isRetryable(status, retryAfterMs)`; `wrapError` computes the retry delay once and widens the retryable set to include 403 secondary rate limits.
- `src/layers/GitHubClientLive.test.ts` — tests for both retried and non-retried 403 paths (error-wrapping + resilience integration).
- Design docs (`layers.md`, `errors-and-schemas.md`, `services.md`, `testing-strategy.md`) and `docs/08-resilient-github-api.md` updated to describe the new classification.
- Housekeeping: removed a broken plugin entry from `.claude/settings.json`; gitignored the AI context cache.

## Test plan

- `pnpm vitest run` on `GitHubClientLive.test.ts` and `resilience.test.ts` — all pass
- `pnpm run typecheck` — clean
- Biome — clean

Closes #139

Signed-off-by: C. Spencer Beggs <spencer@savvyweb.systems>
